### PR TITLE
Implement manual incident subscribers notification

### DIFF
--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -17,6 +17,9 @@ import type {
 } from "../types/db.js";
 import GC from "../../global-constants.js";
 import { getUnixTime, differenceInSeconds } from "date-fns";
+import subscriberQueue from "../queues/subscriberQueue.js";
+import { GetAllSiteData } from "./controller.js";
+import mdToHTML from "../../marked.js";
 
 interface IncidentsDashboardInput {
   page: number;
@@ -35,6 +38,7 @@ export interface IncidentInput {
   incident_type?: string;
   incident_source?: string;
   is_global?: string;
+  notify_subscribers?: boolean;
 }
 
 interface IncidentUpdateInput {
@@ -293,6 +297,25 @@ export const ClosureCommentAlertMarkdown = (
   return comment;
 };
 
+export const NotifySubscribersForIncident = async (
+  incident_id: number,
+  title: string,
+  state: string,
+  update_text: string,
+): Promise<void> => {
+  const siteData = await GetAllSiteData();
+  const siteUrl = (siteData.siteURL || "") + "/";
+  await subscriberQueue.push({
+    title,
+    cta_url: siteUrl + "incidents/" + incident_id,
+    cta_text: "View Incident",
+    update_text: mdToHTML(update_text),
+    update_subject: `[#${incident_id}:${state}] ${title}`,
+    update_id: String(incident_id),
+    event_type: "incidents",
+  });
+};
+
 export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id: number }> => {
   //return error if no title or startDateTime
   if (!data.title || !data.start_date_time) {
@@ -327,6 +350,16 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
   //   message: `${incident.incident_type} Created`,
   //   ...incident,
   // });
+
+  if (data.notify_subscribers) {
+    await NotifySubscribersForIncident(
+      newIncident.id,
+      incident.title,
+      incident.state,
+      `Incident **${incident.title}** has been created.`,
+    );
+  }
+
   return {
     incident_id: newIncident.id,
   };
@@ -455,6 +488,7 @@ export const AddIncidentComment = async (
   comment: string,
   state: string,
   commented_at: number,
+  notify_subscribers: boolean = false,
 ): Promise<IncidentCommentRecord> => {
   let incidentExists = await db.getIncidentById(incident_id);
   if (!incidentExists) {
@@ -480,6 +514,10 @@ export const AddIncidentComment = async (
       }
     }
     await UpdateIncident(incident_id, incidentUpdate);
+  }
+
+  if (notify_subscribers) {
+    await NotifySubscribersForIncident(incident_id, incidentExists.title, state, comment);
   }
 
   return c;

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -305,17 +305,21 @@ export const NotifySubscribersForIncident = async (
   state: string,
   update_text: string,
 ): Promise<void> => {
-  const siteData = await GetAllSiteData();
-  const siteUrl = (siteData.siteURL || "") + "/";
-  await subscriberQueue.push({
-    title,
-    cta_url: siteUrl + "incidents/" + incident_id,
-    cta_text: "View Incident",
-    update_text: mdToHTML(update_text),
-    update_subject: `[#${incident_id}:${state}] ${title}`,
-    update_id: String(incident_id),
-    event_type: "incidents",
-  });
+  try {
+    const siteData = await GetAllSiteData();
+    const siteUrl = (siteData.siteURL || "") + "/";
+    await subscriberQueue.push({
+      title,
+      cta_url: siteUrl + "incidents/" + incident_id,
+      cta_text: "View Incident",
+      update_text: mdToHTML(update_text),
+      update_subject: `[#${incident_id}:${state}] ${title}`,
+      update_id: String(incident_id),
+      event_type: "incidents",
+    });
+  } catch (err) {
+    console.error(`Error sending subscriber notification for incident ${incident_id}:`, err);
+  }
 };
 
 export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id: number }> => {

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -516,7 +516,7 @@ export const AddIncidentComment = async (
     await notifySubscribersOfComment(incidentExists, c);
   }
 
-  if (notify_subscribers) {
+  if (notify_subscribers && incidentType !== GC.INCIDENT) {
     await NotifySubscribersForIncident(incident_id, incidentExists.title, state, comment);
   }
 

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -40,6 +40,7 @@ export interface IncidentInput {
   incident_type?: string;
   incident_source?: string;
   is_global?: string;
+  notify_subscribers?: boolean;
 }
 
 interface IncidentUpdateInput {
@@ -298,6 +299,25 @@ export const ClosureCommentAlertMarkdown = (
   return comment;
 };
 
+export const NotifySubscribersForIncident = async (
+  incident_id: number,
+  title: string,
+  state: string,
+  update_text: string,
+): Promise<void> => {
+  const siteData = await GetAllSiteData();
+  const siteUrl = (siteData.siteURL || "") + "/";
+  await subscriberQueue.push({
+    title,
+    cta_url: siteUrl + "incidents/" + incident_id,
+    cta_text: "View Incident",
+    update_text: mdToHTML(update_text),
+    update_subject: `[#${incident_id}:${state}] ${title}`,
+    update_id: String(incident_id),
+    event_type: "incidents",
+  });
+};
+
 export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id: number }> => {
   //return error if no title or startDateTime
   if (!data.title || !data.start_date_time) {
@@ -326,6 +346,15 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
   }
 
   let newIncident = await db.createIncident(incident);
+
+  if (data.notify_subscribers) {
+    await NotifySubscribersForIncident(
+      newIncident.id,
+      incident.title,
+      incident.state,
+      `Incident **${incident.title}** has been created.`,
+    );
+  }
 
   return {
     incident_id: newIncident.id,
@@ -458,6 +487,7 @@ export const AddIncidentComment = async (
   comment: string,
   state: string,
   commented_at: number,
+  notify_subscribers: boolean = false,
 ): Promise<IncidentCommentRecord> => {
   let incidentExists = await db.getIncidentById(incident_id);
   if (!incidentExists) {
@@ -484,6 +514,10 @@ export const AddIncidentComment = async (
     }
     await UpdateIncident(incident_id, incidentUpdate);
     await notifySubscribersOfComment(incidentExists, c);
+  }
+
+  if (notify_subscribers) {
+    await NotifySubscribersForIncident(incident_id, incidentExists.title, state, comment);
   }
 
   return c;

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -355,16 +355,6 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
 
   let newIncident = await db.createIncident(incident);
 
-  if (data.notify_subscribers) {
-    await NotifySubscribersForIncident(
-      newIncident.id,
-      incident.title,
-      incident.state,
-      `Incident **${incident.title}** has been created.`,
-      `subscriber-incidents-create-${newIncident.id}`,
-    );
-  }
-
   return {
     incident_id: newIncident.id,
   };
@@ -496,7 +486,7 @@ export const AddIncidentComment = async (
   comment: string,
   state: string,
   commented_at: number,
-  notify_subscribers: boolean = false,
+  notify_subscribers: boolean = true,
 ): Promise<IncidentCommentRecord> => {
   let incidentExists = await db.getIncidentById(incident_id);
   if (!incidentExists) {
@@ -522,7 +512,9 @@ export const AddIncidentComment = async (
       }
     }
     await UpdateIncident(incident_id, incidentUpdate);
-    await notifySubscribersOfComment(incidentExists, c);
+    if (notify_subscribers) {
+      await notifySubscribersOfComment(incidentExists, c);
+    }
   }
 
   if (notify_subscribers && incidentType !== GC.INCIDENT) {

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -304,19 +304,23 @@ export const NotifySubscribersForIncident = async (
   title: string,
   state: string,
   update_text: string,
+  dedup_id?: string,
 ): Promise<void> => {
   try {
     const siteData = await GetAllSiteData();
-    const siteUrl = (siteData.siteURL || "") + "/";
-    await subscriberQueue.push({
-      title,
-      cta_url: siteUrl + "incidents/" + incident_id,
-      cta_text: "View Incident",
-      update_text: mdToHTML(update_text),
-      update_subject: `[#${incident_id}:${state}] ${title}`,
-      update_id: String(incident_id),
-      event_type: "incidents",
-    });
+    const siteUrl = siteDataToVariables(siteData).site_url;
+    await subscriberQueue.push(
+      {
+        title,
+        cta_url: `${siteUrl}incidents/${incident_id}`,
+        cta_text: "View Incident",
+        update_text: mdToHTML(update_text),
+        update_subject: `[#${incident_id}:${state}] ${title}`,
+        update_id: String(incident_id),
+        event_type: "incidents",
+      },
+      dedup_id ? { deduplication: { id: dedup_id } } : undefined,
+    );
   } catch (err) {
     console.error(`Error sending subscriber notification for incident ${incident_id}:`, err);
   }
@@ -357,6 +361,7 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
       incident.title,
       incident.state,
       `Incident **${incident.title}** has been created.`,
+      `subscriber-incidents-create-${newIncident.id}`,
     );
   }
 
@@ -521,7 +526,7 @@ export const AddIncidentComment = async (
   }
 
   if (notify_subscribers && incidentType !== GC.INCIDENT) {
-    await NotifySubscribersForIncident(incident_id, incidentExists.title, state, comment);
+    await NotifySubscribersForIncident(incident_id, incidentExists.title, state, comment, `subscriber-incidents-comment-${c.id}`);
   }
 
   return c;

--- a/src/lib/server/notification/notification_utils.ts
+++ b/src/lib/server/notification/notification_utils.ts
@@ -80,7 +80,7 @@ export function maintenanceToVariables(
   return {
     title: `${subjectPrefix}: ${event.title}`,
     event_type: "maintenances",
-    cta_url: siteUrl + "maintenances/" + event.maintenance_id,
+    cta_url: siteUrl + "maintenances/" + event.maintenance_id + "?type=maintenance",
     cta_text: "View Maintenance Details",
     update_id: `maintenance_${event.id}_${updateIdSuffix}`,
     update_subject: `${subjectPrefix}: ${event.title}`,

--- a/src/lib/server/queues/alertingQueue.ts
+++ b/src/lib/server/queues/alertingQueue.ts
@@ -24,6 +24,7 @@ import {
   UpdateMonitorAlertV2Status,
 } from "../controllers/monitorAlertConfigController.js";
 import type { IncidentInput } from "../controllers/incidentController.js";
+import { NotifySubscribersForIncident } from "../controllers/incidentController.js";
 import { InsertNewAlert } from "../controllers/controller.js";
 import { GetMonitorAlertsV2 } from "../controllers/monitorAlertConfigController.js";
 import db from "../db/db.js";
@@ -36,9 +37,7 @@ import sendSlack from "$lib/server/notification/slack_notification.js";
 import sendDiscord from "$lib/server/notification/discord_notification.js";
 import serverResolver from "../resolver.js";
 
-import type { SiteDataForNotification, SubscriptionVariableMap } from "../notification/types.js";
-import mdToHTML from "../../marked.js";
-import subscriberQueue from "./subscriberQueue.js";
+import type { SiteDataForNotification } from "../notification/types.js";
 let alertingQueue: Queue | null = null;
 
 let worker: Worker | null = null;
@@ -65,7 +64,6 @@ async function createNewIncident(
   config: MonitorAlertConfigRecord,
   monitorName: string,
   monitorTag: string,
-  siteUrl: string = "",
 ): Promise<{ incident_id: number }> {
   let startDateTime = getUnixTime(new Date(alert.created_at));
   let incidentInput: IncidentInput = {
@@ -82,23 +80,13 @@ async function createNewIncident(
     config.alert_value,
   );
 
-  const updateVariables: SubscriptionVariableMap = {
-    title: incidentInput.title,
-    cta_url: siteUrl + "incidents/" + incidentCreated.incident_id,
-    cta_text: "View Incident",
-    update_text: mdToHTML(update),
-    update_subject: `[#${incidentCreated.incident_id}:${GC.TRIGGERED}] ${incidentInput.title}`,
-    update_id: String(incidentCreated.incident_id),
-    event_type: "incidents",
-  };
-  subscriberQueue.push(updateVariables);
+  await NotifySubscribersForIncident(
+    incidentCreated.incident_id,
+    incidentInput.title,
+    GC.TRIGGERED,
+    update,
+  );
   return incidentCreated;
-
-  /*
-	
-	
-	
-		subscriberQueue.push(updateVariables);*/
 }
 
 async function closeIncident(
@@ -106,7 +94,6 @@ async function closeIncident(
   config: MonitorAlertConfigRecord,
   monitorName: string,
   monitorTag: string,
-  siteUrl: string = "",
 ): Promise<void> {
   //check if incident is already resolved
   if (!alert.incident_id) {
@@ -124,16 +111,7 @@ async function closeIncident(
   let incident_id = alert.incident_id;
   const comment = ClosureCommentAlertMarkdown(alert, config, monitorName, monitorTag, GC.RESOLVED);
   const updatedAt = getUnixTime(new Date(alert.updated_at));
-  const updateMessage: SubscriptionVariableMap = {
-    title: incident.title,
-    cta_url: `${siteUrl}incidents/${incident_id}`,
-    cta_text: "View Incident",
-    update_text: mdToHTML(comment),
-    update_subject: `[#${incident.id}:${GC.RESOLVED}] ${incident.title}`,
-    update_id: String(incident_id),
-    event_type: "incidents",
-  };
-  subscriberQueue.push(updateMessage);
+  await NotifySubscribersForIncident(incident_id, incident.title, GC.RESOLVED, comment);
   await AddIncidentComment(incident_id, comment, GC.RESOLVED, updatedAt);
 }
 
@@ -255,7 +233,6 @@ const addWorker = () => {
               monitor_alerts_configured,
               monitor_name,
               monitor_tag,
-              templateSiteVars.site_url,
             );
             //update alert with incident number
             if (newIncidentNumber && newIncidentNumber.incident_id > 0) {
@@ -299,7 +276,6 @@ const addWorker = () => {
               monitor_alerts_configured,
               monitor_name,
               monitor_tag,
-              templateSiteVars.site_url,
             );
           }
 

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -275,7 +275,7 @@ export async function POST({ request, cookies }) {
         throw new Error("Incident not found");
       }
     } else if (action == "createIncident") {
-      resp = await CreateIncident(data);
+      resp = await CreateIncident({ ...data, notify_subscribers: !!data.notify_subscribers });
     } else if (action == "updateIncident") {
       resp = await UpdateIncident(data.id, data);
     } else if (action == "deleteIncident") {
@@ -287,7 +287,7 @@ export async function POST({ request, cookies }) {
     } else if (action == "getComments") {
       resp = await GetIncidentActiveComments(data.incident_id);
     } else if (action == "addComment") {
-      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at);
+      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at, !!data.notify_subscribers);
     } else if (action == "deleteComment") {
       resp = await UpdateCommentStatusByID(data.incident_id, data.comment_id, "INACTIVE");
     } else if (action == "updateComment") {

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -276,7 +276,7 @@ export async function POST({ request, cookies }) {
         throw new Error("Incident not found");
       }
     } else if (action == "createIncident") {
-      resp = await CreateIncident(data);
+      resp = await CreateIncident({ ...data, notify_subscribers: !!data.notify_subscribers });
     } else if (action == "updateIncident") {
       resp = await UpdateIncident(data.id, data);
     } else if (action == "deleteIncident") {
@@ -288,7 +288,7 @@ export async function POST({ request, cookies }) {
     } else if (action == "getComments") {
       resp = await GetIncidentActiveComments(data.incident_id);
     } else if (action == "addComment") {
-      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at);
+      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at, !!data.notify_subscribers);
     } else if (action == "deleteComment") {
       resp = await UpdateCommentStatusByID(data.incident_id, data.comment_id, "INACTIVE");
     } else if (action == "updateComment") {

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -276,7 +276,7 @@ export async function POST({ request, cookies }) {
         throw new Error("Incident not found");
       }
     } else if (action == "createIncident") {
-      resp = await CreateIncident({ ...data, notify_subscribers: !!data.notify_subscribers });
+      resp = await CreateIncident({ ...data, notify_subscribers: data.notify_subscribers === true });
     } else if (action == "updateIncident") {
       resp = await UpdateIncident(data.id, data);
     } else if (action == "deleteIncident") {

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -288,7 +288,7 @@ export async function POST({ request, cookies }) {
     } else if (action == "getComments") {
       resp = await GetIncidentActiveComments(data.incident_id);
     } else if (action == "addComment") {
-      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at, !!data.notify_subscribers);
+      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at, data.notify_subscribers ?? true);
     } else if (action == "deleteComment") {
       resp = await UpdateCommentStatusByID(data.incident_id, data.comment_id, "INACTIVE");
     } else if (action == "updateComment") {

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -87,6 +87,8 @@
   let commentState = $state<string>(GC.INVESTIGATING);
   let commentDateTime = $state<string>("");
   let savingComment = $state<boolean>(false);
+  let notifySubscribers = $state(true);
+  let notifySubscribersComment = $state(true);
 
   const states = [GC.INVESTIGATING, GC.IDENTIFIED, GC.MONITORING, GC.RESOLVED];
 
@@ -254,7 +256,8 @@
               status: "OPEN",
               state: GC.INVESTIGATING,
               incident_type: GC.INCIDENT,
-              is_global: incident.is_global
+              is_global: incident.is_global,
+              notify_subscribers: notifySubscribers
             }
           })
         });
@@ -485,6 +488,7 @@
     commentText = "";
     commentState = incident.state;
     commentDateTime = "";
+    notifySubscribersComment = true;
   }
 
   // Save comment (add or edit)
@@ -528,7 +532,8 @@
               incident_id: incident.id,
               comment: commentText,
               state: commentState,
-              commented_at: localDatetimeToTimestamp(commentDateTime)
+              commented_at: localDatetimeToTimestamp(commentDateTime),
+              notify_subscribers: notifySubscribersComment
             }
           })
         });
