### PR TITLE
Fix indents in locale file for English

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -20,11 +20,11 @@
         "DOWN": "DOWN",
         "DEGRADED": "DEGRADED"
     },
-	"incident": {
-		"identified": "Identified",
-		"resolved": "Resolved",
-		"maintenance": "Maintenance"
-	},
+    "incident": {
+        "identified": "Identified",
+        "resolved": "Resolved",
+        "maintenance": "Maintenance"
+    },
     "monitor": {
         "share": "Share",
         "badge": "Badge",


### PR DESCRIPTION
For consistency within the file, I replaced tabs in the English locale file with 4 spaces.
This change does not change the behavior.