### PR TITLE
feat: support fetching monitor status from different dates

### DIFF
--- a/src/routes/(kener)/api/status/+server.js
+++ b/src/routes/(kener)/api/status/+server.js
@@ -31,6 +31,8 @@ export async function GET({ request, url }) {
 	const query = url.searchParams;
 	const tag = query.get("tag");
 	const timestamp = query.get("timestamp");
+	const startDate = query.get("start_date");
+	const endDate = query.get("end_date");
 	if (!!!tag) {
 		return json(
 			{ error: "tag missing" },
@@ -39,7 +41,7 @@ export async function GET({ request, url }) {
 			}
 		);
 	}
-	return json(await GetMonitorStatusByTag(tag, timestamp), {
+	return json(await GetMonitorStatusByTag(tag, timestamp, startDate, endDate), {
 		status: 200
 	});
 }


### PR DESCRIPTION
  I've enhanced the /api/status endpoint to support time range queries. Here's what was changed:

  Current behavior was: Uptime calculated from start of current day to now (or specified timestamp).

  Enhanced functionality:

  1. New parameters:
    - start_date: Start date in YYYY-MM-DD format
    - end_date: End date in YYYY-MM-DD format
  2. Usage examples:
    - GET /api/status?tag=your-monitor&start_date=2025-07-01&end_date=2025-07-31 - July uptime
    - GET /api/status?tag=your-monitor&start_date=2025-07-01 - From July 1st to now
    - GET /api/status?tag=your-monitor&end_date=2025-07-31 - July 31st (full day)
    - GET /api/status?tag=your-monitor - Current day (existing behavior)
  3. Enhanced response includes:
    - time_range.start: Start timestamp
    - time_range.end: End timestamp
    - Original fields: status, uptime, last_updated_at
  4. Error handling:
    - Invalid date formats
    - Start date after end date
    - No data for time range

  The uptime calculation now works across any specified date range, giving you exactly what you requested - the ability to query uptime between
  specific dates like July 1-31.