### PR TITLE
feat(embed): add timezone support to embed parameters

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -12,29 +12,24 @@ There are two ways to embed your monitor in your website
 You can embed your monitor in your website using javascript. We recommend using this method as it takes care of the height of the embedded monitor.
 
 ```html
-<script
-	async
-	src="http://[hostname]/embed/monitor-[tag]/js?theme=light&monitor=http://[hostname]/embed/monitor-[tag]"
-></script>
+<script async src="http://[hostname]/embed/monitor-[tag]/js?theme=light&monitor=http://[hostname]/embed/monitor-[tag]"></script>
 ```
 
 Here is an example
 
 ```html
-<script
-	async
-	src="https://kener.ing/embed/monitor-earth/js?theme=light&monitor=https://kener.ing/embed/monitor-earth"
-></script>
+<script async src="https://kener.ing/embed/monitor-earth/js?theme=light&monitor=https://kener.ing/embed/monitor-earth"></script>
 ```
 
 ### Parameters
 
 You can pass the following parameters to the embed code
 
--   `theme`: You can pass `light` or `dark` theme
--   `monitor`: The monitor url
--   `bgc`: Background color of the monitor. Only supports hex color codes. DO NOT include the `#` symbol. Example: `ff0000`
--   `locale`: The locale of the monitor. You can pass the code of the locale you have enabled in your kener settings. Example: `en`, `fr` etc
+- `theme`: You can pass `light` or `dark` theme
+- `monitor`: The monitor url
+- `bgc`: Background color of the monitor. Only supports hex color codes. DO NOT include the `#` symbol. Example: `ff0000`
+- `locale`: The locale of the monitor. You can pass the code of the locale you have enabled in your kener settings. Example: `en`, `fr` etc
+- `tz`: Timezone. Example `Asia/Calcutta`, `Asia/Tokyo`
 
 Replace `[hostname]` with your kener hostname and `[tag]` with your monitor tag.
 
@@ -49,27 +44,13 @@ Replace `[hostname]` with your kener hostname and `[tag]` with your monitor tag.
 This is the simplest way to embed your monitor in your website. You can use the following code to embed your monitor in your website.
 
 ```html
-<iframe
-	src="http://[hostname]/embed/monitor-[tag]?theme=light"
-	width="100%"
-	height="200"
-	allowfullscreen="allowfullscreen"
-	allowpaymentrequest
-	frameborder="0"
-></iframe>
+<iframe src="http://[hostname]/embed/monitor-[tag]?theme=light" width="100%" height="200" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
 ```
 
 Here is an example
 
 ```html
-<iframe
-	src="https://kener.ing/embed/monitor-earth?theme=light"
-	width="100%"
-	height="100"
-	allowfullscreen="allowfullscreen"
-	allowpaymentrequest
-	frameborder="0"
-></iframe>
+<iframe src="https://kener.ing/embed/monitor-earth?theme=light" width="100%" height="100" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
 ```
 
 Replace `[hostname]` with your kener hostname and `[tag]` with your monitor tag.
@@ -78,9 +59,9 @@ Replace `[hostname]` with your kener hostname and `[tag]` with your monitor tag.
 
 You can pass the following parameters to the embed code
 
--   `theme`: You can pass `light` or `dark` theme
--   `bgc`: Background color of the monitor. Only supports hex color codes. DO NOT include the `#` symbol. Example: `ff0000`
--   `locale`: The locale of the monitor. You can pass the code of the locale you have enabled in your kener settings. Example: `en`, `fr` etc
+- `theme`: You can pass `light` or `dark` theme
+- `bgc`: Background color of the monitor. Only supports hex color codes. DO NOT include the `#` symbol. Example: `ff0000`
+- `locale`: The locale of the monitor. You can pass the code of the locale you have enabled in your kener settings. Example: `en`, `fr` etc
 
 ### Demo
 

--- a/embed.html
+++ b/embed.html
@@ -13,7 +13,7 @@
   <body>
     <script
       async
