### PR TITLE
fix(api): Stringify existing objects before inserting into database

### DIFF
--- a/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
@@ -98,7 +98,7 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
       updateData.type_data = JSON.stringify(mergedTypeData);
     }
   } else {
-    updateData.type_data = existingMonitor.type_data;
+    updateData.type_data = JSON.stringify(existingMonitor.type_data);
   }
 
   if (body.monitor_settings_json !== undefined) {
@@ -119,7 +119,7 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
       updateData.monitor_settings_json = JSON.stringify(mergedSettings);
     }
   } else {
-    updateData.monitor_settings_json = existingMonitor.monitor_settings_json;
+    updateData.monitor_settings_json = JSON.stringify(existingMonitor.monitor_settings_json);
   }
 
   await db.updateMonitor(updateData as unknown as Parameters<typeof db.updateMonitor>[0]);


### PR DESCRIPTION
When trying to update a monitor without setting the `type_data` and `monitor_settings_json` failed because the existing data wasn't stringified again:

```
TypeError: update `monitors` set `tag` = 'test', `name` = 'TestING', `description` = '', `image` = '', `cron` = '* * * * *', `default_status` = 'UP', `status` = 'ACTIVE', `category_name` = 'Home', `monitor_type` = '', `type_data` = {}, `is_hidden` = 'NO', `monitor_settings_json` = {"uptime_formula_numerator":"up + maintenance","uptime_formula_denominator":"up + maintenance + down + degraded"}, `updated_at` = CURRENT_TIMESTAMP where `id` = 16 - SQLite3 can only bind numbers, strings, bigints, buffers, and null
    at Client_BetterSQLite3._query (/app/node_modules/knex/lib/dialects/better-sqlite3/index.js:44:38)
    at executeQuery (/app/node_modules/knex/lib/execution/internal/query-executioner.js:37:17)
    at Client_BetterSQLite3.query (/app/node_modules/knex/lib/client.js:154:12)
    at Runner.query (/app/node_modules/knex/lib/execution/runner.js:141:36)
    at ensureConnectionCallback (/app/node_modules/knex/lib/execution/internal/ensure-connection-callback.js:13:17)
    at Runner.ensureConnection (/app/node_modules/knex/lib/execution/runner.js:318:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Runner.run (/app/node_modules/knex/lib/execution/runner.js:30:19)
    at async MonitorsRepository.updateMonitor (file:///app/build/server/chunks/db-CZ12hRg2.js:374:12)
    at async PATCH (file:///app/build/server/chunks/_server.ts-TT9k2FMY.js:99:3)
```
