### PR TITLE
Docker unified healthcheck

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,1 @@
-#!/bin/sh
-set -e
-
-# Automatically set PUBLIC_WHITE_LABEL based on WHITE_LABEL
-export PUBLIC_WHITE_LABEL="${WHITE_LABEL}"
-
-# Replace shell with the given command (from CMD or runtime args)
-exec "$@"
+#!/bin/shset -e# Automatically set PUBLIC_WHITE_LABEL based on WHITE_LABELexport PUBLIC_WHITE_LABEL="${WHITE_LABEL}"# Replace shell with the given command (from CMD or runtime args)exec "$@"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,18 +1,1 @@
-#!/bin/sh
-
-set -eu
-
-HOST="${HEALTHCHECK_HOST:-127.0.0.1}"
-PORT="${HEALTHCHECK_PORT:-3000}"
-PATH_NAME="${HEALTHCHECK_PATH:-/api/health}"
-
-URL="http://${HOST}:${PORT}${PATH_NAME}"
-
-if command -v wget >/dev/null 2>&1; then
-	wget --spider -q "$URL"
-elif command -v curl >/dev/null 2>&1; then
-	curl -fsS "$URL" >/dev/null
-else
-	echo "Neighter wget nor curl found"
-	exit 1
-fi
+#!/bin/shset -euHOST="${HEALTHCHECK_HOST:-127.0.0.1}"PORT="${HEALTHCHECK_PORT:-3000}"PATH_NAME="${HEALTHCHECK_PATH:-/api/health}"URL="http://${HOST}:${PORT}${PATH_NAME}"if command -v wget >/dev/null 2>&1; then	wget --spider -q "$URL"elif command -v curl >/dev/null 2>&1; then	curl -fsS "$URL" >/dev/nullelse	echo "Neighter wget nor curl found"	exit 1fi


### PR DESCRIPTION
- Unified healthcheck scripts for Debian and Alpine-based Docker images
- Fixed Windows line ending issues for entrypoint.sh and healthcheck.sh
- Ensures cross-platform compatibility and maintainable Docker builds

Note: I haven’t fully tested running the container on Windows, so there might still be some quirks there, but the main goal of unifying the scripts is done. I apologise if this causes the maintainer issues, this is my first contribution and will happily accept any feedback or suggestions