### PR TITLE
implement last known status retrieval in monitoring system

### DIFF
--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -751,3 +751,6 @@ export const GetStatusCountsByIntervalGroupedByMonitor = async (
   await setCache(cacheKey, result, 60);
   return result;
 };
+export const GetLastKnownStatus = async (monitor_tag: string): Promise<MonitoringData | undefined> => {
+  return await db.getLastKnownStatus(monitor_tag);
+};

--- a/src/lib/server/db/dbimpl.ts
+++ b/src/lib/server/db/dbimpl.ts
@@ -70,6 +70,7 @@ class DbImpl {
   getStatusCountsByInterval!: MonitoringRepository["getStatusCountsByInterval"];
   getStatusCountsByIntervalGroupedByMonitor!: MonitoringRepository["getStatusCountsByIntervalGroupedByMonitor"];
   getStatusCountsForLastN!: MonitoringRepository["getStatusCountsForLastN"];
+  getLastKnownStatus!: MonitoringRepository["getLastKnownStatus"];
 
   // ============ Monitors ============
   getMonitorsByTags!: MonitorsRepository["getMonitorsByTags"];
@@ -432,6 +433,7 @@ class DbImpl {
       this.monitoring,
     );
     this.getStatusCountsForLastN = this.monitoring.getStatusCountsForLastN.bind(this.monitoring);
+    this.getLastKnownStatus = this.monitoring.getLastKnownStatus.bind(this.monitoring);
   }
 
   private bindMonitorsMethods(): void {

--- a/src/lib/server/db/repositories/monitoring.ts
+++ b/src/lib/server/db/repositories/monitoring.ts
@@ -596,4 +596,9 @@ export class MonitoringRepository extends BaseRepository {
       minLatency: Number(result?.min_latency) || 0,
     };
   }
+
+  //get the last known status for a monitor
+  async getLastKnownStatus(monitor_tag: string): Promise<MonitoringData | undefined> {
+    return await this.knex("monitoring_data").where("monitor_tag", monitor_tag).orderBy("timestamp", "desc").first();
+  }
 }

--- a/src/lib/server/schedulers/dailyCleanup.ts
+++ b/src/lib/server/schedulers/dailyCleanup.ts
@@ -47,7 +47,7 @@ const getRetentionPolicy = async (): Promise<DataRetentionPolicy> => {
 const runDailyCleanup = async (): Promise<DailyCleanupResult> => {
   const policy = await getRetentionPolicy();
   const retentionDays = Math.max(1, Math.floor(policy.retentionDays || defaultPolicy.retentionDays));
-
+  console.log(`Data retention policy: enabled=${policy.enabled}, retentionDays=${retentionDays}`);
   if (!policy.enabled) {
     return {
       skipped: true,

--- a/src/lib/server/services/noneCall.ts
+++ b/src/lib/server/services/noneCall.ts
@@ -1,5 +1,6 @@
-import DNSResolver from "../dns.js";
+import { GetLastKnownStatus } from "../controllers/monitorsController.js";
 import type { NoneMonitor, MonitoringResult } from "../types/monitor.js";
+import GC from "../../global-constants.js";
 
 class NoneCall {
   monitor: NoneMonitor;
@@ -8,7 +9,25 @@ class NoneCall {
     this.monitor = monitor;
   }
 
-  async execute(): Promise<null> {
+  async execute(): Promise<MonitoringResult | null> {
+    let overrideWithLastKnownStatus = this.monitor.type_data.overrideWithLastKnownStatus;
+    if (!!overrideWithLastKnownStatus) {
+      //get the last known status
+      let lastKnownStatus = await GetLastKnownStatus(this.monitor.tag);
+      if (
+        !!lastKnownStatus &&
+        !!lastKnownStatus.status &&
+        !!lastKnownStatus.latency &&
+        !!lastKnownStatus.type &&
+        lastKnownStatus.type === GC.MANUAL
+      ) {
+        return {
+          status: lastKnownStatus.status,
+          latency: lastKnownStatus.latency,
+          type: lastKnownStatus.type,
+        };
+      }
+    }
     return null;
   }
 }

--- a/src/lib/server/services/noneCall.ts
+++ b/src/lib/server/services/noneCall.ts
@@ -17,13 +17,12 @@ class NoneCall {
       if (
         !!lastKnownStatus &&
         !!lastKnownStatus.status &&
-        !!lastKnownStatus.latency &&
         !!lastKnownStatus.type &&
         lastKnownStatus.type === GC.MANUAL
       ) {
         return {
           status: lastKnownStatus.status,
-          latency: lastKnownStatus.latency,
+          latency: lastKnownStatus.latency || 0,
           type: lastKnownStatus.type,
         };
       }

--- a/src/lib/server/types/monitor.ts
+++ b/src/lib/server/types/monitor.ts
@@ -14,7 +14,9 @@ export interface MonitoringResultTS {
   [timestamp: number]: MonitoringResult;
 }
 
-export interface NoneMonitorTypeData {}
+export interface NoneMonitorTypeData {
+  overrideWithLastKnownStatus: boolean;
+}
 export interface ApiMonitorTypeData {
   url: string;
   body?: string;

--- a/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-none.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-none.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
+  import { Checkbox } from "$lib/components/ui/checkbox/index.js";
+  import { Label } from "$lib/components/ui/label/index.js";
   import type { NoneMonitorTypeData } from "$lib/server/types/monitor.js";
 
   let { data = $bindable() }: { data: NoneMonitorTypeData } = $props();
+
+  if (data.overrideWithLastKnownStatus === undefined) {
+    data.overrideWithLastKnownStatus = false;
+  }
 </script>
 
-<div class="bg-muted/50 rounded-lg p-6 text-center">
-  <p class="text-muted-foreground text-sm">
-    This monitor type does not have any automatic checks. Status updates must be made manually via the API or through
-    incidents.
-  </p>
+<div class="space-y-4">
+  <div class="bg-muted/50 rounded-lg p-6 text-center">
+    <p class="text-muted-foreground text-sm">
+      This monitor type does not have any automatic checks. Status updates must be made manually via the API or through
+      incidents.
+    </p>
+  </div>
+
+  <div class="flex items-start gap-3 rounded-lg border p-4">
+    <Checkbox id="none-override-last-known-status" bind:checked={data.overrideWithLastKnownStatus} />
+    <div class="grid gap-1.5 leading-none">
+      <Label for="none-override-last-known-status" class="cursor-pointer">Override with last known status</Label>
+      <p class="text-muted-foreground text-sm">
+        On each scheduled run, reuse the last manual status (created using the API) so this monitor keeps that state in
+        status history, uptime, and alert evaluation until you change it.
+      </p>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
impelemnts #721 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "None" monitor type can optionally use the last known monitor status (status, latency, and source) instead of returning no data.
  * Added a settings checkbox to enable the override in the monitor configuration UI.

* **Improvements**
  * Daily cleanup now logs resolved data retention policy and computed retention days for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->