### PR TITLE
Fix SMTP_SECURE environment variable always being truthy when set

### DIFF
--- a/src/lib/server/controllers/controller.js
+++ b/src/lib/server/controllers/controller.js
@@ -1003,7 +1003,7 @@ export const GetSMTPFromENV = () => {
     smtp_user: process.env.SMTP_USER,
     smtp_from_email: process.env.SMTP_FROM_EMAIL,
     smtp_pass: process.env.SMTP_PASS,
-    smtp_secure: !!process.env.SMTP_SECURE,
+    smtp_secure: !!Number(process.env.SMTP_SECURE),
   };
 };
 


### PR DESCRIPTION
This originally manifested as an SSL error when attempting to send emails via SMTP using STARTTLS, despite `SMTP_SECURE=0` being set in the environment, due to the string not being empty:

```
Error sending email via SMTP [Error: 8013FCB0927F0000:error:0A00010B:SSL routines:tls_validate_record_header:wrong version number:ssl/record/methods/tlsany_meth.c:80:
] {
  library: 'SSL routines',
  reason: 'wrong version number',
  code: 'ESOCKET',
  command: 'CONN'
}
```

Before this PR:

| `console.debug(process.env)` | `console.debug(meta)` |
| :- | :- |
| `SMTP_SECURE: '0'` | `smtp_secure: true` |
| `SMTP_SECURE: '1'` | `smtp_secure: true` |
| `SMTP_SECURE: ''` | `smtp_secure: false` |
| `SMTP_SECURE: 'asdf'` | `smtp_secure: true` |
| `SMTP_SECURE: 'true'` | `smtp_secure: true` |
| `SMTP_SECURE: 'false'` | `smtp_secure: true` |

After:

| `console.debug(process.env)` | `console.debug(meta)` |
| :- | :- |
| `SMTP_SECURE: '0'` | `smtp_secure: false` |
| `SMTP_SECURE: '1'` | `smtp_secure: true` |
| `SMTP_SECURE: ''` | `smtp_secure: false` |
| `SMTP_SECURE: 'asdf'` | `smtp_secure: false` |
| `SMTP_SECURE: 'true'` | `smtp_secure: false` |
| `SMTP_SECURE: 'false'` | `smtp_secure: false` |

It should not be a breaking change as the variable did not work as intended previously, and [the docs](https://kener.ing/docs/environment-vars) specify only `0` and `1` as valid values, though it may be helpful to only consider empty/`0` as false and all others as true, depending on preference.

Tested with Fastmail