### PR TITLE
fix: API Reference page not loading (#532)

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ process.env.UPLOAD_PATH = "./uploads";
 app.use(base + "/uploads", express.static("uploads"));
 
 try {
-	const openapiJSON = fs.readFileSync("./openapi.json", "utf-8");
+	const openapiJSON = JSON.parse(fs.readFileSync("./openapi.json", "utf-8"));
 	app.use(
 		"/api-reference",
 		apiReference({


### PR DESCRIPTION
The API reference page was blank because spec.content expected a parsed
JSON object but received a JSON string. Added JSON.parse() to properly
parse the OpenAPI spec before passing it to @scalar/express-api-reference.

Fixes #532
<img width="1377" height="786" alt="Screenshot 2026-01-09 at 12 22 04 PM" src="https://github.com/user-attachments/assets/81784da3-c8bd-4b14-95e9-f90f92760b25" />