-      src="http://localhost:3000/embed/monitor-bitbuckettcp/js?bgc=212226&locale=en&theme=dark&monitor=http://localhost:3000/embed/monitor-bitbuckettcp"
+      src="http://localhost:3000/embed/monitor-earth/js?theme=light&monitor=http://localhost:3000/embed/monitor-earth&locale=fr&tz=Asia/Tokyo"
     ></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kener",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "private": false,
   "license": "MIT",
   "description": "Kener is a modern, open-source status page application built with Node.js. It provides real-time monitoring, uptime tracking, incident management, and beautiful dashboards. Perfect for DevOps teams, SaaS providers, and businesses needing reliable service status communication with minimal setup.",

--- a/src/routes/(embed)/+layout.server.js
+++ b/src/routes/(embed)/+layout.server.js
@@ -2,61 +2,59 @@
 import i18n from "$lib/i18n/server";
 import { redirect } from "@sveltejs/kit";
 import { base } from "$app/paths";
-import {
-	GetAllSiteData,
-	IsSetupComplete,
-	IsLoggedInSession
-} from "$lib/server/controllers/controller.js";
+import { GetAllSiteData, IsSetupComplete, IsLoggedInSession } from "$lib/server/controllers/controller.js";
 
 export async function load({ params, route, url, cookies, request }) {
-	let isSetupComplete = await IsSetupComplete();
-	if (!isSetupComplete) {
-		throw redirect(302, base + "/manage/setup");
-	}
+  let isSetupComplete = await IsSetupComplete();
+  if (!isSetupComplete) {
+    throw redirect(302, base + "/manage/setup");
+  }
 
-	if (process.env.KENER_SECRET_KEY === undefined) {
-		throw redirect(302, base + "/manage/setup");
-	}
+  if (process.env.KENER_SECRET_KEY === undefined) {
+    throw redirect(302, base + "/manage/setup");
+  }
+  const query = url.searchParams;
+  let isLoggedIn = await IsLoggedInSession(cookies);
 
-	let isLoggedIn = await IsLoggedInSession(cookies);
+  let site = await GetAllSiteData();
+  const headers = request.headers;
+  const userAgent = headers.get("user-agent");
+  let localTz = "UTC";
 
-	let site = await GetAllSiteData();
-	const headers = request.headers;
-	const userAgent = headers.get("user-agent");
-	let localTz = "UTC";
-	const localTzCookie = cookies.get("localTz");
-	if (!!localTzCookie) {
-		localTz = localTzCookie;
-	}
-	let showNav = true;
-	if (url.pathname.startsWith("/embed")) {
-		showNav = false;
-	}
-	// if the user agent is lighthouse, then we are running a lighthouse test
-	//if bot also set localTz to -1 to avoid reload
-	let isBot = false;
-	if (userAgent?.includes("Chrome-Lighthouse") || userAgent?.includes("bot")) {
-		isBot = true;
-	}
-	const query = url.searchParams;
-	//load all files from lib locales folder
-	let selectedLang = query.get("locale") ? query.get("locale") : "en";
+  const localTzQuery = query.get("tz");
+  if (!!localTzQuery) {
+    localTz = localTzQuery;
+  }
 
-	let embed = false;
-	if (route.id.endsWith("monitor-[tag]")) {
-		embed = true;
-	}
+  let showNav = true;
+  if (url.pathname.startsWith("/embed")) {
+    showNav = false;
+  }
+  // if the user agent is lighthouse, then we are running a lighthouse test
+  //if bot also set localTz to -1 to avoid reload
+  let isBot = false;
+  if (userAgent?.includes("Chrome-Lighthouse") || userAgent?.includes("bot")) {
+    isBot = true;
+  }
 
-	const bgc = query.get("bgc") ? "#" + query.get("bgc") : "";
-	return {
-		site: site,
-		localTz: localTz,
-		showNav,
-		isBot,
-		lang: i18n(String(selectedLang)),
-		selectedLang: selectedLang,
-		embed,
-		bgc,
-		isLoggedIn: !!isLoggedIn.user
-	};
+  //load all files from lib locales folder
+  let selectedLang = query.get("locale") ? query.get("locale") : "en";
+
+  let embed = false;
+  if (route.id.endsWith("monitor-[tag]")) {
+    embed = true;
+  }
+
+  const bgc = query.get("bgc") ? "#" + query.get("bgc") : "";
+  return {
+    site: site,
+    localTz: localTz,
+    showNav,
+    isBot,
+    lang: i18n(String(selectedLang)),
+    selectedLang: selectedLang,
+    embed,
+    bgc,
+    isLoggedIn: !!isLoggedIn.user,
+  };
 }

