### PR TITLE
feat: create maintenance incident type via API

### DIFF
--- a/src/lib/server/controllers/controller.js
+++ b/src/lib/server/controllers/controller.js
@@ -773,6 +773,10 @@ export const CreateIncident = async (data) => {
     incident_source: !!data.incident_source ? data.incident_source : "DASHBOARD",
   };
 
+  if (!["INCIDENT", "MAINTENANCE"].includes(incident.incident_type)) {
+    throw new Error("Incident type must be either INCIDENT or MAINTENANCE");
+  }
+
   //incident_type == INCIDENT delete endDateTime
   if (incident.incident_type === "INCIDENT") {
     incident.end_date_time = null;

--- a/src/routes/(kener)/api/incident/+server.js
+++ b/src/routes/(kener)/api/incident/+server.js
@@ -20,7 +20,9 @@ export async function POST({ request }) {
   let incident = {
     title: payload.title,
     start_date_time: payload.start_date_time,
-    incident_source: "API",
+    end_date_time: payload.end_date_time || null,
+    incident_type: payload.incident_type || "INCIDENT",
+    incident_source: "API"
   };
 
   try {


### PR DESCRIPTION
Hi! I wanted to create a Maintenance via the API but it is currently not possible.

### Summary

This PR allows to give 2 more parameters in the API:

- `incident_type`
- `end_date_time`

It also adds a new check inside `CreateIncident()` in order to avoid dirty values in the DB.

### API calls

**Create a Maintenance**

```
POST /api/incident
{
    "title": "Test maintenance",
    "start_date_time": 1762268631,
    "end_date_time": 1762272231,
    "incident_type": "MAINTENANCE"
}

RESPONSE -> 201
{
    "id": 9,
    "start_date_time": 1762268631,
    "end_date_time": 1762272231,
    "created_at": "2025-11-04 12:42:52",
    "updated_at": "2025-11-04 12:42:52",
    "title": "Test maintenance",
    "status": "OPEN",
    "state": "INVESTIGATING"
}
```

**Create an incident with a wrong type**

```
POST /api/incident
{
    "title": "Test maintenance",
    "start_date_time": 1762260039,
    "end_date_time": 1762268631,
    "incident_type": "MAINTENANCEEEE"
}

RESPONSE -> 400
{
    "error": "Incident type must be either INCIDENT or MAINTENANCE"
}
```

### Notes

I noticed that creating a maintenance in this way, the state was set to "INVESTIGATING" instead of "RESOLVED" (when creating via web UI). It looks impactless but I'm not aware of the whole workflows.

Fixes #468 