### PR TITLE
fixed the issue#332 with more optimized ORIGIN env calls

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,6 +15,10 @@ const base = process.env.KENER_BASE_PATH || "";
 const app = express();
 const db = knex(knexOb);
 
+if (process.env.ORIGIN) {
+       process.env.SVELTEKIT_ORIGIN = process.env.ORIGIN;
+}
+
 app.use((req, res, next) => {
 	if (req.path.startsWith("/embed")) {
 		res.setHeader("Content-Security-Policy", "frame-ancestors *");

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ const PORT = Number(process.env.PORT) || 3000;
 const base = process.env.KENER_BASE_PATH || "";
 const VITE_BUILD_ENV = process.env.VITE_BUILD_ENV || "development"; // Default to "development"
 const isProduction = VITE_BUILD_ENV === "production";
+const ORIGIN = process.env.ORIGIN || `http://localhost:${PORT}`;
 
 export default defineConfig(({ mode }) => ({
   optimizeDeps: {
@@ -49,6 +50,7 @@ export default defineConfig(({ mode }) => ({
     version(),
   ],
   server: {
+    allowedHosts: [new URL(ORIGIN).hostname],
     port: PORT,
     watch: {
       ignored: ["**/src/lib/server/data/**"], // Adjust the path to the file you want to ignore


### PR DESCRIPTION
There was an issue in the `main.js` file with how the environment variable for the domain was being used. The app was referencing `ORIGIN`, but the correct variable is actually `SVELTEKIT_ORIGIN`. I updated the code to use `SVELTEKIT_ORIGIN` to fix the domain mismatch problem.

Additionally, there was wasn't any `server.allowedHosts()` call happening in `vite.config.js` because of that it wasn’t picking up the domain provided in the `ORIGIN` environment variable. I’ve updated the logic to make sure the domain is correctly set and allowed when the server runs.

resolves: #332 