### PR TITLE
Fix redirect loop when `TZ=UTC`

### DIFF
--- a/src/routes/(kener)/+layout.svelte
+++ b/src/routes/(kener)/+layout.svelte
@@ -69,10 +69,8 @@
   let myTimezone = data.localTz;
   onMount(async () => {
     myTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if (data.localTz === "UTC") {
-      if (data.isBot === false) {
-        setTz(myTimezone);
-      }
+    if (data.isBot === false && myTimezone && myTimezone != data.localTz) {
+      setTz(myTimezone);
     }
     if (defaultTheme != "none") {
       setMode(defaultTheme);


### PR DESCRIPTION
If the system `TZ` IS `UTC` then this code caused a permanent redirect loop.

Also, if the users timezone is set to UTC then the page refreshes forever.

Fixes: #592 