### PR TITLE
fix(docker): clean up Docker tagging

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -87,15 +87,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Debug values
-        run: |
-          echo "Branch ref: ${{ github.ref }}"
-          echo "Matrix variant: ${{ matrix.variant }}"
-
-      - name: Debug tag evaluation
-        run: |
-          echo "Alpine tag enabled: ${{ matrix.variant == 'alpine' && github.ref == 'refs/heads/main' }}"
-
       # Combined metadata extraction for both registries
       - name: Extract Docker metadata
         id: meta
@@ -105,23 +96,17 @@ jobs:
             ${{ env.DOCKERHUB_IMAGE_NAME }}
             ${{ env.GITHUB_REGISTRY }}/${{ env.GITHUB_IMAGE_NAME }}
           tags: |
-            # Tag non-main branches (...for Alpine variant, add suffix)
-            type=ref,event=branch,suffix=-${{ matrix.variant }},enable=${{ matrix.variant == 'alpine' && github.ref != 'refs/heads/main' }}
-            type=ref,event=branch,enable=${{ matrix.variant == 'debian' && github.ref != 'refs/heads/main' }}
-
-            # Tag matrix.variant (Alpine) releases as version (1.0.0), major.minor (1.0), major (1), and matrix.variant (alpine)
-            type=semver,pattern={{version}},suffix=-${{ matrix.variant }},enable=${{ matrix.variant == 'alpine' }}
-            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.variant }},enable=${{ matrix.variant == 'alpine' }}
-            type=semver,pattern={{major}},suffix=-${{ matrix.variant }},enable=${{ matrix.variant == 'alpine' }}
-            # type=raw,value=${{ matrix.variant }},enable=${{ matrix.variant == 'alpine' && github.ref == 'refs/heads/main' }}
-            type=raw,value=alpine,enable=${{ matrix.variant == 'alpine' && github.ref == 'refs/heads/main' }}
-            # type=raw,value=alpine,enable=${{ (matrix.variant == 'alpine' && github.ref == 'refs/heads/main') && 'true' || 'false' }}
-
-            # Tag default (Debian) releases as version (1.0.0), major.minor (1.0), major (1), and latest
+            # Debian Variant Tags
             type=semver,pattern={{version}},enable=${{ matrix.variant == 'debian' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'debian' }}
             type=semver,pattern={{major}},enable=${{ matrix.variant == 'debian' }}
-            type=raw,value=latest,enable=${{ matrix.variant == 'debian' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'debian' }}
+
+            # Alpine Variant Tags
+            type=semver,pattern={{version}},suffix=-alpine,enable=${{ matrix.variant == 'alpine' }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-alpine,enable=${{ matrix.variant == 'alpine' }}
+            type=semver,pattern={{major}},suffix=-alpine,enable=${{ matrix.variant == 'alpine' }}
+            type=raw,value=alpine,enable=${{ matrix.variant == 'alpine' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0


### PR DESCRIPTION
Simplified Docker tagging – in turn fixes broken `alpine` tag to correctly point to latest stable Alpine release. Changes include:

- No more type=ref,event=branch – because this workflow is only for releases & manual triggers on `main` branch.
- Ensures `alpine` tag is always created for Alpine variant builds.
- Ensures `latest` tag is always created for Debian builds.
- Ensures all semver-based tags work correctly for both variants.