### PR TITLE
refactor: rename visibility property to isHidden and update related l…

### DIFF
--- a/src/lib/components/manage/homePage.svelte
+++ b/src/lib/components/manage/homePage.svelte
@@ -260,7 +260,7 @@
       {
         name: "",
         description: "",
-        visibility: true
+        isHidden: false
       }
     ];
   }
@@ -676,17 +676,18 @@
               disabled={i === 0}
             />
           </div>
-          <div class="relative flex items-center mt-4">
+          <div class="relative flex flex-col items-center gap-y-2">
+            <Label for="{i}vis" class="block w-full">Visibility</Label>
             <DropdownMenu.Root>
-              <DropdownMenu.Trigger disabled={i === 0}>
-                <Button variant="outline" class="mr-2" disabled={i === 0}>
-                  {cat.visibility ? "Public" : "Private"}
+              <DropdownMenu.Trigger disabled={i === 0} id="{i}vis">
+                <Button variant="outline" class="mr-2" disabled={cat.name === "Home"}>
+                  {cat.isHidden ? "Private" : "Public"}
                 </Button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Content>
                 <DropdownMenu.Group>
-                  <DropdownMenu.Item on:click={() => (cat.visibility = false)} disabled={i === 0}>Private</DropdownMenu.Item>
-                  <DropdownMenu.Item on:click={() => (cat.visibility = true)} disabled={i === 0}>Public</DropdownMenu.Item>
+                  <DropdownMenu.Item on:click={() => (cat.isHidden = true)}>Private</DropdownMenu.Item>
+                  <DropdownMenu.Item on:click={() => (cat.isHidden = false)}>Public</DropdownMenu.Item>
                 </DropdownMenu.Group>
               </DropdownMenu.Content>
             </DropdownMenu.Root>
@@ -694,7 +695,7 @@
           <div class="flex items-center">
             <Button
               variant="ghost"
-              class="h-6 w-6 p-1"
+              class="mt-4 h-6 w-6 p-1"
               disabled={i === 0}
               on:click={() => (categories = categories.filter((_, index) => index !== i))}
             >

--- a/src/lib/server/db/seedSiteData.js
+++ b/src/lib/server/db/seedSiteData.js
@@ -97,7 +97,7 @@ const seedSiteData = {
     cssSrc: "",
     family: "",
   },
-  categories: [{ name: "Home", description: "Monitors for Home Page" }],
+  categories: [{ name: "Home", description: "Monitors for Home Page", isHidden: false }],
   homeIncidentCount: 5,
   homeIncidentStartTimeWithin: 30,
   kenerTheme: "default",

--- a/src/routes/(kener)/+page.server.js
+++ b/src/routes/(kener)/+page.server.js
@@ -4,7 +4,7 @@ import { GetMonitors, GetIncidentsOpenHome, SystemDataMessage } from "$lib/serve
 import { SortMonitor } from "$lib/clientTools.js";
 import moment from "moment";
 import { page } from "$app/stores";
-import { redirect, error } from '@sveltejs/kit';
+import { redirect, error } from "@sveltejs/kit";
 
 function removeTags(str) {
   if (str === null || str === "") return false;
@@ -152,8 +152,8 @@ export async function load({ parent, url }) {
     let allCategories = siteData.categories;
     let selectedCategory = allCategories.find((category) => category.name === query.get("category"));
     if (selectedCategory) {
-      if (!selectedCategory.visibility && !parentData.isLoggedIn) {
-        throw redirect(303, '/manage/app');
+      if (!!selectedCategory.isHidden && !parentData.isLoggedIn) {
+        throw error(404, "Category not found");
       }
       pageTitle = selectedCategory.name + " - " + pageTitle;
       pageDescription = selectedCategory.description;
@@ -164,9 +164,8 @@ export async function load({ parent, url }) {
         subtitle: selectedCategory.description,
         image: selectedCategory.image,
       };
-    }
-    else {
-      throw error(404, 'Category not found');
+    } else {
+      throw error(404, "Category not found");
     }
   }
   if (isCategoryPage || isMonitorPage || isGroupPage) {

--- a/src/routes/(kener)/+page.svelte
+++ b/src/routes/(kener)/+page.svelte
@@ -18,7 +18,7 @@
   import { format } from "date-fns";
   import GMI from "$lib/components/gmi.svelte";
   import { page } from "$app/stores";
-  
+
   export let data;
   let shareMenusToggle = false;
   function showShareMenu(e) {
@@ -264,9 +264,7 @@
   <section
     class="section-categories relative z-10 mx-auto mb-8 w-full max-w-[890px] flex-1 flex-col items-start backdrop-blur-[2px] md:w-[655px]"
   >
-  {#each data.site.categories.filter((category) => 
-    category.name != "Home" && 
-    (category.visibility || $page.data.isLoggedIn)) as category}
+    {#each data.site.categories.filter((category) => category.name != "Home" && (!!!category.isHidden || $page.data.isLoggedIn)) as category}
       <a href={`?category=${category.name}`} rel="external">
         <Card.Root class="mb-4 hover:bg-secondary">
           <Card.Header class="bounce-right relative w-full cursor-pointer px-4  ">


### PR DESCRIPTION
This pull request introduces changes to improve the handling of category visibility in the application by replacing the `visibility` property with a more intuitive `isHidden` property. It also includes minor code style adjustments. Below is a summary of the most significant changes:

### Refactoring category visibility:

* Replaced the `visibility` property with `isHidden` in the `categories` object across the codebase, including its initialization in `seedSiteData` (`src/lib/server/db/seedSiteData.js`) and its usage in the `homePage.svelte` component. (`[[1]](diffhunk://#diff-3685f3a7df4fd41f91013c3ab649a9b7b2d1d019fffe1d7bbcd2b674ab44b9a9L263-R263)`, `[[2]](diffhunk://#diff-f77aea40480e3c31da945c38f30f54432c5696e45bb9784999c068d1004a3004L100-R100)`)
* Updated the dropdown menu in `homePage.svelte` to reflect the new `isHidden` property, changing the labels and logic for toggling between "Public" and "Private" states. (`[src/lib/components/manage/homePage.svelteL679-R698](diffhunk://#diff-3685f3a7df4fd41f91013c3ab649a9b7b2d1d019fffe1d7bbcd2b674ab44b9a9L679-R698)`)
* Modified the `load` function in `+page.server.js` to check `isHidden` instead of `visibility` when determining access to categories. It now throws a `404` error for hidden categories if the user is not logged in. (`[[1]](diffhunk://#diff-4d3a5e4f520230918453654d64792bb946b4af2275b85620e6dac6229c30f432L155-R156)`, `[[2]](diffhunk://#diff-4d3a5e4f520230918453654d64792bb946b4af2275b85620e6dac6229c30f432L167-R168)`)
* Adjusted the category filtering logic in `+page.svelte` to use `isHidden` for determining which categories to display. (`[src/routes/(kener)/+page.svelteL267-R267](diffhunk://#diff-560dd748fe2f01b2258038e49038b589781265ba390be7c99d6a55aed00aafbbL267-R267)`)

### Code style improvements:

* Standardized quote style in `+page.server.js` by replacing single quotes with double quotes for consistency. (`[src/routes/(kener)/+page.server.jsL7-R7](diffhunk://#diff-4d3a5e4f520230918453654d64792bb946b4af2275b85620e6dac6229c30f432L7-R7)`)