### PR TITLE
docs: typo Github => GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Kener combines public status page essentials with advanced admin workflows.
 
 If you’re enjoying Kener and want to support its development, consider sponsoring me on GitHub or treating me to a coffee. Your support helps keep the project growing! 🚀
 
-- [Sponsor Me Using Github](https://github.com/sponsors/rajnandan1)
+- [Sponsor Me Using GitHub](https://github.com/sponsors/rajnandan1)
 
 - [Buy Me a Coffee](https://www.buymeacoffee.com/rajnandan1)
 

--- a/src/lib/server/db/seedSiteData.ts
+++ b/src/lib/server/db/seedSiteData.ts
@@ -36,7 +36,7 @@ const seedSiteData = {
   ],
   nav: [
     { name: "Documentation", url: "https://kener.ing/docs/home", iconURL: "" },
-    { name: "Github", iconURL: "", url: "https://github.com/rajnandan1/kener" },
+    { name: "GitHub", iconURL: "", url: "https://github.com/rajnandan1/kener" },
     { name: "Login", iconURL: "", url: "/account/signin" },
   ],
   hero: {

--- a/src/routes/(docs)/docs/content/v3/changelogs.md
+++ b/src/routes/(docs)/docs/content/v3/changelogs.md
@@ -58,7 +58,7 @@ Here are the changelogs for Kener. Changelogs are only published when there are 
 
 - Improved build time by migrating lucid-svelte to individual components
 
-### Github Issues Resolved in this release {#v3-2-5-github-issues}
+### GitHub Issues Resolved in this release {#v3-2-5-github-issues}
 
 - Feature: Enhancement of Webhook Custom Body Functionality [#238](https://github.com/rajnandan1/kener/issues/238)
 - Feature: Add LDAP for authentication [#210](https://github.com/rajnandan1/kener/issues/210)

--- a/src/routes/(docs)/docs/content/v3/customize-site.md
+++ b/src/routes/(docs)/docs/content/v3/customize-site.md
@@ -25,7 +25,7 @@ metaTags:
 nav:
     - name: "Documentation"
       url: "/docs"
-	- name: "Github"
+	- name: "GitHub"
       iconURL: "/github.svg"
       url: "https://github.com/rajnandan1/kener"
 siteURL: https://kener.ing

--- a/src/routes/(docs)/docs/content/v3/deployment.md
+++ b/src/routes/(docs)/docs/content/v3/deployment.md
@@ -39,7 +39,7 @@ pm2 start main.js
 docker.io/rajnandan1/kener:latest
 ```
 
-[Github Packages](https://github.com/rajnandan1/kener/pkgs/container/kener)
+[GitHub Packages](https://github.com/rajnandan1/kener/pkgs/container/kener)
 
 ```bash
 ghcr.io/rajnandan1/kener:latest

--- a/src/routes/(docs)/docs/content/v3/incident-management.md
+++ b/src/routes/(docs)/docs/content/v3/incident-management.md
@@ -1,6 +1,6 @@
 ---
 title: Incident Management | Kener
-description: Kener uses Github to power incident management using labels
+description: Kener uses GitHub to power incident management using labels
 ---
 
 Kener lets you manage incidents using its dashboard or APIs.

--- a/src/routes/(docs)/docs/content/v3/monitor-examples.md
+++ b/src/routes/(docs)/docs/content/v3/monitor-examples.md
@@ -97,8 +97,8 @@ export GH_TOKEN=some.token.for.github
 > **_NOTE:_** DO NOT forget the `$` sign in your monitor secret, otherwise it will not be picked up.
 
 ```yaml
-- name: Github Issues
-  description: Github Issues Fetch
+- name: GitHub Issues
+  description: GitHub Issues Fetch
   tag: "gh-search-issue"
   api:
   	method: GET
@@ -112,8 +112,8 @@ export GH_TOKEN=some.token.for.github
 Assuming `ORDER_ID` is present in env
 
 ```yaml
-- name: Github Issues
-  description: Github Issues Fetch
+- name: GitHub Issues
+  description: GitHub Issues Fetch
   tag: "gh-search-issue"
   api:
   	method: POST
@@ -130,8 +130,8 @@ Read more about [eval](https://kener.ing/docs/monitors#eval)
 Below example will call https://api.github.com/repos/rajnandan1/kener/issues. If the status code is 200 then it will be UP else DOWN. It will also check if the response time is greater than 2000ms then it will be DEGRADED.
 
 ```yaml
-- name: Github Issues
-  description: Github Issues Fetch
+- name: GitHub Issues
+  description: GitHub Issues Fetch
   tag: "gh-search-issue"
   api:
   	method: GET
@@ -208,7 +208,7 @@ The below monitor will show DEGRADED if 3 or more degraded status in a day and D
 
 Make sure you have set up triggers in `server.yaml`. Read more about [alerts](/docs/alerting).
 
-The below example will trigger an alert if the monitor is DOWN for 10 consecutive times. It will also create an incident in Github and send alerts to Webhook, Discord and Slack. It will also trigger an alert if the monitor is DEGRADED for 5 consecutive times. It will not create an incident in Github and send alerts to Webhook, Discord and Slack.
+The below example will trigger an alert if the monitor is DOWN for 10 consecutive times. It will also create an incident in GitHub and send alerts to Webhook, Discord and Slack. It will also trigger an alert if the monitor is DEGRADED for 5 consecutive times. It will not create an incident in GitHub and send alerts to Webhook, Discord and Slack.
 
 ```yaml
 - name: Earth

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -115,7 +115,7 @@ To add a trigger to a monitor make sure you have created a trigger. You can read
 - Add details for either DOWN or DEGRADED.
     - Failure Threshold(Required): The number of consecutive failures before the trigger is activated.
     - Success Threshold(Required): The number of consecutive successes before the trigger is deactivated.
-    - Create Incident: Chose whether to create an incident or not when the trigger is activated. The incident will be created in Github. So make sure you have set up the Github token in the environment variables. The incident will be closed when the monitor is back to UP.
+    - Create Incident: Chose whether to create an incident or not when the trigger is activated. The incident will be created in GitHub. So make sure you have set up the GitHub token in the environment variables. The incident will be closed when the monitor is back to UP.
     - Severity (Required): The severity of the incident. It can be `Critcal` or `Warning`.
     - Custom Message (Required): Add your owner alert message.
     - Choose Triggers: Choose the triggers you want to activate the trigger. You can choose multiple triggers.

--- a/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
+++ b/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
@@ -29,4 +29,4 @@ Ready to get started? Head over to the [Quick Start](/docs/v4/getting-started/qu
 1. [GitHub Sponsors](https://github.com/sponsors/rajnandan1)
 2. [PayPal](https://www.paypal.com/paypalme/rajnandan1)
 3. [Buy Me a Coffee](https://www.buymeacoffee.com/rajnandan1)
-4. [Github Star](https://github.com/rajnandan1/kener)
+4. [GitHub Star](https://github.com/rajnandan1/kener)


### PR DESCRIPTION
Fix the typo: Github => GitHub (across the project)