### PR TITLE
Fix Redis writes after replica failover by reconnecting on `READONLY`

### DIFF
--- a/src/lib/server/redisConnector.ts
+++ b/src/lib/server/redisConnector.ts
@@ -6,12 +6,24 @@ dotenv.config();
 let redisIOClient: IORedis | null = null;
 let redisClient: IORedis | null = null;
 
+const redisClientOptions: Redis.RedisOptions = {
+  maxRetriesPerRequest: null,
+  // Reconnect if Redis starts rejecting writes after a failover.
+  reconnectOnError: (error) => {
+    const message = error?.message ?? "";
+    if (message.includes("READONLY")) {
+      return 1;
+    }
+    return false;
+  },
+};
+
 export function redisIOConnection(): IORedis {
   if (!redisIOClient) {
     if (!process.env.REDIS_URL) {
       throw new Error("REDIS_URL is not defined in environment variables");
     }
-    redisIOClient = new IORedis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
+    redisIOClient = new IORedis(process.env.REDIS_URL, redisClientOptions);
   }
   return redisIOClient;
 }
@@ -21,7 +33,7 @@ export function redisConnection(): Redis {
     if (!process.env.REDIS_URL) {
       throw new Error("REDIS_URL is not defined in environment variables");
     }
-    redisClient = new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
+    redisClient = new Redis(process.env.REDIS_URL, redisClientOptions);
   }
   return redisClient;
 }

--- a/src/lib/server/redisConnector.ts
+++ b/src/lib/server/redisConnector.ts
@@ -6,13 +6,28 @@ dotenv.config();
 let redisIOClient: IORedis | null = null;
 let redisClient: IORedis | null = null;
 
+function shouldReconnectAfterRedisError(message: string): boolean {
+  const m = message.toUpperCase();
+  // Failover: writes hit a replica until the client points at the new primary.
+  if (m.includes("READONLY")) return true;
+  // RDB/AOF reload after pod restart — commands fail until loading finishes.
+  if (m.includes("LOADING")) return true;
+  // Replication: primary unavailable during StatefulSet rollout.
+  if (m.includes("MASTERDOWN")) return true;
+  return false;
+}
+
 const redisClientOptions: Redis.RedisOptions = {
   maxRetriesPerRequest: null,
-  // Reconnect if Redis starts rejecting writes after a failover.
-  reconnectOnError: (error) => {
+  // Detect dead peers during long K8s / network stalls (default ioredis keepAlive is off).
+  keepAlive: 30000,
+  // Allow long RDB reloads after a StatefulSet restart before giving up on "ready".
+  maxLoadingRetryTime: 120_000,
+  reconnectOnError: (error: Error) => {
     const message = error?.message ?? "";
-    if (message.includes("READONLY")) {
-      return 1;
+    if (shouldReconnectAfterRedisError(message)) {
+      // Reconnect and retry the failed command once the connection is healthy again.
+      return 2;
     }
     return false;
   },

--- a/src/lib/server/redisConnector.ts
+++ b/src/lib/server/redisConnector.ts
@@ -1,5 +1,6 @@
 import IORedis from "ioredis";
 import Redis from "ioredis";
+import type { RedisOptions } from "ioredis";
 import dotenv from "dotenv";
 dotenv.config();
 
@@ -17,7 +18,7 @@ function shouldReconnectAfterRedisError(message: string): boolean {
   return false;
 }
 
-const redisClientOptions: Redis.RedisOptions = {
+const redisClientOptions: RedisOptions = {
   maxRetriesPerRequest: null,
   // Detect dead peers during long K8s / network stalls (default ioredis keepAlive is off).
   keepAlive: 30000,


### PR DESCRIPTION
## Summary
`ioredis` clients from `redisIOConnection()` and `redisConnection()`. In replicated Redis setups, after primary failover the existing connection can still target a node that is now a replica. That node rejects writes with `READONLY`, and the singleton client did not recover until the process restarted.
## Changes
- Add shared `redisClientOptions` for both `IORedis` and `Redis` constructors.
- Keep `maxRetriesPerRequest: null` (required for BullMQ).
- Add `reconnectOnError` so errors whose message includes `READONLY` trigger a reconnect (`return 1`), allowing recovery when DNS or the service endpoint updates to the new primary.
## Motivation
Users with replication (e.g. multiple replicas / managed failover) reported writes failing after the master changed until Kener was restarted.
## How to test
1. Run Kener against Redis with replication or a provider that can fail over the primary.
2. Fail over the primary.
3. Exercise a write path (cache, BullMQ job, etc.).
4. Confirm writes work without restarting Kener.
## Notes
- `REDIS_URL` should still point at a **writer/primary** endpoint when the provider exposes separate reader and writer URLs. This change improves behavior when the same hostname resolves to a new primary or when recycling the connection is required after a role change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection reliability and resilience through enhanced error detection and automatic recovery capabilities. The service now gracefully handles common operational challenges including failovers, replication changes, and transient interruptions with intelligent reconnection logic. These enhancements reduce potential downtime, minimize service disruptions, and ensure more consistent system availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->