### PR TITLE
feat: add head method to api monitor type

### DIFF
--- a/src/lib/components/manage/monitorSheet.svelte
+++ b/src/lib/components/manage/monitorSheet.svelte
@@ -527,6 +527,9 @@
                   <Select.Item value="DELETE" label="DELETE" class="text-sm font-medium">
                     DELETE
                   </Select.Item>
+                  <Select.Item value="HEAD" label="HEAD" class="text-sm font-medium">
+                    HEAD
+                  </Select.Item>
                 </Select.Group>
               </Select.Content>
             </Select.Root>

--- a/src/routes/(kener)/api/incident/[incident_id]/updates/+server.js
+++ b/src/routes/(kener)/api/incident/[incident_id]/updates/+server.js
@@ -36,6 +36,7 @@ export async function GET({ request, params }) {
 		);
 	}
 }
+
 export async function POST({ request, params }) {
 	// const headers = await request.headers();
 	const authError = await auth(request);
@@ -149,5 +150,24 @@ export async function PATCH({ request, params, url }) {
 				status: 400
 			}
 		);
+	}
+}
+
+export async function HEAD({ request, params }) {
+	const authError = await auth(request);
+	if (authError !== null) {
+    return new Response(null, { status: 401 });
+	}
+	const incident_id = params.incident_id; // number required
+
+	try {
+    // Fetch the incident comments to verify existence but discard body
+		let resp = await GetIncidentComments(incident_id);
+    // Return only headers with a 200 status
+    return json(null, {
+			status: 200
+		});
+	} catch (e) {
+		return new Response(null, { status: 400 });
 	}
 }


### PR DESCRIPTION
Will allow user to configure only a HEAD request, which is lighter-weight/faster than a GET request as it does not need/return the request body.

<img src="https://github.com/user-attachments/assets/be54a9f7-99de-42b1-bb20-c89cd9875fc8" alt="CleanShot 2025-02-11 at 19 12 59@2x" width="400px">