### PR TITLE
Fix: Heartbeat monitor respects cron-based grace periods

### DIFF
--- a/src/lib/server/services/heartbeatCall.js
+++ b/src/lib/server/services/heartbeatCall.js
@@ -2,6 +2,7 @@
 import { UP, DOWN, DEGRADED, REALTIME, TIMEOUT, ERROR, MANUAL } from "../constants.js";
 import { GetMinuteStartNowTimestampUTC } from "../tool.js";
 import { GetLastHeartbeat } from "../controllers/controller.js";
+import cronParser from "cron-parser";
 
 class HeartbeatCall {
   monitor;
@@ -11,12 +12,38 @@ class HeartbeatCall {
   }
 
   async execute() {
-    let nowMinute = GetMinuteStartNowTimestampUTC();
+    let nowMinute = GetMinuteStartNowTimestampUTC(); // current time in seconds (minute start)
     let latestData = await GetLastHeartbeat(this.monitor.tag);
     if (!latestData) {
       return {};
     }
-    let latency = nowMinute - latestData.timestamp;
+
+    // 🛠️ FIX: Use cron to calculate expected heartbeat time
+    let expectedTime;
+    try {
+      const interval = cronParser.parseExpression(this.monitor.cron, {
+        currentDate: new Date(),
+      });
+      expectedTime = Math.floor(interval.prev().getTime() / 1000); // seconds
+    } catch (err) {
+      return {
+        status: ERROR,
+        message: "Invalid cron format",
+        type: REALTIME,
+      };
+    }
+
+    // If heartbeat was received after or at expected time, it's UP
+    if (latestData.timestamp >= expectedTime) {
+      return {
+        status: UP,
+        latency: nowMinute - latestData.timestamp,
+        type: REALTIME,
+      };
+    }
+
+    // Calculate how late the expected heartbeat is
+    let latency = nowMinute - expectedTime;
     let downRemainingMinutes = Number(this.monitor.type_data.downRemainingMinutes);
     if (latency > downRemainingMinutes * 60) {
       return {
@@ -25,6 +52,7 @@ class HeartbeatCall {
         type: REALTIME,
       };
     }
+
     let degradedRemainingMinutes = Number(this.monitor.type_data.degradedRemainingMinutes);
     if (latency > degradedRemainingMinutes * 60) {
       return {
@@ -33,6 +61,7 @@ class HeartbeatCall {
         type: REALTIME,
       };
     }
+
     return {
       status: UP,
       latency: latency,

--- a/src/lib/server/services/heartbeatCall.js
+++ b/src/lib/server/services/heartbeatCall.js
@@ -22,7 +22,7 @@ class HeartbeatCall {
     let expectedTime;
     try {
       const cronJob = Cron(this.monitor.cron);
-      const prevDate = cronJob.prev();
+      const prevDate = cronJob.previousRun();
       expectedTime = Math.floor(prevDate.getTime() / 1000); // seconds
     } catch (err) {
       return {

--- a/src/lib/server/services/heartbeatCall.js
+++ b/src/lib/server/services/heartbeatCall.js
@@ -2,7 +2,7 @@
 import { UP, DOWN, DEGRADED, REALTIME, TIMEOUT, ERROR, MANUAL } from "../constants.js";
 import { GetMinuteStartNowTimestampUTC } from "../tool.js";
 import { GetLastHeartbeat } from "../controllers/controller.js";
-import cronParser from "cron-parser";
+import { Cron } from "croner";
 
 class HeartbeatCall {
   monitor;
@@ -18,13 +18,12 @@ class HeartbeatCall {
       return {};
     }
 
-    // Use cron to calculate expected heartbeat time
+    // Use croner to calculate expected heartbeat time
     let expectedTime;
     try {
-      const interval = cronParser.parseExpression(this.monitor.cron, {
-        currentDate: new Date(),
-      });
-      expectedTime = Math.floor(interval.prev().getTime() / 1000); // seconds
+      const cronJob = Cron(this.monitor.cron);
+      const prevDate = cronJob.prev();
+      expectedTime = Math.floor(prevDate.getTime() / 1000); // seconds
     } catch (err) {
       return {
         status: ERROR,

--- a/src/lib/server/services/heartbeatCall.js
+++ b/src/lib/server/services/heartbeatCall.js
@@ -18,7 +18,7 @@ class HeartbeatCall {
       return {};
     }
 
-    // 🛠️ FIX: Use cron to calculate expected heartbeat time
+    // Use cron to calculate expected heartbeat time
     let expectedTime;
     try {
       const interval = cronParser.parseExpression(this.monitor.cron, {

--- a/src/lib/server/services/heartbeatCall.js
+++ b/src/lib/server/services/heartbeatCall.js
@@ -26,9 +26,9 @@ class HeartbeatCall {
       expectedTime = Math.floor(prevDate.getTime() / 1000); // seconds
     } catch (err) {
       return {
-        status: ERROR,
-        message: "Invalid cron format",
-        type: REALTIME,
+        status: DOWN,
+        latency: 0,
+        type: ERROR,
       };
     }
 


### PR DESCRIPTION
### Description
This PR fixes an issue where heartbeat monitors were being marked as "Down" immediately after a missed heartbeat, even when "Degraded After" and "Down After" grace periods were configured.

### Changes:

- Added cron-parser to determine the expected heartbeat time based on the configured cron expression.
- Changed latency calculation to be based on how long it’s been since the expected heartbeat time, not the last received heartbeat.
- Applied grace periods (degradedRemainingMinutes and downRemainingMinutes) correctly based on this latency.

### Fixes:

- If a service is expected to send a heartbeat at 4:00 AM, and it misses that, the system will now:
- Stay UP until 4:30 AM (if Degraded After = 30 min)
- Become DEGRADED at 4:30 AM
- Become DOWN at 5:00 AM (if Down After = 60 min)

Fixes #450