### PR TITLE
Add optional groups for monitors within a status page

### DIFF
--- a/migrations/20260528140000_add_group_name_page_monitors.ts
+++ b/migrations/20260528140000_add_group_name_page_monitors.ts
@@ -1,0 +1,19 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn("pages_monitors", "group_name");
+  if (!hasColumn) {
+    await knex.schema.alterTable("pages_monitors", (table) => {
+      table.string("group_name").nullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn("pages_monitors", "group_name");
+  if (hasColumn) {
+    await knex.schema.alterTable("pages_monitors", (table) => {
+      table.dropColumn("group_name");
+    });
+  }
+}

--- a/src/lib/allPerms.ts
+++ b/src/lib/allPerms.ts
@@ -14,7 +14,7 @@
  * maintenances.write → createMaintenance, updateMaintenance, deleteMaintenance, createMaintenanceEvent, updateMaintenanceEvent, deleteMaintenanceEvent, addMonitorToMaintenance, removeMonitorFromMaintenance, updateMaintenanceMonitorImpact
  *
  * pages.read         → getPages
- * pages.write        → createPage, updatePage, deletePage, addMonitorToPage, removeMonitorFromPage, reorderPageMonitors
+ * pages.write        → createPage, updatePage, deletePage, addMonitorToPage, removeMonitorFromPage, reorderPageMonitors, updatePageMonitorGroup
  *
  * triggers.read      → getTriggers
  * triggers.write     → createUpdateTrigger, updateMonitorTriggers, deleteTrigger, testTrigger
@@ -162,6 +162,7 @@ export const ACTION_PERMISSION_MAP: Record<string, string | null> = {
   addMonitorToPage: "pages.write",
   removeMonitorFromPage: "pages.write",
   reorderPageMonitors: "pages.write",
+  updatePageMonitorGroup: "pages.write",
 
   // Triggers
   getTriggers: "triggers.read",

--- a/src/lib/server/controllers/dashboardController.ts
+++ b/src/lib/server/controllers/dashboardController.ts
@@ -155,17 +155,52 @@ export interface PageNavItem {
   page_logo: string | null;
 }
 
+export interface PageMonitorGroup {
+  // null means "ungrouped" — renders without a header (matches pre-groups behaviour)
+  name: string | null;
+  tags: string[];
+}
+
 export interface PageDashboardData {
   pageStatus: { statusSummary: string; statusClass: string };
   ongoingIncidents: IncidentForMonitorListWithComments[];
   ongoingMaintenances: MaintenanceEventsMonitorList[];
   upcomingMaintenances: MaintenanceEventsMonitorList[];
   monitorTags: string[];
+  // Ordered: ungrouped (if any) first, then groups in their first-appearance
+  // order. Pages with no group_name on any monitor yield a single group with
+  // name = null, preserving the existing render shape.
+  monitorGroups: PageMonitorGroup[];
   monitorGroupMembersByTag: Record<string, string[]>;
   pageDetails: PageRecordTyped;
   socialPagePreviewImage?: string;
   metaPageTitle?: string;
   metaPageDescription?: string;
+}
+
+function buildMonitorGroups(
+  pageMonitors: Array<{ monitor_tag: string; group_name: string | null }>,
+): PageMonitorGroup[] {
+  const ungrouped: string[] = [];
+  const groupOrder: string[] = [];
+  const byGroup = new Map<string, string[]>();
+  for (const pm of pageMonitors) {
+    if (!pm.group_name) {
+      ungrouped.push(pm.monitor_tag);
+      continue;
+    }
+    if (!byGroup.has(pm.group_name)) {
+      groupOrder.push(pm.group_name);
+      byGroup.set(pm.group_name, []);
+    }
+    byGroup.get(pm.group_name)!.push(pm.monitor_tag);
+  }
+  const result: PageMonitorGroup[] = [];
+  if (ungrouped.length > 0) result.push({ name: null, tags: ungrouped });
+  for (const name of groupOrder) {
+    result.push({ name, tags: byGroup.get(name)! });
+  }
+  return result;
 }
 
 const BuildPageStatus = (latestData: Array<{ status?: string | null; latency?: number | null }>, nowTs: number) => {
@@ -317,6 +352,7 @@ export const GetPageDashboardData = async (
 
   const { page: pageDetails, monitors: pageMonitors } = pageData;
   const monitorTags = pageMonitors.map((pm) => pm.monitor_tag);
+  const monitorGroups = buildMonitorGroups(pageMonitors);
 
   // Parse page settings with defaults
   let settings: PageSettingsType = defaultPageSettings;
@@ -369,6 +405,7 @@ export const GetPageDashboardData = async (
       ongoingMaintenances: [],
       upcomingMaintenances: [],
       monitorTags,
+      monitorGroups,
       monitorGroupMembersByTag: {},
       pageDetails: pageDetailsTyped,
       socialPagePreviewImage,
@@ -414,6 +451,7 @@ export const GetPageDashboardData = async (
     ongoingMaintenances,
     upcomingMaintenances,
     monitorTags,
+    monitorGroups,
     monitorGroupMembersByTag,
     pageDetails: pageDetailsTyped,
     socialPagePreviewImage,

--- a/src/lib/server/controllers/pagesController.ts
+++ b/src/lib/server/controllers/pagesController.ts
@@ -136,6 +136,7 @@ export async function AddMonitorToPage(
   monitor_tag: string,
   monitor_settings_json?: string | null,
   position?: number,
+  group_name?: string | null,
 ): Promise<void> {
   // Check if page exists
   const page = await db.getPageById(page_id);
@@ -161,7 +162,29 @@ export async function AddMonitorToPage(
     monitor_tag,
     monitor_settings_json: monitor_settings_json || null,
     position: finalPosition,
+    group_name: group_name ?? null,
   });
+}
+
+/**
+ * Set or clear the group of a single monitor on a page. group_name=null
+ * moves it back to "ungrouped" — same as removing the group label.
+ */
+export async function UpdatePageMonitorGroup(
+  page_id: number,
+  monitor_tag: string,
+  group_name: string | null,
+): Promise<void> {
+  const page = await db.getPageById(page_id);
+  if (!page) {
+    throw new Error(`Page with id ${page_id} not found`);
+  }
+  const exists = await db.monitorExistsOnPage(page_id, monitor_tag);
+  if (!exists) {
+    throw new Error(`Monitor "${monitor_tag}" not found on this page`);
+  }
+  const normalized = group_name === null ? null : group_name.trim() || null;
+  await db.updatePageMonitorGroup(page_id, monitor_tag, normalized);
 }
 
 /**

--- a/src/lib/server/controllers/pagesController.ts
+++ b/src/lib/server/controllers/pagesController.ts
@@ -1,5 +1,33 @@
 import db from "../db/db.js";
 import type { PageRecord, PageRecordInsert, PageMonitorRecord, PageMonitorRecordInsert } from "../types/db.js";
+import type { PageMonitorInput } from "../../types/api.js";
+
+// ============ Page Monitor Input ============
+
+/**
+ * Normalize the `monitors` field on Create/Update Page requests.
+ * Accepts either a plain string (the tag, ungrouped) or an object with
+ * `{ tag, group?, position? }`. Throws on malformed entries; returns
+ * objects with explicit position (index fallback) and group (null fallback).
+ */
+export function normalizePageMonitorInputs(
+  input: PageMonitorInput[],
+): Array<{ tag: string; group: string | null; position: number }> {
+  return input.map((item, idx) => {
+    if (typeof item === "string") {
+      return { tag: item, group: null, position: idx };
+    }
+    if (!item || typeof item !== "object" || typeof item.tag !== "string" || item.tag.trim().length === 0) {
+      throw new Error("Each monitor must be a string tag or an object with a non-empty `tag` field");
+    }
+    const group = item.group ?? null;
+    if (group !== null && typeof group !== "string") {
+      throw new Error("Monitor `group` must be a string or null");
+    }
+    const position = typeof item.position === "number" ? item.position : idx;
+    return { tag: item.tag.trim(), group: group === null ? null : group.trim() || null, position };
+  });
+}
 
 // ============ Page CRUD Operations ============
 

--- a/src/lib/server/db/dbimpl.ts
+++ b/src/lib/server/db/dbimpl.ts
@@ -228,6 +228,7 @@ class DbImpl {
   getPageMonitorsExcludeHidden!: PagesRepository["getPageMonitorsExcludeHidden"];
   getPagesByMonitorTag!: PagesRepository["getPagesByMonitorTag"];
   updatePageMonitorSettings!: PagesRepository["updatePageMonitorSettings"];
+  updatePageMonitorGroup!: PagesRepository["updatePageMonitorGroup"];
   monitorExistsOnPage!: PagesRepository["monitorExistsOnPage"];
   deletePageMonitorsByTag!: PagesRepository["deletePageMonitorsByTag"];
   deletePageMonitorsByPageId!: PagesRepository["deletePageMonitorsByPageId"];
@@ -596,6 +597,7 @@ class DbImpl {
     this.getPageMonitorsExcludeHidden = this.pages.getPageMonitorsExcludeHidden.bind(this.pages);
     this.getPagesByMonitorTag = this.pages.getPagesByMonitorTag.bind(this.pages);
     this.updatePageMonitorSettings = this.pages.updatePageMonitorSettings.bind(this.pages);
+    this.updatePageMonitorGroup = this.pages.updatePageMonitorGroup.bind(this.pages);
     this.monitorExistsOnPage = this.pages.monitorExistsOnPage.bind(this.pages);
     this.deletePageMonitorsByTag = this.pages.deletePageMonitorsByTag.bind(this.pages);
     this.deletePageMonitorsByPageId = this.pages.deletePageMonitorsByPageId.bind(this.pages);

--- a/src/lib/server/db/repositories/pages.ts
+++ b/src/lib/server/db/repositories/pages.ts
@@ -105,6 +105,13 @@ export class PagesRepository extends BaseRepository {
     });
   }
 
+  async updatePageMonitorGroup(page_id: number, monitor_tag: string, group_name: string | null): Promise<number> {
+    return await this.knex("pages_monitors").where({ page_id, monitor_tag }).update({
+      group_name,
+      updated_at: this.knex.fn.now(),
+    });
+  }
+
   async monitorExistsOnPage(page_id: number, monitor_tag: string): Promise<boolean> {
     const result = await this.knex("pages_monitors").where({ page_id, monitor_tag }).first();
     return !!result;

--- a/src/lib/server/db/repositories/pages.ts
+++ b/src/lib/server/db/repositories/pages.ts
@@ -66,6 +66,7 @@ export class PagesRepository extends BaseRepository {
       monitor_tag: data.monitor_tag,
       monitor_settings_json: data.monitor_settings_json,
       position: data.position ?? 0,
+      group_name: data.group_name ?? null,
       created_at: this.knex.fn.now(),
       updated_at: this.knex.fn.now(),
     });

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -492,6 +492,7 @@ export interface PageMonitorRecord {
   monitor_tag: string;
   monitor_settings_json: string | null;
   position: number;
+  group_name: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -501,6 +502,7 @@ export interface PageMonitorRecordInsert {
   monitor_tag: string;
   monitor_settings_json?: string | null;
   position?: number;
+  group_name?: string | null;
 }
 
 export interface PageMonitorRecordTyped {
@@ -508,6 +510,7 @@ export interface PageMonitorRecordTyped {
   monitor_tag: string;
   monitor_settings: Record<string, unknown> | null;
   position: number;
+  group_name: string | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -443,7 +443,13 @@ export interface PageSettings {
 
 export interface PageMonitorResponse {
   monitor_tag: string;
+  position?: number;
+  group?: string | null;
 }
+
+// Items for the request `monitors` field. Plain strings (legacy) stay
+// supported; objects let callers specify a group and/or position.
+export type PageMonitorInput = string | { tag: string; group?: string | null; position?: number };
 
 export interface PageResponse {
   id: number;
@@ -473,7 +479,7 @@ export interface CreatePageRequest {
   page_subheader?: string | null;
   page_logo?: string | null;
   page_settings?: Partial<PageSettings>;
-  monitors?: string[];
+  monitors?: PageMonitorInput[];
 }
 
 export interface CreatePageResponse {
@@ -487,7 +493,7 @@ export interface UpdatePageRequest {
   page_subheader?: string | null;
   page_logo?: string | null;
   page_settings?: Partial<PageSettings>;
-  monitors?: string[];
+  monitors?: PageMonitorInput[];
 }
 
 export interface UpdatePageResponse {

--- a/src/routes/(api)/api/v4/pages/+server.ts
+++ b/src/routes/(api)/api/v4/pages/+server.ts
@@ -7,8 +7,10 @@ import type {
   CreatePageRequest,
   CreatePageResponse,
   BadRequestResponse,
+  PageMonitorInput,
 } from "$lib/types/api";
 import type { PageRecord } from "$lib/server/types/db";
+import { normalizePageMonitorInputs } from "$lib/server/controllers/pagesController";
 
 function formatDateToISO(date: Date | string): string {
   if (date instanceof Date) {
@@ -105,7 +107,11 @@ async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
     page_subheader: page.page_subheader,
     page_logo: page.page_logo,
     page_settings: pageSettings,
-    monitors: pageMonitors.map((pm) => ({ monitor_tag: pm.monitor_tag, position: pm.position })),
+    monitors: pageMonitors.map((pm) => ({
+      monitor_tag: pm.monitor_tag,
+      position: pm.position,
+      group: pm.group_name,
+    })),
     created_at: formatDateToISO(page.created_at),
     updated_at: formatDateToISO(page.updated_at),
   };
@@ -188,15 +194,23 @@ export const POST: RequestHandler = async ({ request }) => {
     return json(errorResponse, { status: 400 });
   }
 
-  // Validate monitors if provided
+  // Normalize monitors (accepts string[] or Array<{tag, group?, position?}>)
+  let normalizedMonitors: ReturnType<typeof normalizePageMonitorInputs> = [];
   if (body.monitors && Array.isArray(body.monitors)) {
-    for (const monitorTag of body.monitors) {
-      const monitor = await db.getMonitorByTag(monitorTag);
+    try {
+      normalizedMonitors = normalizePageMonitorInputs(body.monitors as PageMonitorInput[]);
+    } catch (e) {
+      return json({ error: { code: "BAD_REQUEST", message: (e as Error).message } } satisfies BadRequestResponse, {
+        status: 400,
+      });
+    }
+    for (const m of normalizedMonitors) {
+      const monitor = await db.getMonitorByTag(m.tag);
       if (!monitor) {
         const errorResponse: BadRequestResponse = {
           error: {
             code: "BAD_REQUEST",
-            message: `Monitor with tag '${monitorTag}' does not exist`,
+            message: `Monitor with tag '${m.tag}' does not exist`,
           },
         };
         return json(errorResponse, { status: 400 });
@@ -220,15 +234,14 @@ export const POST: RequestHandler = async ({ request }) => {
   const createdPage = await db.createPage(pageData);
 
   // Add monitors to the page
-  if (body.monitors && Array.isArray(body.monitors)) {
-    for (let i = 0; i < body.monitors.length; i++) {
-      await db.addMonitorToPage({
-        page_id: createdPage.id,
-        monitor_tag: body.monitors[i],
-        monitor_settings_json: null,
-        position: i,
-      });
-    }
+  for (const m of normalizedMonitors) {
+    await db.addMonitorToPage({
+      page_id: createdPage.id,
+      monitor_tag: m.tag,
+      monitor_settings_json: null,
+      position: m.position,
+      group_name: m.group,
+    });
   }
 
   const response: CreatePageResponse = {

--- a/src/routes/(api)/api/v4/pages/[page_path]/+server.ts
+++ b/src/routes/(api)/api/v4/pages/[page_path]/+server.ts
@@ -9,8 +9,10 @@ import type {
   DeletePageResponse,
   BadRequestResponse,
   NotFoundResponse,
+  PageMonitorInput,
 } from "$lib/types/api";
 import type { PageRecord } from "$lib/server/types/db";
+import { normalizePageMonitorInputs } from "$lib/server/controllers/pagesController";
 
 function formatDateToISO(date: Date | string): string {
   if (date instanceof Date) {
@@ -107,7 +109,11 @@ async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
     page_subheader: page.page_subheader,
     page_logo: page.page_logo,
     page_settings: pageSettings,
-    monitors: pageMonitors.map((pm) => ({ monitor_tag: pm.monitor_tag, position: pm.position })),
+    monitors: pageMonitors.map((pm) => ({
+      monitor_tag: pm.monitor_tag,
+      position: pm.position,
+      group: pm.group_name,
+    })),
     created_at: formatDateToISO(page.created_at),
     updated_at: formatDateToISO(page.updated_at),
   };
@@ -223,15 +229,23 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
     }
   }
 
-  // Validate monitors if provided
+  // Normalize monitors (accepts string[] or Array<{tag, group?, position?}>)
+  let normalizedMonitors: ReturnType<typeof normalizePageMonitorInputs> | null = null;
   if (body.monitors !== undefined && Array.isArray(body.monitors)) {
-    for (const monitorTag of body.monitors) {
-      const monitor = await db.getMonitorByTag(monitorTag);
+    try {
+      normalizedMonitors = normalizePageMonitorInputs(body.monitors as PageMonitorInput[]);
+    } catch (e) {
+      return json({ error: { code: "BAD_REQUEST", message: (e as Error).message } } satisfies BadRequestResponse, {
+        status: 400,
+      });
+    }
+    for (const m of normalizedMonitors) {
+      const monitor = await db.getMonitorByTag(m.tag);
       if (!monitor) {
         const errorResponse: BadRequestResponse = {
           error: {
             code: "BAD_REQUEST",
-            message: `Monitor with tag '${monitorTag}' does not exist`,
+            message: `Monitor with tag '${m.tag}' does not exist`,
           },
         };
         return json(errorResponse, { status: 400 });
@@ -286,17 +300,18 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
   }
 
   // Handle monitors update - replace all monitors
-  if (body.monitors !== undefined && Array.isArray(body.monitors)) {
+  if (normalizedMonitors !== null) {
     // Delete all existing page monitors
     await db.deletePageMonitorsByPageId(page.id);
 
-    // Add new monitors
-    for (let i = 0; i < body.monitors.length; i++) {
+    // Add new monitors (preserving any group_name supplied)
+    for (const m of normalizedMonitors) {
       await db.addMonitorToPage({
         page_id: page.id,
-        monitor_tag: body.monitors[i],
+        monitor_tag: m.tag,
         monitor_settings_json: null,
-        position: i,
+        position: m.position,
+        group_name: m.group,
       });
     }
   }

--- a/src/routes/(kener)/+page.svelte
+++ b/src/routes/(kener)/+page.svelte
@@ -198,29 +198,39 @@
         {/each}
       </div>
     {/if}
-    <div class="overflow-hidden rounded-3xl border">
-      <div class={`grid grid-cols-1 ${getGridContainerClass(viewType)}`}>
-        {#each data.monitorTags as tag, i (tag)}
-          <div
-            class="{viewType === 'compact-grid' || viewType === 'default-grid'
-              ? `${getGridItemSpanClass(i, data.monitorTags.length, viewType)} bg-background`
-              : i < data.monitorTags.length - 1
-                ? 'border-b'
-                : ''} px-2 py-2 sm:px-0"
-          >
-            <MonitorBar
-              {tag}
-              prefetchedData={monitorBarDataByTag[tag]}
-              prefetchedError={monitorBarErrorByTag[tag]}
-              days={barCount}
-              {endOfDayTodayAtTz}
-              groupChildTags={data.monitorGroupMembersByTag?.[tag] || []}
-              compact={isCompact}
-              grid={viewType === "compact-grid" || viewType === "default-grid"}
-            />
+    <!-- Render monitors grouped by group_name. Pages with no group_name yield
+         a single group with name=null, which renders without a header — i.e.
+         backward-compatible with the pre-groups layout. -->
+    {#each data.monitorGroups as group, gIdx (group.name ?? `__ungrouped_${gIdx}`)}
+      <div class="flex flex-col gap-2">
+        {#if group.name}
+          <h2 class="px-3 text-lg font-semibold sm:px-4">{group.name}</h2>
+        {/if}
+        <div class="overflow-hidden rounded-3xl border">
+          <div class={`grid grid-cols-1 ${getGridContainerClass(viewType)}`}>
+            {#each group.tags as tag, i (tag)}
+              <div
+                class="{viewType === 'compact-grid' || viewType === 'default-grid'
+                  ? `${getGridItemSpanClass(i, group.tags.length, viewType)} bg-background`
+                  : i < group.tags.length - 1
+                    ? 'border-b'
+                    : ''} px-2 py-2 sm:px-0"
+              >
+                <MonitorBar
+                  {tag}
+                  prefetchedData={monitorBarDataByTag[tag]}
+                  prefetchedError={monitorBarErrorByTag[tag]}
+                  days={barCount}
+                  {endOfDayTodayAtTz}
+                  groupChildTags={data.monitorGroupMembersByTag?.[tag] || []}
+                  compact={isCompact}
+                  grid={viewType === "compact-grid" || viewType === "default-grid"}
+                />
+              </div>
+            {/each}
           </div>
-        {/each}
+        </div>
       </div>
-    </div>
+    {/each}
   {/if}
 </div>

--- a/src/routes/(kener)/[page_path]/+page.svelte
+++ b/src/routes/(kener)/[page_path]/+page.svelte
@@ -198,29 +198,39 @@
         {/each}
       </div>
     {/if}
-    <div class="overflow-hidden rounded-3xl border">
-      <div class={`grid grid-cols-1 ${getGridContainerClass(viewType)}`}>
-        {#each data.monitorTags as tag, i (tag)}
-          <div
-            class="{viewType === 'compact-grid' || viewType === 'default-grid'
-              ? `${getGridItemSpanClass(i, data.monitorTags.length, viewType)} bg-background`
-              : i < data.monitorTags.length - 1
-                ? 'border-b'
-                : ''} px-2 py-2 sm:px-0"
-          >
-            <MonitorBar
-              {tag}
-              prefetchedData={monitorBarDataByTag[tag]}
-              prefetchedError={monitorBarErrorByTag[tag]}
-              days={barCount}
-              {endOfDayTodayAtTz}
-              groupChildTags={data.monitorGroupMembersByTag?.[tag] || []}
-              compact={isCompact}
-              grid={viewType === "compact-grid" || viewType === "default-grid"}
-            />
+    <!-- Render monitors grouped by group_name. Pages with no group_name yield
+         a single group with name=null, which renders without a header — i.e.
+         backward-compatible with the pre-groups layout. -->
+    {#each data.monitorGroups as group, gIdx (group.name ?? `__ungrouped_${gIdx}`)}
+      <div class="flex flex-col gap-2">
+        {#if group.name}
+          <h2 class="px-3 text-lg font-semibold sm:px-4">{group.name}</h2>
+        {/if}
+        <div class="overflow-hidden rounded-3xl border">
+          <div class={`grid grid-cols-1 ${getGridContainerClass(viewType)}`}>
+            {#each group.tags as tag, i (tag)}
+              <div
+                class="{viewType === 'compact-grid' || viewType === 'default-grid'
+                  ? `${getGridItemSpanClass(i, group.tags.length, viewType)} bg-background`
+                  : i < group.tags.length - 1
+                    ? 'border-b'
+                    : ''} px-2 py-2 sm:px-0"
+              >
+                <MonitorBar
+                  {tag}
+                  prefetchedData={monitorBarDataByTag[tag]}
+                  prefetchedError={monitorBarErrorByTag[tag]}
+                  days={barCount}
+                  {endOfDayTodayAtTz}
+                  groupChildTags={data.monitorGroupMembersByTag?.[tag] || []}
+                  compact={isCompact}
+                  grid={viewType === "compact-grid" || viewType === "default-grid"}
+                />
+              </div>
+            {/each}
           </div>
-        {/each}
+        </div>
       </div>
-    </div>
+    {/each}
   {/if}
 </div>

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -63,6 +63,7 @@ import {
   RemoveMonitorFromPage,
   GetPageMonitors,
   ReorderPageMonitors,
+  UpdatePageMonitorGroup,
 } from "$lib/server/controllers/pagesController.js";
 import {
   CreateMaintenance,
@@ -404,13 +405,16 @@ export async function POST({ request, cookies }) {
       await DeletePage(data.id);
       resp = { success: true };
     } else if (action == "addMonitorToPage") {
-      await AddMonitorToPage(data.page_id, data.monitor_tag);
+      await AddMonitorToPage(data.page_id, data.monitor_tag, undefined, undefined, data.group_name ?? null);
       resp = { success: true };
     } else if (action == "removeMonitorFromPage") {
       await RemoveMonitorFromPage(data.page_id, data.monitor_tag);
       resp = { success: true };
     } else if (action == "reorderPageMonitors") {
       await ReorderPageMonitors(data.page_id, data.monitor_tags);
+      resp = { success: true };
+    } else if (action == "updatePageMonitorGroup") {
+      await UpdatePageMonitorGroup(data.page_id, data.monitor_tag, data.group_name ?? null);
       resp = { success: true };
     }
     // ============ Maintenance Actions ============

--- a/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
@@ -17,6 +17,7 @@
   import XIcon from "@lucide/svelte/icons/x";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
+  import GripVerticalIcon from "@lucide/svelte/icons/grip-vertical";
   import UploadIcon from "@lucide/svelte/icons/upload";
   import ImageIcon from "@lucide/svelte/icons/image";
   import TrashIcon from "@lucide/svelte/icons/trash";
@@ -40,7 +41,12 @@
   };
 
   interface PageWithMonitors extends PageRecord {
-    monitors?: { monitor_tag: string }[];
+    monitors?: { monitor_tag: string; group_name?: string | null }[];
+  }
+
+  interface SelectedMonitor {
+    monitor_tag: string;
+    group_name: string | null;
   }
 
   // Get page ID from URL params
@@ -69,10 +75,44 @@
 
   // Monitor selection
   let selectedMonitorTag = $state("");
-  let selectedMonitors = $state<string[]>([]);
+  let selectedMonitors = $state<SelectedMonitor[]>([]);
+  // Group sections created in the UI before any monitor has been dropped in;
+  // they vanish on reload if still empty (nothing to persist).
+  let pendingGroups = $state<string[]>([]);
   let addingMonitor = $state(false);
   let removingMonitor = $state<string | null>(null);
   let reordering = $state(false);
+  let addingGroup = $state(false);
+  let newGroupName = $state("");
+  let draggedTag = $state<string | null>(null);
+  // null target = ungrouped section, undefined = no active drag-over
+  let dropTargetGroup = $state<string | null | undefined>(undefined);
+
+  // Derived: monitors grouped into sections. Ungrouped first, then named groups
+  // in first-appearance order, then any pending (empty) groups awaiting drops.
+  const groupSections = $derived.by(() => {
+    const ungrouped: SelectedMonitor[] = [];
+    const groupOrder: string[] = [];
+    const byGroup = new Map<string, SelectedMonitor[]>();
+    for (const m of selectedMonitors) {
+      if (!m.group_name) {
+        ungrouped.push(m);
+        continue;
+      }
+      if (!byGroup.has(m.group_name)) {
+        groupOrder.push(m.group_name);
+        byGroup.set(m.group_name, []);
+      }
+      byGroup.get(m.group_name)!.push(m);
+    }
+    const result: Array<{ name: string | null; monitors: SelectedMonitor[] }> = [];
+    result.push({ name: null, monitors: ungrouped });
+    for (const name of groupOrder) result.push({ name, monitors: byGroup.get(name)! });
+    for (const name of pendingGroups) {
+      if (!byGroup.has(name)) result.push({ name, monitors: [] });
+    }
+    return result;
+  });
 
   // Delete state
   let deleteConfirmText = $state("");
@@ -122,7 +162,11 @@
           page_subheader: foundPage.page_subheader || "",
           page_logo: foundPage.page_logo || ""
         };
-        selectedMonitors = foundPage.monitors?.map((m: { monitor_tag: string }) => m.monitor_tag) || [];
+        selectedMonitors =
+          foundPage.monitors?.map((m: { monitor_tag: string; group_name?: string | null }) => ({
+            monitor_tag: m.monitor_tag,
+            group_name: m.group_name ?? null
+          })) || [];
         // Load page settings with defaults
         if (foundPage.page_settings_json) {
           try {
@@ -237,7 +281,7 @@
         toast.error(result.error);
       } else {
         toast.success("Monitor added to page");
-        selectedMonitors = [...selectedMonitors, selectedMonitorTag];
+        selectedMonitors = [...selectedMonitors, { monitor_tag: selectedMonitorTag, group_name: null }];
         selectedMonitorTag = "";
       }
     } catch (e) {
@@ -297,7 +341,7 @@
         toast.error(result.error);
       } else {
         toast.success("Monitor removed from page");
-        selectedMonitors = selectedMonitors.filter((t) => t !== monitorTag);
+        selectedMonitors = selectedMonitors.filter((m) => m.monitor_tag !== monitorTag);
       }
     } catch (e) {
       toast.error("Failed to remove monitor");
@@ -307,16 +351,30 @@
   }
 
   // Get available monitors (not already on the current page)
-  const availableMonitors = $derived(monitors.filter((m) => !selectedMonitors.includes(m.tag)));
+  const availableMonitors = $derived(monitors.filter((m) => !selectedMonitors.some((sm) => sm.monitor_tag === m.tag)));
 
-  async function moveMonitor(index: number, direction: "up" | "down") {
-    const newIndex = direction === "up" ? index - 1 : index + 1;
-    if (newIndex < 0 || newIndex >= selectedMonitors.length) return;
+  // Reorder within a single group section by swapping the two monitors' positions
+  // in the global selectedMonitors list, then persisting the new flat order.
+  async function moveMonitorInSection(groupName: string | null, tag: string, direction: "up" | "down") {
+    const section = groupSections.find((s) => s.name === groupName);
+    if (!section) return;
+    const idx = section.monitors.findIndex((m) => m.monitor_tag === tag);
+    const newIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (newIdx < 0 || newIdx >= section.monitors.length) return;
+
+    const aTag = section.monitors[idx].monitor_tag;
+    const bTag = section.monitors[newIdx].monitor_tag;
+    const aFlat = selectedMonitors.findIndex((m) => m.monitor_tag === aTag);
+    const bFlat = selectedMonitors.findIndex((m) => m.monitor_tag === bTag);
+    if (aFlat < 0 || bFlat < 0) return;
 
     const updated = [...selectedMonitors];
-    [updated[index], updated[newIndex]] = [updated[newIndex], updated[index]];
+    [updated[aFlat], updated[bFlat]] = [updated[bFlat], updated[aFlat]];
     selectedMonitors = updated;
+    await persistOrder();
+  }
 
+  async function persistOrder() {
     if (!currentPage) return;
     reordering = true;
     try {
@@ -327,18 +385,111 @@
           action: "reorderPageMonitors",
           data: {
             page_id: currentPage.id,
-            monitor_tags: selectedMonitors
+            monitor_tags: selectedMonitors.map((m) => m.monitor_tag)
           }
         })
       });
       const result = await response.json();
-      if (result.error) {
-        toast.error(result.error);
-      }
+      if (result.error) toast.error(result.error);
     } catch (e) {
       toast.error("Failed to reorder monitors");
     } finally {
       reordering = false;
+    }
+  }
+
+  // ---- Drag-and-drop between group sections ----
+  function handleDragStart(tag: string) {
+    draggedTag = tag;
+  }
+  function handleDragEnd() {
+    draggedTag = null;
+    dropTargetGroup = undefined;
+  }
+  function handleDragOver(e: DragEvent, groupName: string | null) {
+    if (!draggedTag) return;
+    e.preventDefault();
+    dropTargetGroup = groupName;
+  }
+  function handleDragLeave(groupName: string | null) {
+    if (dropTargetGroup === groupName) dropTargetGroup = undefined;
+  }
+  async function handleDrop(e: DragEvent, groupName: string | null) {
+    e.preventDefault();
+    const tag = draggedTag;
+    draggedTag = null;
+    dropTargetGroup = undefined;
+    if (!tag || !currentPage) return;
+    const monitor = selectedMonitors.find((m) => m.monitor_tag === tag);
+    if (!monitor || monitor.group_name === groupName) return;
+
+    const previousGroup = monitor.group_name;
+    // Optimistic update + drop pending-group marker if we just landed one
+    selectedMonitors = selectedMonitors.map((m) => (m.monitor_tag === tag ? { ...m, group_name: groupName } : m));
+    if (groupName) pendingGroups = pendingGroups.filter((g) => g !== groupName);
+
+    try {
+      const response = await fetch(clientResolver(resolve, "/manage/api"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "updatePageMonitorGroup",
+          data: { page_id: currentPage.id, monitor_tag: tag, group_name: groupName }
+        })
+      });
+      const result = await response.json();
+      if (result.error) throw new Error(result.error);
+    } catch (e) {
+      // Revert
+      selectedMonitors = selectedMonitors.map((m) => (m.monitor_tag === tag ? { ...m, group_name: previousGroup } : m));
+      toast.error("Failed to move monitor");
+    }
+  }
+
+  // ---- Group management ----
+  function startAddGroup() {
+    addingGroup = true;
+    newGroupName = "";
+  }
+  function cancelAddGroup() {
+    addingGroup = false;
+    newGroupName = "";
+  }
+  function confirmAddGroup() {
+    const name = newGroupName.trim();
+    if (!name) return;
+    const exists = selectedMonitors.some((m) => m.group_name === name) || pendingGroups.includes(name);
+    if (exists) {
+      toast.error("Group already exists");
+      return;
+    }
+    pendingGroups = [...pendingGroups, name];
+    addingGroup = false;
+    newGroupName = "";
+  }
+
+  async function removeGroup(name: string) {
+    if (!currentPage) return;
+    const monitorsInGroup = selectedMonitors.filter((m) => m.group_name === name);
+    // Optimistic — move all to ungrouped
+    selectedMonitors = selectedMonitors.map((m) => (m.group_name === name ? { ...m, group_name: null } : m));
+    pendingGroups = pendingGroups.filter((g) => g !== name);
+    if (monitorsInGroup.length === 0) return;
+    try {
+      await Promise.all(
+        monitorsInGroup.map((m) =>
+          fetch(clientResolver(resolve, "/manage/api"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "updatePageMonitorGroup",
+              data: { page_id: currentPage!.id, monitor_tag: m.monitor_tag, group_name: null }
+            })
+          })
+        )
+      );
+    } catch (e) {
+      toast.error("Failed to remove group");
     }
   }
 
@@ -712,48 +863,120 @@
             </Button>
           </div>
 
-          <!-- Current Monitors -->
-          <div class="space-y-2">
-            <Label>Current Monitors</Label>
+          <!-- Current Monitors, grouped into sections -->
+          <div class="space-y-3">
+            <div class="flex items-center justify-between">
+              <Label>Current Monitors</Label>
+              {#if !addingGroup}
+                <Button variant="outline" size="sm" onclick={startAddGroup} disabled={selectedMonitors.length === 0}>
+                  <PlusIcon class="h-4 w-4" />
+                  Add group
+                </Button>
+              {/if}
+            </div>
+
+            {#if addingGroup}
+              <div class="flex gap-2">
+                <Input
+                  placeholder="Group name (e.g. Mainnet)"
+                  bind:value={newGroupName}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") confirmAddGroup();
+                    if (e.key === "Escape") cancelAddGroup();
+                  }}
+                />
+                <Button onclick={confirmAddGroup} disabled={!newGroupName.trim()}>Create</Button>
+                <Button variant="ghost" onclick={cancelAddGroup}>Cancel</Button>
+              </div>
+            {/if}
+
             {#if selectedMonitors.length > 0}
-              <div class="space-y-2">
-                {#each selectedMonitors as monitorTag, i (monitorTag)}
-                  {@const monitor = monitors.find((m) => m.tag === monitorTag)}
-                  <div class="bg-muted flex items-center justify-between rounded-lg p-3">
-                    <div>
-                      <p class="font-medium">{monitor?.name || monitorTag}</p>
-                      <p class="text-muted-foreground text-xs">{monitorTag}</p>
-                    </div>
-                    <div class="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onclick={() => moveMonitor(i, "up")}
-                        disabled={i === 0 || reordering}
-                      >
-                        <ArrowUpIcon class="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onclick={() => moveMonitor(i, "down")}
-                        disabled={i === selectedMonitors.length - 1 || reordering}
-                      >
-                        <ArrowDownIcon class="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onclick={() => removeMonitorFromPage(monitorTag)}
-                        disabled={removingMonitor === monitorTag}
-                      >
-                        {#if removingMonitor === monitorTag}
-                          <Loader class="h-4 w-4 animate-spin" />
-                        {:else}
+              <div class="space-y-3">
+                {#each groupSections as section (section.name ?? "__ungrouped__")}
+                  <div
+                    class="rounded-lg border p-2 transition-colors {dropTargetGroup === section.name
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border'}"
+                    ondragover={(e) => handleDragOver(e, section.name)}
+                    ondragleave={() => handleDragLeave(section.name)}
+                    ondrop={(e) => handleDrop(e, section.name)}
+                    role="region"
+                    aria-label={section.name ?? "Ungrouped"}
+                  >
+                    <div class="flex items-center justify-between px-2 py-1">
+                      <span class="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                        {section.name ?? "Ungrouped"}
+                      </span>
+                      {#if section.name}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          title="Remove group (monitors move to Ungrouped)"
+                          onclick={() => removeGroup(section.name as string)}
+                        >
                           <XIcon class="h-4 w-4" />
-                        {/if}
-                      </Button>
+                        </Button>
+                      {/if}
                     </div>
+                    {#if section.monitors.length === 0}
+                      <p class="text-muted-foreground px-2 py-2 text-xs italic">
+                        Drag a monitor here to add it to this group.
+                      </p>
+                    {:else}
+                      <div class="space-y-2">
+                        {#each section.monitors as item, i (item.monitor_tag)}
+                          {@const monitor = monitors.find((m) => m.tag === item.monitor_tag)}
+                          <div
+                            class="bg-muted flex items-center justify-between rounded-lg p-3 {draggedTag ===
+                            item.monitor_tag
+                              ? 'opacity-50'
+                              : ''}"
+                            draggable="true"
+                            ondragstart={() => handleDragStart(item.monitor_tag)}
+                            ondragend={handleDragEnd}
+                            role="listitem"
+                          >
+                            <div class="flex items-center gap-2">
+                              <GripVerticalIcon class="text-muted-foreground h-4 w-4 cursor-grab" />
+                              <div>
+                                <p class="font-medium">{monitor?.name || item.monitor_tag}</p>
+                                <p class="text-muted-foreground text-xs">{item.monitor_tag}</p>
+                              </div>
+                            </div>
+                            <div class="flex items-center gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onclick={() => moveMonitorInSection(section.name, item.monitor_tag, "up")}
+                                disabled={i === 0 || reordering}
+                              >
+                                <ArrowUpIcon class="h-4 w-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onclick={() => moveMonitorInSection(section.name, item.monitor_tag, "down")}
+                                disabled={i === section.monitors.length - 1 || reordering}
+                              >
+                                <ArrowDownIcon class="h-4 w-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onclick={() => removeMonitorFromPage(item.monitor_tag)}
+                                disabled={removingMonitor === item.monitor_tag}
+                              >
+                                {#if removingMonitor === item.monitor_tag}
+                                  <Loader class="h-4 w-4 animate-spin" />
+                                {:else}
+                                  <XIcon class="h-4 w-4" />
+                                {/if}
+                              </Button>
+                            </div>
+                          </div>
+                        {/each}
+                      </div>
+                    {/if}
                   </div>
                 {/each}
               </div>

--- a/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
@@ -399,16 +399,25 @@
   }
 
   // ---- Drag-and-drop between group sections ----
-  function handleDragStart(tag: string) {
+  // Firefox requires dataTransfer.setData() inside dragstart or the drag is
+  // silently canceled. We also set a payload so cross-element drops work even
+  // when the reactive draggedTag state is read before Svelte flushes.
+  function handleDragStart(e: DragEvent, tag: string) {
     draggedTag = tag;
+    if (e.dataTransfer) {
+      e.dataTransfer.setData("text/plain", tag);
+      e.dataTransfer.effectAllowed = "move";
+    }
   }
   function handleDragEnd() {
     draggedTag = null;
     dropTargetGroup = undefined;
   }
   function handleDragOver(e: DragEvent, groupName: string | null) {
-    if (!draggedTag) return;
+    // Always preventDefault so the drop event can fire — relying solely on
+    // draggedTag here would skip preventDefault if dragstart had issues.
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
     dropTargetGroup = groupName;
   }
   function handleDragLeave(groupName: string | null) {
@@ -416,7 +425,9 @@
   }
   async function handleDrop(e: DragEvent, groupName: string | null) {
     e.preventDefault();
-    const tag = draggedTag;
+    // Prefer reactive state, but fall back to the dataTransfer payload —
+    // makes the drop resilient if state hasn't flushed for any reason.
+    const tag = draggedTag ?? e.dataTransfer?.getData("text/plain") ?? null;
     draggedTag = null;
     dropTargetGroup = undefined;
     if (!tag || !currentPage) return;
@@ -932,7 +943,7 @@
                               ? 'opacity-50'
                               : ''}"
                             draggable="true"
-                            ondragstart={() => handleDragStart(item.monitor_tag)}
+                            ondragstart={(e) => handleDragStart(e, item.monitor_tag)}
                             ondragend={handleDragEnd}
                             role="listitem"
                           >

--- a/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/pages/[page_id]/+page.svelte
@@ -17,7 +17,8 @@
   import XIcon from "@lucide/svelte/icons/x";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
-  import GripVerticalIcon from "@lucide/svelte/icons/grip-vertical";
+  import FolderInputIcon from "@lucide/svelte/icons/folder-input";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
   import UploadIcon from "@lucide/svelte/icons/upload";
   import ImageIcon from "@lucide/svelte/icons/image";
   import TrashIcon from "@lucide/svelte/icons/trash";
@@ -84,9 +85,7 @@
   let reordering = $state(false);
   let addingGroup = $state(false);
   let newGroupName = $state("");
-  let draggedTag = $state<string | null>(null);
-  // null target = ungrouped section, undefined = no active drag-over
-  let dropTargetGroup = $state<string | null | undefined>(undefined);
+  let movingMonitor = $state<string | null>(null);
 
   // Derived: monitors grouped into sections. Ungrouped first, then named groups
   // in first-appearance order, then any pending (empty) groups awaiting drops.
@@ -398,44 +397,15 @@
     }
   }
 
-  // ---- Drag-and-drop between group sections ----
-  // Firefox requires dataTransfer.setData() inside dragstart or the drag is
-  // silently canceled. We also set a payload so cross-element drops work even
-  // when the reactive draggedTag state is read before Svelte flushes.
-  function handleDragStart(e: DragEvent, tag: string) {
-    draggedTag = tag;
-    if (e.dataTransfer) {
-      e.dataTransfer.setData("text/plain", tag);
-      e.dataTransfer.effectAllowed = "move";
-    }
-  }
-  function handleDragEnd() {
-    draggedTag = null;
-    dropTargetGroup = undefined;
-  }
-  function handleDragOver(e: DragEvent, groupName: string | null) {
-    // Always preventDefault so the drop event can fire — relying solely on
-    // draggedTag here would skip preventDefault if dragstart had issues.
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-    dropTargetGroup = groupName;
-  }
-  function handleDragLeave(groupName: string | null) {
-    if (dropTargetGroup === groupName) dropTargetGroup = undefined;
-  }
-  async function handleDrop(e: DragEvent, groupName: string | null) {
-    e.preventDefault();
-    // Prefer reactive state, but fall back to the dataTransfer payload —
-    // makes the drop resilient if state hasn't flushed for any reason.
-    const tag = draggedTag ?? e.dataTransfer?.getData("text/plain") ?? null;
-    draggedTag = null;
-    dropTargetGroup = undefined;
-    if (!tag || !currentPage) return;
+  // Reassign a single monitor to a different group via the per-row "Move to"
+  // menu. Optimistic update; reverts on server failure.
+  async function moveMonitorToGroup(tag: string, groupName: string | null) {
+    if (!currentPage) return;
     const monitor = selectedMonitors.find((m) => m.monitor_tag === tag);
     if (!monitor || monitor.group_name === groupName) return;
 
     const previousGroup = monitor.group_name;
-    // Optimistic update + drop pending-group marker if we just landed one
+    movingMonitor = tag;
     selectedMonitors = selectedMonitors.map((m) => (m.monitor_tag === tag ? { ...m, group_name: groupName } : m));
     if (groupName) pendingGroups = pendingGroups.filter((g) => g !== groupName);
 
@@ -451,9 +421,10 @@
       const result = await response.json();
       if (result.error) throw new Error(result.error);
     } catch (e) {
-      // Revert
       selectedMonitors = selectedMonitors.map((m) => (m.monitor_tag === tag ? { ...m, group_name: previousGroup } : m));
       toast.error("Failed to move monitor");
+    } finally {
+      movingMonitor = null;
     }
   }
 
@@ -889,7 +860,7 @@
             {#if addingGroup}
               <div class="flex gap-2">
                 <Input
-                  placeholder="Group name (e.g. Mainnet)"
+                  placeholder="Group name"
                   bind:value={newGroupName}
                   onkeydown={(e) => {
                     if (e.key === "Enter") confirmAddGroup();
@@ -902,15 +873,11 @@
             {/if}
 
             {#if selectedMonitors.length > 0}
+              {@const knownGroupNames = groupSections.map((s) => s.name).filter((n): n is string => n !== null)}
               <div class="space-y-3">
                 {#each groupSections as section (section.name ?? "__ungrouped__")}
                   <div
-                    class="rounded-lg border p-2 transition-colors {dropTargetGroup === section.name
-                      ? 'border-primary bg-primary/5'
-                      : 'border-border'}"
-                    ondragover={(e) => handleDragOver(e, section.name)}
-                    ondragleave={() => handleDragLeave(section.name)}
-                    ondrop={(e) => handleDrop(e, section.name)}
+                    class="border-border rounded-lg border p-2"
                     role="region"
                     aria-label={section.name ?? "Ungrouped"}
                   >
@@ -931,30 +898,67 @@
                     </div>
                     {#if section.monitors.length === 0}
                       <p class="text-muted-foreground px-2 py-2 text-xs italic">
-                        Drag a monitor here to add it to this group.
+                        Use the move-to menu on a monitor to add it to this group.
                       </p>
                     {:else}
                       <div class="space-y-2">
                         {#each section.monitors as item, i (item.monitor_tag)}
                           {@const monitor = monitors.find((m) => m.tag === item.monitor_tag)}
-                          <div
-                            class="bg-muted flex items-center justify-between rounded-lg p-3 {draggedTag ===
-                            item.monitor_tag
-                              ? 'opacity-50'
-                              : ''}"
-                            draggable="true"
-                            ondragstart={(e) => handleDragStart(e, item.monitor_tag)}
-                            ondragend={handleDragEnd}
-                            role="listitem"
-                          >
-                            <div class="flex items-center gap-2">
-                              <GripVerticalIcon class="text-muted-foreground h-4 w-4 cursor-grab" />
-                              <div>
-                                <p class="font-medium">{monitor?.name || item.monitor_tag}</p>
-                                <p class="text-muted-foreground text-xs">{item.monitor_tag}</p>
-                              </div>
+                          {@const otherGroups = knownGroupNames.filter((n) => n !== section.name)}
+                          <div class="bg-muted flex items-center justify-between rounded-lg p-3" role="listitem">
+                            <div>
+                              <p class="font-medium">{monitor?.name || item.monitor_tag}</p>
+                              <p class="text-muted-foreground text-xs">{item.monitor_tag}</p>
                             </div>
                             <div class="flex items-center gap-1">
+                              <DropdownMenu.Root>
+                                <DropdownMenu.Trigger>
+                                  {#snippet child({ props })}
+                                    <Button
+                                      {...props}
+                                      variant="ghost"
+                                      size="sm"
+                                      title="Move to group"
+                                      disabled={movingMonitor === item.monitor_tag}
+                                    >
+                                      {#if movingMonitor === item.monitor_tag}
+                                        <Loader class="h-4 w-4 animate-spin" />
+                                      {:else}
+                                        <FolderInputIcon class="h-4 w-4" />
+                                      {/if}
+                                    </Button>
+                                  {/snippet}
+                                </DropdownMenu.Trigger>
+                                <DropdownMenu.Content align="end">
+                                  <DropdownMenu.Label>Move to</DropdownMenu.Label>
+                                  <DropdownMenu.Group>
+                                    {#if section.name !== null}
+                                      <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => moveMonitorToGroup(item.monitor_tag, null)}
+                                      >
+                                        Ungrouped
+                                      </DropdownMenu.Item>
+                                    {/if}
+                                    {#each otherGroups as g (g)}
+                                      <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => moveMonitorToGroup(item.monitor_tag, g)}
+                                      >
+                                        {g}
+                                      </DropdownMenu.Item>
+                                    {/each}
+                                    {#if otherGroups.length === 0 && section.name !== null}
+                                      <DropdownMenu.Separator />
+                                    {/if}
+                                    {#if otherGroups.length === 0 && section.name === null}
+                                      <DropdownMenu.Item disabled>
+                                        No groups yet — use Add group above
+                                      </DropdownMenu.Item>
+                                    {/if}
+                                  </DropdownMenu.Group>
+                                </DropdownMenu.Content>
+                              </DropdownMenu.Root>
                               <Button
                                 variant="ghost"
                                 size="sm"


### PR DESCRIPTION
Adds optional **groups** for monitors within a status page, matching the way Uptime Kuma groups monitors under named sections on a single page.

Each `pages_monitors` row gets a nullable `group_name` column. The public page renders ungrouped monitors first (no header — identical to the pre-groups layout) then one bordered section per group with the group name as an `h2` header.

## Live

Running on this PR at <https://status.arklabs.xyz>:

- <https://status.arklabs.xyz/> — home page with three named groups (Mainnet / Mutinynet / Signet)

The 3 sibling pages (`/mainnet`, `/mutinynet`, `/signet`) are deliberately ungrouped to show backward-compat: a page with no `group_name` on any monitor renders exactly as it did before this PR.

## API

`POST /api/v4/pages` and `PATCH /api/v4/pages/{path}` now accept either of:

```json
"monitors": ["my-monitor", "another"]
```

or

```json
"monitors": [
  { "tag": "api", "group": "Mainnet" },
  { "tag": "node", "group": "Mainnet" },
  { "tag": "telemetry" }
]
```

Responses also include a `group` field per monitor. Old clients are unaffected.

## Admin UI

**Manage → Pages → [page]** now renders monitors as **group sections** with:

- An "Ungrouped" section that's always shown.
- "Add group" inline input that creates a local empty section; persists once a monitor is moved into it.
- Per-monitor "Move to" dropdown listing the other groups (works on touch + desktop). Initial drag-and-drop attempt didn't work on mobile — HTML5 native drag doesn't fire from touch — so the menu replaced it.
- Removing a group moves its monitors back to "Ungrouped".

Optimistic updates on each move via a new `updatePageMonitorGroup` `/manage/api` action; the existing `reorderPageMonitors` action is reused with a flat tag order.

## Backward compatibility

- Migration is additive — `group_name` is nullable with no default.
- Existing pages render identically (single group, `name=null`, no header).
- API still accepts `monitors: string[]`; admin still calls `addMonitorToPage` the same way (new monitors default to ungrouped).

## Out of scope

- Per-group description / collapsible toggle / explicit group ordering — group order is currently derived from the first monitor of each group's position.

## Docker

Combined image (this PR + #731): `docker pull kukks/kener:rss-and-groups`
