### PR TITLE
feat: changes timestamp box to use border

### DIFF
--- a/src/lib/components/monitor.svelte
+++ b/src/lib/components/monitor.svelte
@@ -403,12 +403,12 @@
                 <LoaderBoxes />
               {:else}
                 {#each Object.entries(_0Day) as [ts, bar]}
-                  <div data-index={bar.index} class="bg-{bar.cssClass} today-sq m-[1px] h-[10px] w-[10px]"></div>
-                  <div class="hiddenx relative">
-                    <div
-                      data-index={ts.index}
-                      class="message rounded border bg-black p-2 text-xs font-semibold text-white"
-                    >
+                  <div
+                    data-index={bar.index}
+                    class="bg-{bar.cssClass} today-sq h-[12px] w-[12px] border border-background"
+                  ></div>
+                  <div class="hiddenx relative left-2 top-2">
+                    <div data-index={ts} class="message rounded border bg-black p-2 text-xs font-semibold text-white">
                       <p>
                         <span class="text-{bar.cssClass}"> ● </span>
 


### PR DESCRIPTION
### Issue

#### Before
<img width="599" height="444" alt="07 January - 000215" src="https://github.com/user-attachments/assets/4bb5cec1-dbc2-4e16-9faa-4cdf2a0a40ab" />

#### 
<img width="599" height="444" alt="07 January - 000218" src="https://github.com/user-attachments/assets/37a39b83-7908-4384-96a6-22168861d74b" />
After

The grid of boxes currently uses margin but this interrupts hover experience when the user moves their cursor over multiple boxes, especially in a short space of time. Changing for a 1px border instead of a 1px margin ensures  tooltip stays active without flashing between visible and hidden states.

### Note

This grid could be improved and I have a couple of ideas on how:

- we could change the boxes to use aggregation so an area is marked as green, orange or red instead of hundreds of boxes. the tooltip would show something like "DOWN from 1200 -> 1300"
- having a css only approach is quite cool but making use of the Popover API and controlling position and content with JS could be beneficial to bundle size