@@ -800,7 +805,9 @@
         <div class="flex items-center justify-between rounded-md border p-3">
           <div class="flex flex-col gap-1">
             <Label for="is-global">Global Incident</Label>
-            <p class="text-muted-foreground text-xs">When enabled, this incident will be visible on all status pages</p>
+            <p class="text-muted-foreground text-xs">
+              When enabled, this incident will be visible on all status pages.
+            </p>
           </div>
           <Switch
             id="is-global"
@@ -809,6 +816,17 @@
               incident.is_global = checked ? "YES" : "NO";
             }}
           />
+        </div>
+
+        <!-- Notify Subscribers -->
+        <div class="flex items-center justify-between rounded-md border p-3" class:opacity-50={!isNew}>
+          <div class="flex flex-col gap-1">
+            <Label for="notify-subscribers">{isNew ? "Notify Subscribers" : "Subscribers have been notified"}</Label>
+            <p class="text-muted-foreground text-xs">
+              When disabled, subscribers will not be notified (use for backdated or test incidents).
+            </p>
+          </div>
+          <Switch id="notify-subscribers" bind:checked={notifySubscribers} disabled={!isNew} />
         </div>
 
         <!-- First Comment (only for new) -->
@@ -1042,6 +1060,15 @@
                   <Label>Date/Time</Label>
                   <Input type="datetime-local" bind:value={commentDateTime} />
                 </div>
