### PR TITLE
Fixing app failed to start with docker & kubernetes.

### DIFF
--- a/src/lib/server/services/gamedigCall.js
+++ b/src/lib/server/services/gamedigCall.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import { error } from "@sveltejs/kit";
 import { UP, DOWN, DEGRADED, REALTIME, TIMEOUT, ERROR, MANUAL } from "../constants.js";
 import { GameDig } from 'gamedig';
 import { DefaultGamedigEval, GAMEDIG_SOCKET_TIMEOUT, GAMEDIG_TIMEOUT } from "../../anywhere.js";


### PR DESCRIPTION
This PR fixes the problem described in #398. An import of '@sveltejs/kit' was still present in gamedigCall.js, even though it is really unnecessary + unable users to start the application with docker & kubernetes.

# With this PR
```bash
$ docker compose up --wait
[+] Building 83.3s (33/33) FINISHED                                                                                                                                              docker:default
 => [kener internal] load build definition from Dockerfile                                                                                                                                 0.0s 
 => => transferring dockerfile: 6.80kB                                                                                                                                                     0.0s
 => [kener] resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                          0.3s 
 => CACHED [kener] docker-image://docker.io/docker/dockerfile:1@sha256:4c68376a702446fc3c79af22de146a148bc3367e73c25a5803d453b6b3f722fb                                                    0.0s
 => [kener internal] load metadata for docker.io/library/node:23.7.0-bookworm-slim                                                                                                         0.3s 
 => [kener internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 105B                                                                                                                                                          0.0s 
 => [kener builder-debian 1/2] FROM docker.io/library/node:23.7.0-bookworm-slim@sha256:a5163af143b43b0da7572444bd49a22edb4cc1a74d3a46e1ef840f62bce07cac                                    0.0s
 => [kener internal] load build context                                                                                                                                                    0.1s 
 => => transferring context: 140.61kB                                                                                                                                                      0.1s
 => CACHED [kener builder-debian 2/2] RUN apt-get update && apt-get install -y         build-essential=12.9         python3=3.11.2-1+b1         sqlite3=3.40.1-2+deb12u1         libsqlit  0.0s 
 => CACHED [kener builder 1/6] WORKDIR /app                                                                                                                                                0.0s
 => CACHED [kener builder 2/6] COPY package*.json ./                                                                                                                                       0.0s 
 => CACHED [kener builder 3/6] RUN --mount=type=cache,target=/root/.npm     npm ci --no-fund &&     npm cache clean --force                                                                0.0s
 => [kener builder 4/6] COPY . .                                                                                                                                                           0.9s 
 => [kener builder 5/6] RUN rm -rf src/routes/(docs)         static/documentation         static/fonts/lato/full &&     mkdir -p uploads database &&     chmod -R 750 uploads database     0.1s
 => [kener builder 6/6] RUN npm run build &&     npm prune --omit=dev                                                                                                                     52.2s 
 => CACHED [kener final-debian 2/2] RUN apt-get update && apt-get install -y         iputils-ping=3:20221126-1+deb12u1         sqlite3=3.40.1-2+deb12u1         tzdata     curl &&     rm  0.0s 
 => CACHED [kener final  1/16] WORKDIR /app                                                                                                                                                0.0s
 => CACHED [kener final  2/16] COPY --chown=node:node --from=builder /app/src/lib/ ./src/lib/                                                                                              0.0s
 => [kener final  3/16] COPY --chown=node:node --from=builder /app/build ./build                                                                                                           0.3s
 => [kener final  4/16] COPY --chown=node:node --from=builder /app/uploads ./uploads                                                                                                       0.1s
 => [kener final  5/16] COPY --chown=node:node --from=builder /app/database ./database                                                                                                     0.1s
 => [kener final  6/16] COPY --chown=node:node --from=builder /app/node_modules ./node_modules                                                                                             4.8s
 => [kener final  7/16] COPY --chown=node:node --from=builder /app/migrations ./migrations                                                                                                 0.0s
 => [kener final  8/16] COPY --chown=node:node --from=builder /app/seeds ./seeds                                                                                                           0.1s
 => [kener final  9/16] COPY --chown=node:node --from=builder /app/static ./static                                                                                                         0.1s
 => [kener final 10/16] COPY --chown=node:node --from=builder /app/entrypoint.sh ./entrypoint.sh                                                                                           0.0s
 => [kener final 11/16] COPY --chown=node:node --from=builder /app/knexfile.js ./knexfile.js                                                                                               0.0s
 => [kener final 12/16] COPY --chown=node:node --from=builder /app/main.js ./main.js                                                                                                       0.0s
 => [kener final 13/16] COPY --chown=node:node --from=builder /app/openapi.json ./openapi.json                                                                                             0.0s
 => [kener final 14/16] COPY --chown=node:node --from=builder /app/openapi.yaml ./openapi.yaml                                                                                             0.0s
 => [kener final 15/16] COPY --chown=node:node --from=builder /app/package.json ./package.json                                                                                             0.0s
 => [kener final 16/16] RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime && echo Etc/UTC > /etc/timezone &&     chmod +x ./entrypoint.sh                                             0.4s
 => [kener] exporting to image                                                                                                                                                            12.3s
 => => exporting layers                                                                                                                                                                   12.3s
 => => writing image sha256:f7bc992f885f40ed098567df1f89ab3e62767c808ae7bfd920b7b19938cba986                                                                                               0.0s
 => => naming to docker.io/library/kener-kener                                                                                                                                             0.0s
 => [kener] resolving provenance for metadata file                                                                                                                                         0.0s
[+] Running 3/3
 ✔ kener                  Built                                                                                                                                                            0.0s 
 ✔ Network kener_default  Created                                                                                                                                                          0.1s 
 ✔ Container kener        Healthy
```