--- a/src/routes/(embed)/+layout.svelte
+++ b/src/routes/(embed)/+layout.svelte
@@ -29,24 +29,8 @@
   } else {
     defaultLocaleValue = allLocales.find((locale) => locale.code === defaultLocaleKey).name;
   }
-  /**
-   * @param {string} locale
-   */
-  function setLanguage(locale) {
-    document.cookie = `localLang=${locale};max-age=${60 * 60 * 24 * 365 * 30}`;
-    if (locale === defaultLocaleKey) return;
-    defaultLocaleValue = allLocales[locale];
-  }
 
-  let Analytics;
   onMount(async () => {
-    let localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if (localTz != data.localTz) {
-      if (data.isBot === false) {
-        document.cookie = "localTz=" + localTz + ";max-age=" + 60 * 60 * 24 * 365 * 30;
-        location.reload();
-      }
-    }
     if (defaultTheme != "none") {
       setMode(defaultTheme);
     }

--- a/src/routes/(embed)/embed/monitor-[tag]/js/+server.js
+++ b/src/routes/(embed)/embed/monitor-[tag]/js/+server.js
@@ -1,22 +1,34 @@
 // @ts-nocheck
 // @ts-ignore
 export async function GET({ url, params }) {
-	const { tag } = params;
-	const query = url.searchParams;
-	const uriEmbedded = query.get("monitor");
-	const theme = query.get("theme") || "light";
-	const bgc = query.get("bgc") || "transparent";
-	const locale = query.get("locale") || "en";
-	const uriOriginal = uriEmbedded;
+  const { tag } = params;
+  const query = url.searchParams;
+  const uriEmbedded = query.get("monitor");
+  const theme = query.get("theme") || "light";
+  const bgc = query.get("bgc") || "transparent";
+  const locale = query.get("locale") || "en";
+  const tz = query.get("tz") || "NONE";
+  const uriOriginal = uriEmbedded;
 
-	const currentSlug = tag;
-	const js = `
+  const currentSlug = tag;
+  const js = `
 	(function () {
+		//find user timezone
+		let localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+		let tz = "${tz}";
+		if(tz === "NONE") {
+			if(!!localTz){
+				tz = localTz;
+			} else {
+				tz = "UTC";
+			}
+		} 
+		
     var createEmbedFrame = function () {
         var uid = "KENER_" + ~~(new Date().getTime() / 86400000);
         var uriOriginal = "${uriOriginal}";
         var uriOriginalNoProtocol = uriOriginal.split("//").pop();
-        var uriEmbedded = "${uriEmbedded}?theme=${theme}&bgc=${bgc}&locale=${locale}";
+        var uriEmbedded = "${uriEmbedded}?theme=${theme}&bgc=${bgc}&locale=${locale}&tz=" + tz;
         var currentSlug = "${currentSlug}";
         var target = document.querySelector("script[src*='" + uriOriginalNoProtocol + "']");
         var iframe = document.createElement("iframe");
@@ -66,9 +78,9 @@ export async function GET({ url, params }) {
 }).call(this);
 
 	`;
-	return new Response(js, {
-		headers: {
-			"Content-Type": "application/javascript"
-		}
-	});
+  return new Response(js, {
+    headers: {
+      "Content-Type": "application/javascript",
+    },
+  });
 }


### PR DESCRIPTION
Introduces a 'tz' parameter for specifying timezone in embed scripts and iframe URLs, improving localization for embedded monitors. Updates documentation and refactors parameter handling to prioritize explicit timezone over browser-detected values.

Relates to improved internationalization and user experience.