+              </div>
+              <div class="flex items-center justify-between rounded-md border p-3">
+                <div class="flex flex-col gap-1">
+                  <Label for="notify-subscribers-comment">Notify Subscribers</Label>
+                  <p class="text-muted-foreground text-xs">
+                    When disabled, subscribers will not be notified (use for backdated or test incidents).
+                  </p>
+                </div>
+                <Switch id="notify-subscribers-comment" bind:checked={notifySubscribersComment} />
               </div>
               <div class="flex justify-end gap-2">
                 <Button variant="outline" size="sm" onclick={cancelAddComment}>Cancel</Button>

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -259,8 +259,7 @@
               status: "OPEN",
               state: GC.INVESTIGATING,
               incident_type: GC.INCIDENT,
-              is_global: incident.is_global,
-              notify_subscribers: notifySubscribers
+              is_global: incident.is_global
             }
           })
         });
@@ -286,7 +285,7 @@
             });
           }
 
-          // Add first comment if provided
+          // Add first comment if provided — this is also the subscriber notification
           if (firstComment.trim()) {
             await fetch(clientResolver(resolve, "/manage/api"), {
               method: "POST",
@@ -297,7 +296,8 @@
                   incident_id: incidentId,
                   comment: firstComment,
                   state: GC.INVESTIGATING,
-                  commented_at: incident.start_date_time
+                  commented_at: incident.start_date_time,
+                  notify_subscribers: notifySubscribers
                 }
               })
             });
