### PR TITLE
docs: add Zeabur as a one-click deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ For the full quick start (including local Docker builds and dev mode), see the d
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/spSvic?referralCode=1Pn7vs&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/9LPJ55?referralCode=pan93412&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
 ## Features
 
 Kener combines public status page essentials with advanced admin workflows.

--- a/src/routes/(docs)/docs/content/v4/setup/deployment.md
+++ b/src/routes/(docs)/docs/content/v4/setup/deployment.md
@@ -5,6 +5,8 @@ description: Deploy Kener with Docker or Node.js and verify service health with 
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/spSvic?referralCode=1Pn7vs&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/9LPJ55?referralCode=pan93412&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
 Use this guide when moving from local testing to production. It includes `.env` examples for PostgreSQL, MySQL, subpath deployments, and both SMTP/Resend email providers.
 
 ## Quick start with Docker Compose {#quick-start-with-docker-compose}


### PR DESCRIPTION
## Summary

- Add Zeabur deploy button to README and deployment docs alongside the existing Railway button
- Zeabur is an AI-powered DevOps platform supporting managed infrastructure and bring-your-own-server setups

[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/9LPJ55?referralCode=pan93412)

## Test plan

- [x] Verify deploy button renders correctly in README
- [x] Verify deploy button renders correctly in deployment docs page
- [x] Confirm Zeabur template link works

<img width="1990" height="726" alt="CleanShot 2026-03-12 at 12 00 21@2x" src="https://github.com/user-attachments/assets/b7a16b7e-7b65-40f5-b834-0adbfde1ba7f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)