### PR TITLE
fix: README generation

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -11,7 +11,11 @@ on:
       - main
     paths:
       - 'README.template.md'
-  workflow_dispatch:  # Allows manual execution
+  workflow_dispatch:  # Allows for manual execution
+  workflow_run:  # Triggers this workflow to run when it recognizes 'publish-images' workflow has ran and successfully completed
+    workflows: ["Publish Docker Image to Registries"]
+    types:
+      - completed
 
 permissions:
   contents: write  # Explicitly allow pushing changes
@@ -41,28 +45,33 @@ jobs:
       - name: Install Dependencies
         run: npm install mustache dotenv
 
-      - name: Download Version File
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: version-metadata
 
-      - name: Load Variables from File
+      - name: Extract Major and Major-Minor Versions
         run: |
-          while IFS='=' read -r key value; do
-            echo "$key=$value" >> $GITHUB_ENV
-          done < versions.txt
+          VERSION="${{ vars.BUILD_VERSION }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+          echo "Full version: $VERSION"
+          echo "Major version: $MAJOR"
+          echo "Major-Minor version: $MAJOR_MINOR"
+
+          # Export all as environment variables
+          echo "LATEST_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "LATEST_MAJOR_VERSION=$MAJOR" >> $GITHUB_ENV
+          echo "LATEST_MAJOR_MINOR_VERSION=$MAJOR_MINOR" >> $GITHUB_ENV
 
       - name: Generate README.md
         env:
-          BUILD_FULL_VERSION: ${{ env.BUILD_FULL_VERSION }}  # e.g., 1.2.3
-          BUILD_MAJOR_MINOR_VERSION: ${{ env.BUILD_MAJOR_MINOR_VERSION }}  # e.g., 1.2
-          BUILD_MAJOR_VERSION: ${{ env.BUILD_MAJOR_VERSION }}  # e.g., 1
+          BUILD_FULL_VERSION: ${{ env.LATEST_VERSION }}  # e.g., 1.2.3
+          BUILD_MAJOR_VERSION: ${{ env.LATEST_MAJOR_VERSION}}  # e.g., 1
+          BUILD_MAJOR_MINOR_VERSION: ${{ env.LATEST_MAJOR_MINOR_VERSION }}  # e.g., 1.2
         run: node scripts/generate-readme.js
 
       - name: Commit and Push Changes
         env:
-          KENER_GH_PAT_TOKEN: ${{ secrets.KENER_GH_PAT_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           git add README.md
           git commit -m "Auto-generate README.md with release versions" || echo "No changes to commit"
-          git push https://x-access-token:${{ secrets.KENER_GH_PAT_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
+          git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git HEAD:main

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,10 +1,10 @@
-name: Publish Docker image to Docker Hub and GitHub Container Registry
+name: Publish Docker Image to Registries
 
 on:
   release:
     types:
       - published  # Runs only when a GitHub Release is published
-  workflow_dispatch:  # Allows manual execution
+  workflow_dispatch:  # Allows for manual execution
 
 env:
   ALPINE_VERSION: "23-alpine"
@@ -47,6 +47,7 @@ jobs:
         variant: [alpine, debian]
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       packages: write
       # This is used to complete the identity challenge with sigstore/fulcio when running outside of PRs.
@@ -109,35 +110,6 @@ jobs:
             type=semver,pattern={{major}},enable=${{ matrix.variant == 'debian' }}
             type=raw,value=latest,enable=${{ matrix.variant == 'debian' && github.ref == 'refs/heads/main' }}
 
-      - name: Save Version Output
-        run: |
-          echo "BUILD_FULL_VERSION=${{ steps.meta.outputs.version }}" >> versions.txt
-          echo "BUILD_MAJOR_MINOR_VERSION=${{ steps.meta.outputs.major }}.${{ steps.meta.outputs.minor }}" >> versions.txt
-          echo "BUILD_MAJOR_VERSION=${{ steps.meta.outputs.major }}" >> versions.txt
-
-      - name: Verify Saved Versions
-        run: cat versions.txt
-
-      - name: Delete Existing Version Artifact (If Exists)
-        run: |
-          ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name=="version-metadata") | .id' || echo "not_found")
-          if [[ "$ARTIFACT_ID" != "not_found" ]]; then
-            echo "Deleting existing artifact with ID: $ARTIFACT_ID"
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID
-          else
-            echo "No existing artifact found. Skipping deletion."
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload Version File
-        # Always run this on the first successful job only
-        if: github.run_attempt == 1
-        uses: actions/upload-artifact@v4.6.0
-        with:
-          name: version-metadata
-          path: versions.txt
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0
 
@@ -166,3 +138,20 @@ jobs:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      # For use in other workflows (e.g. 'generate-readme', etc.)
+      - name: Save Build Version to Repository Variable
+        if: matrix.variant == 'debian' && github.run_attempt == 1
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+
+          # Check if VERSION is empty and set a fallback value
+          if [ -z "$VERSION" ]; then
+            # Fetch the latest release using Git
+            git tag -l --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1
+          fi
+
+          echo "Setting BUILD_VERSION to $VERSION"
+          gh variable set BUILD_VERSION --body "$VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}  # Needs to be PAT w/ Read access to metadata and secrets & Read and Write access to actions, actions variables, and code

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -18,8 +18,8 @@ const template = fs.readFileSync(templatePath, "utf-8");
 // Load environment variables and provide default values
 const data = {
   kener_full_version: process.env.BUILD_FULL_VERSION || "N/A",
-  kener_major_minor_version: process.env.BUILD_MAJOR_MINOR_VERSION || "N/A",
   kener_major_version: process.env.BUILD_MAJOR_VERSION || "N/A",
+  kener_major_minor_version: process.env.BUILD_MAJOR_MINOR_VERSION || "N/A",
 };
 
 // Render README.md


### PR DESCRIPTION
Changed from trying to use artifacts and the GHA workflow failing to now using a simple `BUILD_VERSION` repository variable and automatically updating that when the `build-and-push-to-registries` workflow succeeds.

Other changes include:

* Added `workflow_run` trigger to `generate-readme.yml` so when that workflow recognizes the “Publish Docker Image to Registries” workflow runs and succeeds, it will automatically run the `generate-readme.yml` workflow (since a new Docker release will require Docker image variants table in README.md to have versioning updated)
* Generate major and major-minor versions from the `BUILD_VERSION` repository variable (more efficient than storing three separate variables from the `build-and-push-to-registries` workflow job)