@@ -826,7 +826,7 @@
           <div class="flex flex-col gap-1">
             <Label for="notify-subscribers">{isNew ? "Notify Subscribers" : "Subscribers have been notified"}</Label>
             <p class="text-muted-foreground text-xs">
-              When disabled, subscribers will not be notified (use for backdated or test incidents).
+              When enabled, subscribers are notified <strong>if an initial update is provided</strong>. Disable for backdated or test incidents.
             </p>
           </div>
           <Switch id="notify-subscribers" bind:checked={notifySubscribers} disabled={!isNew} />

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -821,16 +821,18 @@
           />
         </div>
 
-        <!-- Notify Subscribers -->
-        <div class="flex items-center justify-between rounded-md border p-3" class:opacity-50={!isNew}>
+        <!-- Notify Subscribers (creation only — no persisted notification state to show on existing incidents) -->
+        {#if isNew}
+        <div class="flex items-center justify-between rounded-md border p-3">
           <div class="flex flex-col gap-1">
-            <Label for="notify-subscribers">{isNew ? "Notify Subscribers" : "Subscribers have been notified"}</Label>
+            <Label for="notify-subscribers">Notify Subscribers</Label>
             <p class="text-muted-foreground text-xs">
               When enabled, subscribers are notified <strong>if an initial update is provided</strong>. Disable for backdated or test incidents.
             </p>
           </div>
-          <Switch id="notify-subscribers" bind:checked={notifySubscribers} disabled={!isNew} />
+          <Switch id="notify-subscribers" bind:checked={notifySubscribers} />
         </div>
+        {/if}
 
         <!-- First Comment (only for new) -->
         {#if isNew}

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -287,7 +287,7 @@
 
           // Add first comment if provided — this is also the subscriber notification
           if (firstComment.trim()) {
-            await fetch(clientResolver(resolve, "/manage/api"), {
+            const commentResponse = await fetch(clientResolver(resolve, "/manage/api"), {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -301,6 +301,12 @@
                 }
               })
             });
+            const commentResult = await commentResponse.json();
+            if (commentResult.error) {
+              toast.warning(`Incident created but initial update failed: ${commentResult.error}`);
+              goto(clientResolver(resolve, `/manage/app/incidents/${incidentId}`));
+              return;
+            }
           }
           toast.success("Incident created successfully");
           goto(clientResolver(resolve, `/manage/app/incidents/${incidentId}`));

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -52,13 +52,15 @@
     status: string;
     state: string;
     is_global: string;
+    incident_type: string;
   }>({
     id: 0,
     title: "",
     start_date_time: Math.floor(Date.now() / 1000),
     status: "OPEN",
     state: GC.INVESTIGATING,
-    is_global: "YES"
+    is_global: "YES",
+    incident_type: GC.INCIDENT
   });
 
   // For datetime inputs (convert to/from local datetime string)
