### PR TITLE
Update: Suppress warnings in production build

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,6 +2,8 @@ import { vitePreprocess } from "@sveltejs/kit/vite";
 import adapter from "@sveltejs/adapter-node";
 
 const basePath = !!process.env.KENER_BASE_PATH ? process.env.KENER_BASE_PATH : "";
+const VITE_BUILD_ENV = process.env.VITE_BUILD_ENV || "development"; // Default to "development"
+const isProduction = VITE_BUILD_ENV === "production";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,7 +14,29 @@ const config = {
 		}
 	},
 
-	preprocess: [vitePreprocess({})]
+	preprocess: [vitePreprocess({})],
+
+	compilerOptions: {
+		dev: !isProduction, // Disable dev mode in production
+		enableSourcemap: !isProduction // Disable sourcemaps in production
+	},
+
+	onwarn: (warning, handler) => {
+		// Suppress specific warnings in production
+		const ignoredWarnings = [
+			"a11y-", // Accessibility warnings
+			"unused-export-let", // Suppresses "unused export property" warnings
+			"empty-chunk", // Suppresses empty chunk warnings
+			"module-unused-import", // Suppresses unused imports like "default" from auto-animate
+			"conflicting-svelte-resolve" // Suppresses conflicting resolve warnings
+		];
+
+		if (isProduction && ignoredWarnings.some((w) => warning.code && warning.code.startsWith(w))) {
+			return; // Ignore these warnings in production builds
+		}
+
+		handler(warning); // Otherwise, show the warning
+	}
 };
 
 export default config;


### PR DESCRIPTION
When building for production, various warnings are output which slows down production build. We don't really need these as warnings should more-so be output (& handled) during development and/or with specific NPM test script. This PR should lower CI/CD build times.

The following changes were made:
- Suppress unused export properties (unused-export-let).
- Suppress conflicting Svelte resolve warnings (conflicting-svelte-resolve).
- Suppress empty chunk warnings (empty-chunk).
- Suppress unused module imports (module-unused-import).
- Keep other important warnings visible, so we’re still aware of potential issues.

We can now specify an _(optional)_ `VITE_BUILD_ENV=production` during `npm run build` so that these warnings are ‘ignored’. (`VITE_BUILD_ENV=development`, by default)

Now, production build should be cleaner and faster! 🚀