@@ -153,7 +155,8 @@
           start_date_time: result.start_date_time,
           status: result.status,
           state: result.state,
-          is_global: result.is_global || "YES"
+          is_global: result.is_global || "YES",
+          incident_type: result.incident_type || GC.INCIDENT
         };
         // Fetch comments and monitors
         await Promise.all([fetchComments(), fetchIncidentMonitors()]);
@@ -1061,6 +1064,7 @@
                   <Input type="datetime-local" bind:value={commentDateTime} />
                 </div>
               </div>
+              {#if incident.incident_type !== GC.INCIDENT}
               <div class="flex items-center justify-between rounded-md border p-3">
                 <div class="flex flex-col gap-1">
                   <Label for="notify-subscribers-comment">Notify Subscribers</Label>
@@ -1070,6 +1074,7 @@
                 </div>
                 <Switch id="notify-subscribers-comment" bind:checked={notifySubscribersComment} />
               </div>
+              {/if}
               <div class="flex justify-end gap-2">
                 <Button variant="outline" size="sm" onclick={cancelAddComment}>Cancel</Button>
                 <Button size="sm" onclick={saveComment} disabled={!commentText.trim() || savingComment}>


### PR DESCRIPTION
Hi, I do not know if you actually want this change, but I had to make it, so I am sharing in case you want it.

## Summary

Adds subscriber notifications for manually created incidents, and fixes a broken "View Maintenance Details" link in maintenance notification emails.

## Changes

### `862c623c` feat: implement manual incident subscribers notifications

A "Notify Subscribers" toggle is added to the incident UI, visible and enabled by default on new incidents, shown as a disabled "Subscribers have been notified" on existing ones.

<img width="659" height="498" alt="image" src="https://github.com/user-attachments/assets/4bed7be1-eba7-48d5-a4f0-49f5104158e3" />

<img width="654" height="529" alt="image" src="https://github.com/user-attachments/assets/c4bfb93e-76fd-4ae7-8d26-1cbfc8a9f0ec" />

- New `NotifySubscribersForIncident(incident_id, title, state, update_text)` in `incidentController.ts`
- Incident admin UI: "Notify Subscribers" toggle on new incidents, separate toggle for comments
- `notify_subscribers` field added to `IncidentInput` and wired through the API handler

### `f1302b68` fix: make maintenance email link point to public maintenance page

The "View Maintenance Details" CTA in maintenance notification emails was linking to `/maintenances/{maintenance_id}`, causing a 404 since event IDs differ from maintenance IDs. Appending `?type=maintenance` resolves this.

## How to test

1. Create a new incident with the "Notify Subscribers" toggle enabled → subscribers should receive an email notification
2. On an existing incident, verify the toggle reads "Subscribers have been notified" and is disabled
3. Add a comment to an incident with "Notify Subscribers" enabled → subscribers should receive the comment notification
4. Trigger a maintenance notification email → click "View Maintenance Details" → should land on the correct public maintenance page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Notify Subscribers” toggles for creating incidents and for adding new updates/comments, with defaults enabled and cancel/reset behavior for existing incident additions.
  * Subscriber notifications are now conditionally dispatched based on incident type, with support for deduplicated comment notifications.
* **Bug Fixes**
  * Maintenance notification call-to-action links now preserve the intended notification context by appending the correct query parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->