### PR TITLE
Implement manual transitions for maintenance events to reflect actual…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,3 +97,10 @@ _Avoid_: Maintenance window, maintenance event (that's an occurrence, see below)
 **Maintenance Event**:
 A single occurrence of a Maintenance, generated from its RRULE: a concrete start/end time with a lifecycle status (SCHEDULED → READY → ONGOING → COMPLETED). Has its own id, independent of the Maintenance id. The public maintenance page is keyed by Maintenance Event id.
 _Avoid_: Occurrence, maintenance instance
+
+**Cancelled Event**:
+A Maintenance Event called off by an admin instead of running to completion. An event not yet started keeps its planned window when cancelled; an ONGOING event that is cancelled — or completed early — has its end time moved to the moment it was ended, so the recorded window always reflects what actually happened, not what was planned. COMPLETED means the work finished; CANCELLED means the occurrence was called off, before or during. Both are terminal: no relabeling, no un-cancel.
+_Avoid_: Skipped event, aborted event
+
+**Ended Notification**:
+The subscriber notification sent when a Maintenance Event reaches a terminal status — COMPLETED or CANCELLED, naturally or by an admin. One toggle (`ended`) governs all of them; there is no separate cancellation toggle.

--- a/docs/adr/0006-manual-maintenance-event-transitions.md
+++ b/docs/adr/0006-manual-maintenance-event-transitions.md
@@ -1,0 +1,15 @@
+# Manual maintenance-event transitions rewrite the record to what actually happened
+
+Issue #722 asked for a way to end a maintenance early instead of deleting it or editing its timer. We added manual transitions on Maintenance Events with one governing principle: **the event record reflects what actually happened, not what was planned.** Manually completing or cancelling an ONGOING event truncates `end_date_time` to the moment of the transition; cancelling a not-yet-started event (SCHEDULED/READY) keeps its planned window, since it never affected monitors. We rejected status-only updates (the record would forever claim a 4-hour window for a 1-hour maintenance, and every reader would have to compensate by also checking status).
+
+Allowed transitions: ONGOING → COMPLETED, and SCHEDULED/READY/ONGOING → CANCELLED. COMPLETED means the work finished; CANCELLED means the occurrence was called off. Both are terminal — no relabeling, no un-cancel. Reverse transitions were rejected because the minute-scheduler's catch-up query would immediately flip a resurrected past-start SCHEDULED event back to ONGOING and fire "in progress" notifications. The escape hatch for a mistaken cancel is editing the Maintenance schedule, which regenerates events.
+
+Consequences that fall out of existing code rather than new code:
+
+- Monitor impact stops immediately on transition — the realtime query filters on `status IN (SCHEDULED, READY, ONGOING)`, so no time rewrite is needed for that.
+- For recurring Maintenances, cancelling an occurrence permanently skips it: event generation dedups by `start_date_time` against **all** existing events regardless of status, so the CANCELLED row blocks regeneration. This is intended behavior, not an accident — do not "fix" the dedup to ignore CANCELLED rows.
+- Public "upcoming"/"ongoing" lists already filter by status, so cancelled events vanish from them while remaining visible (with a CANCELLED badge) on the event detail and events-by-month history pages.
+
+API shape: the transition rides the existing `PATCH /api/v4/maintenances/{maintenance_id}/events/{event_id}` as a second, mutually exclusive mode — either `start_date_time`+`end_date_time` (window edit, unchanged) or `status` alone (transition). Mixing them is a 400, which avoids deciding who wins when an explicit `end_date_time` contradicts the truncation rule. A dedicated action sub-route was rejected as a break from v4's CRUD style.
+
+Notifications: every transition to a terminal status — natural or manual, COMPLETED or CANCELLED — notifies subscribers under the existing `ended` toggle. A dedicated `cancelled` toggle was rejected: the settings object is stored whole, so existing sites would silently default the new key to off, and the uniform reading of `ended` ("tell me when an event reaches its end state") makes a separate toggle unnecessary.

--- a/src/lib/allPerms.ts
+++ b/src/lib/allPerms.ts
@@ -11,7 +11,7 @@
  * incidents.write    → createIncident, updateIncident, deleteIncident, addMonitor, removeMonitor, addComment, deleteComment, updateComment
  *
  * maintenances.read  → getMaintenances, getMaintenance, getMaintenanceEvents, getMaintenanceEvent, getMaintenanceMonitors
- * maintenances.write → createMaintenance, updateMaintenance, deleteMaintenance, createMaintenanceEvent, updateMaintenanceEvent, deleteMaintenanceEvent, addMonitorToMaintenance, removeMonitorFromMaintenance, updateMaintenanceMonitorImpact
+ * maintenances.write → createMaintenance, updateMaintenance, deleteMaintenance, createMaintenanceEvent, updateMaintenanceEvent, updateMaintenanceEventStatus, deleteMaintenanceEvent, addMonitorToMaintenance, removeMonitorFromMaintenance, updateMaintenanceMonitorImpact
  *
  * pages.read         → getPages
  * pages.write        → createPage, updatePage, deletePage, addMonitorToPage, removeMonitorFromPage, reorderPageMonitors
@@ -149,6 +149,7 @@ export const ACTION_PERMISSION_MAP: Record<string, string | null> = {
   deleteMaintenance: "maintenances.write",
   createMaintenanceEvent: "maintenances.write",
   updateMaintenanceEvent: "maintenances.write",
+  updateMaintenanceEventStatus: "maintenances.write",
   deleteMaintenanceEvent: "maintenances.write",
   addMonitorToMaintenance: "maintenances.write",
   removeMonitorFromMaintenance: "maintenances.write",

--- a/src/lib/server/controllers/maintenanceController.ts
+++ b/src/lib/server/controllers/maintenanceController.ts
@@ -486,18 +486,75 @@ export const UpdateMaintenanceEvent = async (
   return await db.updateMaintenanceEvent(id, data);
 };
 
-export const UpdateMaintenanceEventStatus = async (id: number, status: string): Promise<number> => {
-  const validStatuses = ["SCHEDULED", "IN_PROGRESS", "COMPLETED", "CANCELLED"];
-  if (!validStatuses.includes(status)) {
-    throw new Error(`Invalid status: ${status}`);
+/**
+ * Manually transition a maintenance event to a terminal status.
+ * Allowed transitions: ONGOING → COMPLETED, SCHEDULED/READY/ONGOING → CANCELLED.
+ * An event that already started has its end_date_time moved to the moment it was
+ * ended (the record reflects what actually happened); an event that never started
+ * keeps its planned window. See docs/adr/0006-manual-maintenance-event-transitions.md
+ */
+export const UpdateMaintenanceEventStatus = async (id: number, status: string): Promise<MaintenanceEventRecord> => {
+  if (status !== GC.COMPLETED && status !== GC.CANCELLED) {
+    throw new Error(`Invalid status: ${status}. Allowed values are ${GC.COMPLETED} and ${GC.CANCELLED}`);
   }
+  const targetStatus = status as "COMPLETED" | "CANCELLED";
 
   const existing = await db.getMaintenanceEventById(id);
   if (!existing) {
     throw new Error(`Maintenance event with id ${id} does not exist`);
   }
 
-  return await db.updateMaintenanceEventStatus(id, status);
+  const allowedFrom: string[] = targetStatus === GC.COMPLETED ? [GC.ONGOING] : [GC.SCHEDULED, GC.READY, GC.ONGOING];
+  if (!allowedFrom.includes(existing.status)) {
+    throw new Error(`Cannot transition event from ${existing.status} to ${targetStatus}`);
+  }
+
+  if (existing.status === GC.ONGOING) {
+    // Ended now, but never before its first minute nor after its planned end
+    const endDateTime = Math.min(
+      existing.end_date_time,
+      Math.max(GetMinuteStartNowTimestampUTC(), existing.start_date_time + 60),
+    );
+    await db.updateMaintenanceEvent(id, { status: targetStatus, end_date_time: endDateTime });
+  } else {
+    await db.updateMaintenanceEventStatus(id, targetStatus);
+  }
+
+  const updated = await db.getMaintenanceEventById(id);
+  if (!updated) {
+    throw new Error(`Maintenance event with id ${id} does not exist`);
+  }
+
+  try {
+    const siteData = await GetAllSiteData();
+    const notificationSettings =
+      siteData.globalMaintenanceNotificationSettings || seedSiteData.globalMaintenanceNotificationSettings;
+    if (notificationSettings.event_types.ended) {
+      const siteVars = siteDataToVariables(siteData);
+      const siteUrl = siteVars.site_url;
+      const maintenance = await db.getMaintenanceById(updated.maintenance_id);
+      const monitors = await db.getMonitorsByMaintenanceId(updated.maintenance_id);
+      const monitorNames = monitors.map((m) => `${m.monitor_name}(${m.monitor_impact})`).join(", ");
+      const eventDetailed: MaintenanceEventRecordDetailed = {
+        ...updated,
+        title: maintenance?.title || "",
+        description: maintenance?.description || null,
+      };
+      const update = maintenanceToVariables(
+        eventDetailed,
+        monitorNames,
+        targetStatus === GC.COMPLETED ? "**has been completed**" : "**has been cancelled**",
+        targetStatus === GC.COMPLETED ? "completed" : "cancelled",
+        targetStatus === GC.COMPLETED ? "Maintenance Completed" : "Maintenance Cancelled",
+        siteUrl,
+      );
+      await subscriberQueue.push(update);
+    }
+  } catch (err) {
+    console.error(`Error sending ${targetStatus} notification for maintenance event ${id}:`, err);
+  }
+
+  return updated;
 };
 
 export const DeleteMaintenanceEvent = async (id: number): Promise<number> => {

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -369,8 +369,15 @@ export interface GetMaintenanceEventResponse {
 }
 
 export interface UpdateMaintenanceEventRequest {
-  start_date_time: number;
-  end_date_time: number;
+  /** Window edit mode: both times required. Cannot be combined with `status`. */
+  start_date_time?: number;
+  end_date_time?: number;
+  /**
+   * Transition mode: COMPLETED (from ONGOING) or CANCELLED (from SCHEDULED/READY/ONGOING).
+   * Cannot be combined with time fields. Transitioning an ONGOING event moves its
+   * end_date_time to the moment of the transition.
+   */
+  status?: "COMPLETED" | "CANCELLED";
 }
 
 export interface UpdateMaintenanceEventResponse {

--- a/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/[event_id]/+server.ts
+++ b/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/[event_id]/+server.ts
@@ -11,6 +11,8 @@ import type {
 } from "$lib/types/api";
 import { GetMinuteStartTimestampUTC } from "$lib/server/tool";
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
+import { UpdateMaintenanceEventStatus } from "$lib/server/controllers/maintenanceController";
+import GC from "$lib/global-constants";
 import serverResolver from "$lib/server/resolver";
 
 function formatDateToISO(date: Date | string): string {
@@ -116,7 +118,46 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
     return json(errorResponse, { status: 400 });
   }
 
-  // Validate required fields - both are required for event update
+  // Transition mode: `status` alone, mutually exclusive with window edits
+  if (body.status !== undefined) {
+    if (body.start_date_time !== undefined || body.end_date_time !== undefined) {
+      const errorResponse: BadRequestResponse = {
+        error: {
+          code: "BAD_REQUEST",
+          message: "Cannot update status and start/end times in the same request",
+        },
+      };
+      return json(errorResponse, { status: 400 });
+    }
+
+    if (body.status !== GC.COMPLETED && body.status !== GC.CANCELLED) {
+      const errorResponse: BadRequestResponse = {
+        error: {
+          code: "BAD_REQUEST",
+          message: `status must be ${GC.COMPLETED} or ${GC.CANCELLED}`,
+        },
+      };
+      return json(errorResponse, { status: 400 });
+    }
+
+    try {
+      const updatedEvent = await UpdateMaintenanceEventStatus(eventId, body.status);
+      const response: UpdateMaintenanceEventResponse = {
+        event: await buildEventResponse(updatedEvent),
+      };
+      return json(response);
+    } catch (err) {
+      const errorResponse: BadRequestResponse = {
+        error: {
+          code: "BAD_REQUEST",
+          message: err instanceof Error ? err.message : "Failed to update event status",
+        },
+      };
+      return json(errorResponse, { status: 400 });
+    }
+  }
+
+  // Window edit mode: both times required
   if (body.start_date_time === undefined || body.start_date_time === null) {
     const errorResponse: BadRequestResponse = {
       error: {

--- a/src/routes/(docs)/docs/content/v4/incidents/auto-generated.md
+++ b/src/routes/(docs)/docs/content/v4/incidents/auto-generated.md
@@ -148,45 +148,62 @@ This provides complete context about:
 
 When the alert resolves, a detailed closure update is added:
 
+```markdown
 The alert has been resolved, Total duration: 47 minutes
 
 #### Alert Details
 
-title: Auto-Generated Incidents
-description: Quick reference for incident creation via alerting
+| Setting               | Value       |
 | :-------------------- | :---------- |
-| **Monitor Name** | Payment API |
-Kener can auto-create incidents from alert configurations.
-| **Monitor Tag** | payment-api |
-
-## How it works {#how-it-works}
-
-| **Alert Value** | DOWN |
-
-1. Alert triggers.
-2. Alert has **Create Incident = YES**.
-3. Incident is created and monitor is attached.
-4. When alert resolves, incident is resolved automatically.
-   | **Failure Threshold** | 3 |
-
-## Where to configure {#where-to-configure}
+| **Monitor Name**      | Payment API |
+| **Incident Status**   | RESOLVED    |
+| **Monitor Tag**       | payment-api |
+| **Alert Type**        | STATUS      |
+| **Alert Value**       | DOWN        |
+| **Severity**          | CRITICAL    |
+| **Failure Threshold** | 3           |
+| **Success Threshold** | 5           |
+```
 
 This includes:
-Use **Manage → Alerts → Alert Configurations**.
 
 - Total incident duration
-
-## Notes {#notes}
-
+- Alert configuration
 - Resolution confirmation
-- Auto-generated incidents are ideal for critical, user-facing alerts.
-- Tune thresholds to avoid noisy incident creation.
+- Success threshold that was met
 
-## See also {#see-also}
+## Configuration Requirements {#configuration-requirements}
 
-- [Alert Configurations](/docs/v4/alerting/alert-configurations)
-- [Triggers](/docs/v4/alerting/triggers)
-- [Creating and Managing Incidents](/docs/v4/incidents/creating-managing)
+To enable auto-generated incidents:
+
+### 1. Create Alert Configuration {#create-alert-config}
+
+Navigate to **Manage > Alerts > Create Alert**
+
+**Configure:**
+
+- Monitor to watch
+- Alert type (STATUS, LATENCY, UPTIME)
+- Alert value (threshold)
+- Failure threshold
+- Success threshold
+- Severity (CRITICAL or WARNING)
+
+**Enable Incident Creation:**
+
+- Set **Create Incident** to **YES**
+
+See [Alert Configurations](/docs/v4/alerting/alert-configurations) for complete details.
+
+### 2. Configure Triggers (Optional) {#configure-triggers}
+
+While triggers are optional for incident creation, they enable notifications:
+
+**Create Triggers:**
+
+- Discord
+- Slack
+- Email
 - Webhook
 
 **Attach to Alert:**
@@ -194,7 +211,7 @@ Use **Manage → Alerts → Alert Configurations**.
 - Select triggers when creating/editing alert
 - Triggers fire on both TRIGGERED and RESOLVED events
 
-See [Triggers](/docs/alerting/triggers) for setup.
+See [Triggers](/docs/v4/alerting/triggers) for setup.
 
 ## Manual vs Auto-Generated {#manual-vs-auto}
 
@@ -289,11 +306,13 @@ A monitor can have multiple alert configurations:
 
 **Example:**
 
+```
 Monitor: api-gateway
 
 Alert 1: STATUS - DOWN (failure: 1)
 Alert 2: LATENCY - 1000ms (failure: 5)
 Alert 3: UPTIME - 99.9% (failure: 10)
+```
 
 **Each Alert:**
 
@@ -330,7 +349,7 @@ When incident is auto-resolved:
 - Uses configured templates
 - Variable: `is_resolved = true`
 
-See [Triggers](/docs/alerting/triggers) and [Templates](/docs/alerting/templates) for customization.
+See [Triggers](/docs/v4/alerting/triggers) and [Templates](/docs/v4/alerting/templates) for customization.
 
 ### Subscriber Notifications {#subscriber-notifications}
 
@@ -427,7 +446,7 @@ Every alert trigger creates an alert event log:
 3. Trigger credentials valid
 4. Check trigger logs for errors
 
-See [Troubleshooting Triggers](/docs/alerting/triggers#troubleshooting-triggers) for detailed diagnosing.
+See [Troubleshooting Triggers](/docs/v4/alerting/triggers#troubleshooting-triggers) for detailed diagnosing.
 
 ## Best Practices {#best-practices}
 
@@ -465,11 +484,13 @@ See [Troubleshooting Triggers](/docs/alerting/triggers#troubleshooting-triggers)
 
 **Workflow:**
 
+```
 1. Alert triggers → Auto-creates incident
 2. You investigate → Add IDENTIFIED update
 3. You deploy fix → Add MONITORING update
 4. Alert resolves → Auto-adds RESOLVED update
 5. You add post-mortem → Add final manual update
+```
 
 ### Threshold Tuning {#threshold-tuning}
 
@@ -493,7 +514,7 @@ See [Troubleshooting Triggers](/docs/alerting/triggers#troubleshooting-triggers)
 
 ## Next Steps {#next-steps}
 
-- [Alert Configurations](/docs/alerting/alert-configurations) - Set up alerts that create incidents
-- [Triggers](/docs/alerting/triggers) - Configure notification channels
-- [Incident Updates](/docs/incidents/updates) - Add manual updates to auto-generated incidents
-- [Incident Overview](/docs/incidents/overview) - Understand incident basics
+- [Alert Configurations](/docs/v4/alerting/alert-configurations) - Set up alerts that create incidents
+- [Triggers](/docs/v4/alerting/triggers) - Configure notification channels
+- [Incident Updates](/docs/v4/incidents/updates) - Add manual updates to auto-generated incidents
+- [Incident Overview](/docs/v4/incidents/overview) - Understand incident basics

--- a/src/routes/(docs)/docs/content/v4/incidents/updates.md
+++ b/src/routes/(docs)/docs/content/v4/incidents/updates.md
@@ -60,32 +60,69 @@ The incident state after this update. This is **crucial** because:
 - State progression drives the incident lifecycle
 
 **Available States:**
-title: Incident Updates
-description: Quick reference for posting timeline updates on incidents
 
+- **INVESTIGATING** - Initial investigation
 - **IDENTIFIED** - Root cause found
 - **MONITORING** - Fix applied, watching for stability
-  Incident updates are timeline entries used to communicate progress and move incident state.
+- **RESOLVED** - Issue fully resolved
 
-## Quick reference {#quick-reference}
+**Important:** When you set state to **RESOLVED**, Kener automatically sets the incident's `end_date_time` to the update's timestamp.
 
-When posting an update, choose one state:
+### Timestamp (Required) {#timestamp}
 
-- `INVESTIGATING`
-- `IDENTIFIED`
-- `MONITORING`
-- `RESOLVED`
+When this update was made.
 
-Setting `RESOLVED` closes the incident and sets end time.
+**Default:** Current date and time
 
+**Can Be Modified:**
+
+- Useful for backdating updates
 - Aligning timeline with actual events
-  Use concise, user-facing text and include only meaningful changes.
+- Recording updates made after the fact
 
-## See also {#see-also}
+**Display:** Shown in your local timezone but stored as UTC
 
-- [Creating and Managing Incidents](/docs/v4/incidents/creating-managing)
-- [Impact on Monitoring](/docs/v4/incidents/impact-on-monitoring)
-  **Important State Changes:**
+## Creating Updates {#creating-updates}
+
+### During Incident Creation {#during-creation}
+
+When creating a new incident, you can optionally provide an **Initial Update**:
+
+1. Fill out the incident details
+2. Add text in the "Initial Update" field
+3. Uses Markdown formatting
+4. Automatically created with state "INVESTIGATING"
+5. Timestamp matches incident start time
+
+### Adding Updates to Existing Incidents {#adding-updates}
+
+1. Navigate to the incident detail page
+2. Click **Add Update** button
+3. Enter your message (Markdown supported)
+4. Select the new state
+5. Optionally adjust the timestamp
+6. Click **Add Update**
+
+**What Happens:**
+
+- Update is added to the incident timeline
+- Incident state changes to the update's state
+- If state is RESOLVED, end_date_time is set
+- Update appears immediately on status page
+- Subscribers receive notifications (if configured)
+
+## Editing Updates {#editing-updates}
+
+You can edit any existing update:
+
+1. Find the update in the incident timeline
+2. Click the **Edit** (pencil icon) button
+3. Modify the message
+4. Change the state if needed
+5. Adjust the timestamp if needed
+6. Click **Save**
+
+**Important State Changes:**
 
 **Moving to RESOLVED:**
 
@@ -401,6 +438,6 @@ See [Subscription documentation](/docs/v4/subscriptions) for setup.
 
 ## Next Steps {#next-steps}
 
-- [Incident Impact on Monitoring](/docs/incidents/impact-on-monitoring) - How incident state affects monitor status
-- [Creating and Managing Incidents](/docs/incidents/creating-managing) - Back to incident management basics
-- [Auto-Generated Incidents](/docs/incidents/auto-generated) - How alerts create and update incidents automatically
+- [Incident Impact on Monitoring](/docs/v4/incidents/impact-on-monitoring) - How incident state affects monitor status
+- [Creating and Managing Incidents](/docs/v4/incidents/creating-managing) - Back to incident management basics
+- [Auto-Generated Incidents](/docs/v4/incidents/auto-generated) - How alerts create and update incidents automatically

--- a/src/routes/(docs)/docs/content/v4/maintenances/creating-managing.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/creating-managing.md
@@ -491,7 +491,7 @@ Add buffer time to your estimates:
 
 - Ensure BYDAY is set for weekly frequency
 - Check interval is positive number
-- Verify RRULE syntax (see [RRULE Patterns](/docs/maintenances/rrule-patterns))
+- Verify RRULE syntax (see [RRULE Patterns](/docs/v4/maintenances/rrule-patterns))
 
 **Problem:** Events not generated for recurring maintenance
 
@@ -511,6 +511,6 @@ Add buffer time to your estimates:
 
 ## Next Steps {#next-steps}
 
-- [Maintenance Events](/docs/maintenances/events) - Learn about event lifecycle and automatic transitions
-- [Maintenance Impact on Monitoring](/docs/maintenances/impact-on-monitoring) - How maintenances affect monitor status display
-- [RRULE Patterns](/docs/maintenances/rrule-patterns) - Advanced scheduling patterns and examples
+- [Maintenance Events](/docs/v4/maintenances/events) - Learn about event lifecycle and automatic transitions
+- [Maintenance Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring) - How maintenances affect monitor status display
+- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns) - Advanced scheduling patterns and examples

--- a/src/routes/(docs)/docs/content/v4/maintenances/events.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/events.md
@@ -179,63 +179,66 @@ Action: Override monitor statuses
 
 ```
 READY → ONGOING
-title: Maintenance Events
-description: How maintenance events are generated and shown to users
+Condition: current_time >= start_time AND current_time < end_time
+Executed by: Status update scheduler (runs every minute)
 ```
 
-A maintenance event is one occurrence of a maintenance window.
+#### COMPLETED {#completed-state}
 
-## Event generation {#event-generation}
+**When:** Current time is past end time, or an admin completes an ONGOING event early
 
-### One-time maintenance {#one-time-maintenance}
+**Meaning:**
 
-- Creates one event.
-- Triggered when maintenance is created.
+- Maintenance has finished
 - Monitor statuses restored to realtime values
+- Historical record
 
-### Recurring maintenance {#recurring-maintenance}
+**Displayed As:** "Completed"
 
-- Creates upcoming events from RRULE.
-- Scheduler refreshes upcoming occurrences.
-- Duplicate event start times are skipped.
+**Notification:** "Maintenance Completed" notification sent
 
-## Event statuses {#event-statuses}
+**Example:**
 
-- `SCHEDULED`
-- `READY`
-- `ONGOING`
-- `COMPLETED`
-- `CANCELLED`
-
-Status transitions are time-based and automatic.
+```
 Current Time: May 15, 4:05 PM
-
-## User-visible behavior {#user-visible-behavior}
-
+Event End: May 15, 4:00 PM
 Status: COMPLETED (finished 5 minutes ago)
-
-- Ongoing events affect monitor display according to impact settings.
-- Upcoming and past visibility depends on site/page event display settings.
-
+Action: Restore monitor statuses
 ```
-## Manual actions {#manual-actions}
+
 **Automatic Transition:**
-- You can cancel/delete events from maintenance management screens.
-- Edit the parent maintenance to regenerate future schedule behavior.
+
+```
+ONGOING → COMPLETED
+Condition: current_time >= end_time
+Executed by: Status update scheduler (runs every minute)
 ```
 
-## Related guides {#related-guides}
+**Manual Completion:**
 
-Condition: current_time >= end_time
+An ONGOING event can be completed early from the maintenance edit page or via the API (see [Completing an Event Early](#completing-events)). Its end time is moved to the moment it was completed, so the recorded window reflects what actually happened.
 
-- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing)
-- [Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring)
-- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns)
-  **Displayed As:** "Cancelled"
+#### CANCELLED {#cancelled-state}
 
-**Notification:** No automatic notification
+**When:** Manually cancelled by an admin (allowed for SCHEDULED, READY, and ONGOING events)
 
-**Manual Action:** User clicks delete/cancel on event
+**Meaning:**
+
+- The occurrence was called off — before or during its window
+- Monitor statuses are not (or no longer) overridden
+- Kept in history, explicitly marked as cancelled vs completed
+
+**Time Handling:**
+
+- Cancelled before start: the planned window is kept unchanged
+- Cancelled while ONGOING: the end time is moved to the moment of cancellation
+
+**Displayed As:** "Cancelled"
+
+**Notification:** "Maintenance Cancelled" notification sent (controlled by the same "ended" notification setting as completion)
+
+> [!NOTE]
+> COMPLETED and CANCELLED are terminal — an event cannot be moved out of them. For recurring maintenances, a cancelled occurrence is never regenerated, so cancelling is how you skip one occurrence while keeping the schedule.
 
 ## Automatic Status Transitions {#automatic-transitions}
 
@@ -323,8 +326,19 @@ When: At start time
 Subject: Maintenance Completed
 Body: "{title} has been completed"
 Monitors: List of affected monitors with impacts
-When: At end time
+When: At end time, or immediately when completed early
 ```
+
+**Cancelled (manual cancellation):**
+
+```
+Subject: Maintenance Cancelled
+Body: "{title} has been cancelled"
+Monitors: List of affected monitors with impacts
+When: Immediately when an admin cancels the event
+```
+
+Completed and Cancelled notifications share the same "ended" notification setting.
 
 ### Notification Channels {#notification-channels}
 
@@ -390,22 +404,35 @@ Users see events on the public status page:
 
 ## Managing Events Manually {#managing-events-manually}
 
+### Completing an Event Early {#completing-events}
+
+If the maintenance work finishes before the scheduled end:
+
+1. Find the ONGOING event on the maintenance edit page
+2. Click **Complete**
+3. Confirm
+
+The event moves to COMPLETED, its end time is set to the current time, monitor statuses return to realtime values, and the completion notification is sent.
+
+Via the API: `PATCH /api/v4/maintenances/{maintenance_id}/events/{event_id}` with body `{"status": "COMPLETED"}`.
+
 ### Cancelling Events {#cancelling-events}
 
 From the maintenance edit page:
 
-1. Find the event in the list
-2. Click the trash icon
-3. Confirm cancellation
-4. Event status changes to CANCELLED
+1. Find the event in the list (SCHEDULED, READY, or ONGOING)
+2. Click **Cancel**
+3. Confirm
+
+Via the API: `PATCH /api/v4/maintenances/{maintenance_id}/events/{event_id}` with body `{"status": "CANCELLED"}`.
 
 **When to Cancel:**
 
 - Maintenance no longer needed
-- Rescheduling to different time
-- Discovered conflict
+- Maintenance was aborted partway through
+- Skipping one occurrence of a recurring maintenance
 
-**Note:** Cancelled events remain in history but are not executed.
+**Note:** Cancelled events remain in history but are not executed. A cancelled occurrence of a recurring maintenance is never regenerated.
 
 ### Deleting Events {#deleting-events}
 
@@ -425,9 +452,9 @@ Events can be permanently deleted:
 
 **Best Practice:** Cancel rather than delete to preserve history.
 
-### Cannot Edit Events {#cannot-edit-events}
+### Editing Event Times {#cannot-edit-events}
 
-Individual events cannot be edited directly. To change event timing or duration:
+Individual event times cannot be edited from the dashboard. To change event timing or duration:
 
 1. Edit the parent maintenance
 2. Update start time, RRULE, or duration
@@ -437,7 +464,9 @@ Individual events cannot be edited directly. To change event timing or duration:
 
 - Future SCHEDULED events deleted
 - New events generated with updated settings
-- ONGOING/COMPLETED events preserved
+- ONGOING/COMPLETED/CANCELLED events preserved
+
+API consumers can edit a single event's window directly: `PATCH /api/v4/maintenances/{maintenance_id}/events/{event_id}` with both `start_date_time` and `end_date_time`. A request cannot combine time fields with a `status` transition.
 
 ## Event Retention {#event-retention}
 
@@ -472,7 +501,7 @@ During ONGOING events:
 - Realtime monitoring continues in background
 - Status page shows maintenance impact
 
-See [Maintenance Impact on Monitoring](/docs/maintenances/impact-on-monitoring) for details.
+See [Maintenance Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring) for details.
 
 ## Troubleshooting {#troubleshooting}
 
@@ -511,6 +540,6 @@ See [Maintenance Impact on Monitoring](/docs/maintenances/impact-on-monitoring) 
 
 ## Next Steps {#next-steps}
 
-- [Maintenance Impact on Monitoring](/docs/maintenances/impact-on-monitoring) - How events affect monitor status display
-- [RRULE Patterns](/docs/maintenances/rrule-patterns) - Advanced scheduling patterns for recurring maintenances
-- [Creating and Managing Maintenances](/docs/maintenances/creating-managing) - Learn how to create and edit maintenances
+- [Maintenance Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring) - How events affect monitor status display
+- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns) - Advanced scheduling patterns for recurring maintenances
+- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing) - Learn how to create and edit maintenances

--- a/src/routes/(docs)/docs/content/v4/maintenances/impact-on-monitoring.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/impact-on-monitoring.md
@@ -66,63 +66,79 @@ Displayed Status: MAINTENANCE
 
 **Example:**
 
+```
 Monitor: Database
 Realtime Status: UP (checks passing now)
 Incident: OPEN
 Monitor Impact: DOWN
 
 Displayed Status: DOWN
-title: Impact on Monitoring
-description: How maintenance events affect displayed monitor status
+```
+
 **Rationale:** Incident status takes precedence over current checks during active issues.
 
-During an **ONGOING** maintenance event, maintenance impact can override monitor status shown to users.
+**Note:** Maintenance status takes precedence over incident status. If both exist, maintenance wins.
 
-## Status precedence {#status-precedence}
+#### 3. Realtime Monitoring Data {#realtime-priority}
 
-Kener resolves status in this order (later overrides earlier):
+**When:** No maintenance or incident affecting this monitor
 
-`default status → realtime monitor result → incident impact → maintenance impact`
+**Display:** Show latest monitoring check result (UP, DOWN, DEGRADED)
 
-So maintenance has the highest effective priority when active.
+**Example:**
 
-## Impact values {#impact-values}
-
+```
 Monitor: Web Server
-Set per monitor in a maintenance:
+Latest Check: DOWN (connection timeout)
+No Maintenance: ✓
+No Incident: ✓
 
-- `MAINTENANCE` (recommended)
-- `DOWN`
-- `DEGRADED`
-- `UP`
+Displayed Status: DOWN
+```
 
-Choose the value that matches expected user impact during the window.
+#### 4. Default Monitor Status (Lowest Priority) {#default-priority}
 
-## Event lifecycle behavior {#event-lifecycle-behavior}
+**When:** No monitoring data exists yet
 
-- `SCHEDULED` / `READY`: no override yet
-- `ONGOING`: override active
-- `COMPLETED` / `CANCELLED`: override removed
+**Display:** Monitor's configured default status
 
-## Realtime monitoring still runs {#realtime-monitoring-still-runs}
+**Example:**
 
+```
 Monitor: New Service
-Even during maintenance, checks continue and data is recorded.
+No Checks Run: (just created)
 Default Status: UP
-Maintenance changes **displayed/effective** status, not monitor execution.
+
 Displayed Status: UP
+```
 
-## Practical guidance {#practical-guidance}
+## Monitor Impact Levels {#impact-levels}
 
-- Prefer `MAINTENANCE` for planned work communication.
-- Use `DOWN` only when service is expected to be unavailable.
-- Avoid overlapping maintenances on the same monitor.
+When configuring a maintenance, you specify the impact for each affected monitor:
 
-## Related guides {#related-guides}
+### MAINTENANCE {#maintenance-impact}
 
-- [Maintenances Overview](/docs/v4/maintenances/overview)
-- [Maintenance Events](/docs/v4/maintenances/events)
-- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing)
+**Visual:** Orange/yellow, wrench icon
+
+**Meaning:** Service is under planned maintenance
+
+**When to Use:**
+
+- General maintenance work
+- Service available but under maintenance
+- Default/recommended choice
+
+**User Interpretation:** "Service may be affected due to planned work"
+
+**Example:**
+
+```yaml
+Monitor: API Server
+Impact: MAINTENANCE
+During Event: Shows orange "Under Maintenance"
+```
+
+### DOWN {#down-impact}
 
 **Visual:** Red, X icon
 
@@ -514,6 +530,6 @@ Description: "Database will be completely offline during this window"
 
 ## Next Steps {#next-steps}
 
-- [Maintenance Events](/docs/maintenances/events) - Learn about event lifecycle and status transitions
-- [Creating and Managing Maintenances](/docs/maintenances/creating-managing) - How to configure monitor impacts
-- [RRULE Patterns](/docs/maintenances/rrule-patterns) - Advanced scheduling patterns
+- [Maintenance Events](/docs/v4/maintenances/events) - Learn about event lifecycle and status transitions
+- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing) - How to configure monitor impacts
+- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns) - Advanced scheduling patterns

--- a/src/routes/(docs)/docs/content/v4/maintenances/overview.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/overview.md
@@ -90,75 +90,92 @@ Kener uses the industry-standard [iCalendar RRULE](http://www.kanzaki.com/docs/i
 FREQ=frequency;[INTERVAL=n;][BYDAY=days;][COUNT=n;]
 ```
 
-title: Maintenances Overview
-description: Plan and communicate scheduled service work with one-time or recurring maintenance windows
-| Pattern | RRULE | Meaning |
+**Example Patterns:**
+
+| Pattern                 | RRULE                              | Meaning               |
 | :---------------------- | :--------------------------------- | :-------------------- |
-Maintenances are planned service windows. Use them to communicate expected downtime or degradation before work starts.
-| Every 2 weeks on Monday | `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO` | Bi-weekly on Monday |
+| Every Sunday            | `FREQ=WEEKLY;BYDAY=SU`             | Weekly on Sunday      |
+| Every 2 weeks on Monday | `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO`  | Bi-weekly on Monday   |
+| Every day               | `FREQ=DAILY`                       | Daily                 |
+| First of each month     | `FREQ=MONTHLY;BYMONTHDAY=1`        | Monthly on day 1      |
+| Weekdays only           | `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` | Monday through Friday |
 
-## What a maintenance includes {#what-a-maintenance-includes}
+Learn more in [RRULE Patterns](/docs/v4/maintenances/rrule-patterns).
 
-| First of each month | `FREQ=MONTHLY;BYMONTHDAY=1` | Monthly on day 1 |
-Each maintenance has:
+## Maintenance Events {#maintenance-events}
 
-- Title and optional description
-- Start time
-- Duration
-- Schedule (`one-time` or recurring `RRULE`)
-- Affected monitors with impact
-- Status (`ACTIVE` / `INACTIVE`)
+When you create a maintenance, Kener automatically generates **maintenance events** based on the RRULE:
+
 - **One-Time Maintenances:** Generate 1 event at creation time
+- **Recurring Maintenances:** Generate events for the next 7 days, refreshed hourly
 
-## Maintenance vs incident {#maintenance-vs-incident}
+Each event represents a single occurrence of the maintenance window and tracks:
 
-| Aspect     | Maintenance                 | Incident                      |
-| ---------- | --------------------------- | ----------------------------- |
-| Nature     | Planned                     | Unplanned                     |
-| Timing     | Scheduled in advance        | Created when issue occurs     |
-| Recurrence | Can recur with RRULE        | Typically one-off             |
-| Purpose    | Communicate expected impact | Communicate active disruption |
+- Start date/time
+- End date/time (calculated from duration)
+- Status (SCHEDULED → READY → ONGOING → COMPLETED, or CANCELLED)
 
-## One-time vs recurring {#one-time-vs-recurring}
+Events are covered in detail in [Maintenance Events](/docs/v4/maintenances/events).
+
+## Maintenance Status {#maintenance-status}
 
 Maintenances have two levels of status:
 
-- **One-time**: single event (`FREQ=MINUTELY;COUNT=1`)
-- **Recurring**: repeated events from RRULE (for example weekly/monthly patterns)
-
 ### Maintenance-Level Status {#maintenance-level-status}
 
-## Monitor impact during maintenance {#monitor-impact-during-maintenance}
-
 Controls whether the maintenance is active in the system:
-Set per-monitor impact for the maintenance window:
 
 - **ACTIVE** - Maintenance is enabled and will generate events
-- `MAINTENANCE` (recommended for planned work)
-- `DOWN`
-- `DEGRADED`
-- `UP` (rare)
+- **INACTIVE** - Maintenance is disabled and will not affect monitors
 
-When an event is ongoing, this impact can override realtime status shown to users.
+**Note:** Changing a maintenance to INACTIVE does not cancel already scheduled events. You must manually cancel or delete those events.
 
-## Event lifecycle {#event-lifecycle}
+### Event-Level Status {#event-level-status}
 
-Each occurrence is a maintenance event that moves through statuses:
+Tracks the lifecycle of each individual maintenance occurrence:
 
-- `SCHEDULED`
-- `READY` (starting soon)
-- `ONGOING`
-- `COMPLETED`
-- `CANCELLED`
+- **SCHEDULED** - Event created, more than 60 minutes away
 - **READY** - Event starts within 60 minutes (notification sent)
-
-## Related guides {#related-guides}
-
+- **ONGOING** - Event is currently in progress
 - **COMPLETED** - Event has finished
-- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing)
-- [Maintenance Events](/docs/v4/maintenances/events)
-- [Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring)
-- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns)
+- **CANCELLED** - Event was manually cancelled
+
+Events automatically transition through states based on the current time. An ONGOING event can also be completed early, and SCHEDULED/READY/ONGOING events can be cancelled — see [Managing Events Manually](/docs/v4/maintenances/events#managing-events-manually).
+
+## Affected Monitors {#affected-monitors}
+
+Each maintenance specifies which monitors are affected and their expected status during the maintenance window:
+
+**Monitor Impact Options:**
+
+- **MAINTENANCE** - Show as under maintenance (recommended)
+- **DOWN** - Show as completely unavailable
+- **DEGRADED** - Show as partially available
+- **UP** - Show as operational (rare, for non-disruptive maintenance)
+
+When a maintenance event is ONGOING, the specified impact **overrides** the monitor's realtime status on the status page.
+
+Learn more in [Maintenance Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring).
+
+## Public Visibility {#public-visibility}
+
+Maintenances are visible to users on your public status page:
+
+### Upcoming Maintenances {#upcoming-maintenances}
+
+- Shown on the home page
+- Displays upcoming events (configurable days ahead)
+- Shows affected monitors and maintenance window
+
+### Ongoing Maintenances {#ongoing-maintenances}
+
+- Prominently displayed during the maintenance window
+- Affected monitors show maintenance status
+- Duration and progress indicators
+
+### Past Maintenances {#past-maintenances}
+
+- Listed on the events/history page
 - Shows completed maintenance events
 - Configurable retention period
 
@@ -214,10 +231,15 @@ When maintenance events change status, notifications can be sent:
 - "Maintenance in progress" notification
 - Confirms maintenance has begun
 
-**COMPLETED (when finished):**
+**COMPLETED (when finished, or completed early):**
 
 - "Maintenance completed" notification
 - Confirms services are back to normal
+
+**CANCELLED (when manually cancelled):**
+
+- "Maintenance cancelled" notification
+- Shares the same "ended" notification setting as completion
 
 Notifications respect your subscription configuration and trigger settings.
 
@@ -255,7 +277,7 @@ Impact: DOWN
 
 ## Next Steps {#next-steps}
 
-- [Creating and Managing Maintenances](/docs/maintenances/creating-managing) - Learn how to create and configure maintenances
-- [Maintenance Events](/docs/maintenances/events) - Understand event lifecycle and management
-- [Maintenance Impact on Monitoring](/docs/maintenances/impact-on-monitoring) - How maintenances affect status display
-- [RRULE Patterns](/docs/maintenances/rrule-patterns) - Advanced scheduling patterns and examples
+- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing) - Learn how to create and configure maintenances
+- [Maintenance Events](/docs/v4/maintenances/events) - Understand event lifecycle and management
+- [Maintenance Impact on Monitoring](/docs/v4/maintenances/impact-on-monitoring) - How maintenances affect status display
+- [RRULE Patterns](/docs/v4/maintenances/rrule-patterns) - Advanced scheduling patterns and examples

--- a/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
@@ -18,71 +18,63 @@ FREQ=frequency[;INTERVAL=n][;BYDAY=days][;BYMONTHDAY=day][;COUNT=n][;UNTIL=date]
 ### Supported Components {#supported-components}
 
 **FREQ** (Required)
-title: RRULE Patterns
-description: Common RRULE patterns for recurring maintenance schedules
 
+- `DAILY` - Daily recurrence
 - `WEEKLY` - Weekly recurrence
 - `MONTHLY` - Monthly recurrence
-  Kener uses iCalendar RRULE strings to schedule recurring maintenances.
-  **INTERVAL** (Optional)
 
-## RRULE basics {#rrule-basics}
+**INTERVAL** (Optional)
 
 - Default: 1
-  Format:
+- Integer value: 2 = every other, 3 = every third, etc.
 
-```text
-FREQ=...;[INTERVAL=n];[BYDAY=...];[BYMONTHDAY=...]
-```
+**BYDAY** (Optional, for WEEKLY)
 
-For one-time maintenances, Kener uses:
+- Day codes: `MO`, `TU`, `WE`, `TH`, `FR`, `SA`, `SU`
+- Multiple days: `MO,WE,FR`
+
 **BYMONTHDAY** (Optional, for MONTHLY)
 
-```text
-FREQ=MINUTELY;COUNT=1
-```
-
 - Day of month: 1-31
+- Example: `BYMONTHDAY=1` (first of month)
 
-## Common patterns {#common-patterns}
+**COUNT** (For one-time only)
 
-| Use case                | RRULE                              |
-| ----------------------- | ---------------------------------- |
-| Every day               | `FREQ=DAILY`                       |
-| Every Sunday            | `FREQ=WEEKLY;BYDAY=SU`             |
-| Weekdays                | `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` |
-| Every 2 weeks on Monday | `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO`  |
-| First day of each month | `FREQ=MONTHLY;BYMONTHDAY=1`        |
-
+- `COUNT=1` - Single occurrence
 - Used for one-time maintenances
-
-## Day codes {#day-codes}
 
 ## Common Patterns {#common-patterns}
 
-- `MO` Monday
-- `TU` Tuesday
-- `WE` Wednesday
-- `TH` Thursday
-- `FR` Friday
-- `SA` Saturday
-- `SU` Sunday
+### Daily Patterns {#daily-patterns}
 
-## Tips {#tips}
+#### Every Day {#every-day}
 
-- Use simple, readable patterns.
-- Verify next occurrences in the maintenance UI preview.
-- Avoid overlapping schedules for the same monitor.
-  **Description:** Maintenance occurs every single day at the configured time
+**RRULE:** `FREQ=DAILY`
 
-## Related guides {#related-guides}
+**Description:** Maintenance occurs every single day at the configured time
 
 **Use Case:** Daily backup windows, nightly cleanup tasks
 
-- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing)
-- [Maintenance Events](/docs/v4/maintenances/events)
-- [Maintenances Overview](/docs/v4/maintenances/overview)
-  **Description:** Maintenance occurs every 2 days
+**Example:**
+
+```
+Title: Nightly Database Backup
+Start: 2:00 AM (any day)
+RRULE: FREQ=DAILY
+Duration: 30 minutes
+
+Occurrences:
+- Today at 2:00 AM
+- Tomorrow at 2:00 AM
+- Day after at 2:00 AM
+- Continues daily...
+```
+
+#### Every Other Day {#every-other-day}
+
+**RRULE:** `FREQ=DAILY;INTERVAL=2`
+
+**Description:** Maintenance occurs every 2 days
 
 **Use Case:** Bi-daily tasks
 
@@ -625,6 +617,6 @@ Description: |
 
 ## Next Steps {#next-steps}
 
-- [Creating and Managing Maintenances](/docs/maintenances/creating-managing) - Apply these patterns in the dashboard
-- [Maintenance Events](/docs/maintenances/events) - Understand how RRULE generates events
-- [Maintenance Overview](/docs/maintenances/overview) - Learn maintenance fundamentals
+- [Creating and Managing Maintenances](/docs/v4/maintenances/creating-managing) - Apply these patterns in the dashboard
+- [Maintenance Events](/docs/v4/maintenances/events) - Understand how RRULE generates events
+- [Maintenance Overview](/docs/v4/maintenances/overview) - Learn maintenance fundamentals

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -74,6 +74,7 @@ import {
   GetMaintenanceEventById,
   GetMaintenanceEventsByMaintenanceId,
   UpdateMaintenanceEvent,
+  UpdateMaintenanceEventStatus,
   DeleteMaintenanceEvent,
   AddMonitorToMaintenance,
   RemoveMonitorFromMaintenance,
@@ -443,6 +444,8 @@ export async function POST({ request, cookies }) {
       const { id, ...updateData } = data;
       await UpdateMaintenanceEvent(id, updateData);
       resp = { success: true };
+    } else if (action == "updateMaintenanceEventStatus") {
+      resp = await UpdateMaintenanceEventStatus(data.id, data.status);
     } else if (action == "deleteMaintenanceEvent") {
       await DeleteMaintenanceEvent(data.id);
       resp = { success: true };

--- a/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
@@ -8,6 +8,7 @@
   import { Checkbox } from "$lib/components/ui/checkbox/index.js";
   import { Switch } from "$lib/components/ui/switch/index.js";
   import * as Card from "$lib/components/ui/card/index.js";
+  import * as Dialog from "$lib/components/ui/dialog/index.js";
   import * as Select from "$lib/components/ui/select/index.js";
   import * as Breadcrumb from "$lib/components/ui/breadcrumb/index.js";
   import * as RadioGroup from "$lib/components/ui/radio-group/index.js";
@@ -21,8 +22,10 @@
   import ClockIcon from "@lucide/svelte/icons/clock";
   import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
   import PlayCircleIcon from "@lucide/svelte/icons/play-circle";
+  import XCircleIcon from "@lucide/svelte/icons/x-circle";
   import type { PageProps } from "./$types";
   import type { MonitorRecord } from "$lib/server/types/db.js";
+  import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { toast } from "svelte-sonner";
   import { format, formatDistanceToNow, isPast, isFuture, isWithinInterval, addDays } from "date-fns";
@@ -107,6 +110,42 @@
   // Events for existing maintenance
   let events = $state<MaintenanceEvent[]>([]);
   let loadingEvents = $state(false);
+
+  // Event status confirmation dialog
+  type EventActionStatus = "COMPLETED" | "CANCELLED";
+  let eventStatusDialogOpen = $state(false);
+  let updatingEventStatus = $state(false);
+  let pendingEventStatusUpdate = $state<{ eventId: number; status: EventActionStatus } | null>(null);
+
+  function openEventStatusDialog(eventId: number, status: EventActionStatus) {
+    pendingEventStatusUpdate = { eventId, status };
+    eventStatusDialogOpen = true;
+  }
+
+  function closeEventStatusDialog() {
+    eventStatusDialogOpen = false;
+    pendingEventStatusUpdate = null;
+  }
+
+  const eventStatusDialogCopy = $derived.by(() => {
+    if (pendingEventStatusUpdate?.status === "COMPLETED") {
+      return {
+        title: "Complete Maintenance Event",
+        description: "This will mark the event as completed and set its end time to the current time.",
+        confirmLabel: "Complete Event",
+        cancelLabel: "Keep Ongoing",
+        confirmVariant: "default" as const
+      };
+    }
+
+    return {
+      title: "Cancel Maintenance Event",
+      description: "This will mark the event as cancelled and remove it from active scheduling.",
+      confirmLabel: "Cancel Event",
+      cancelLabel: "Keep Scheduled",
+      confirmVariant: "destructive" as const
+    };
+  });
 
   // Convert timestamp to local datetime string for input
   function timestampToLocalDatetime(ts: number): string {
@@ -206,10 +245,8 @@
   // Fetch maintenance data
   async function fetchMaintenance() {
     if (isNew) {
-      // Set default start time
-      const now = new Date();
-      now.setMinutes(now.getMinutes() + 60);
-      startDateTimeLocal = timestampToLocalDatetime(Math.floor(now.getTime() / 1000));
+      // Set default start time (1 hour from now)
+      startDateTimeLocal = timestampToLocalDatetime(Math.floor(Date.now() / 1000) + 3600);
       loading = false;
       return;
     }
@@ -409,14 +446,60 @@
     }
   }
 
+  // Manually transition an event to COMPLETED or CANCELLED
+  async function updateEventStatus(eventId: number, status: "COMPLETED" | "CANCELLED") {
+    updatingEventStatus = true;
+
+    try {
+      const response = await fetch(clientResolver(resolve, "/manage/api"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "updateMaintenanceEventStatus", data: { id: eventId, status } })
+      });
+      const result = await response.json();
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(status === "COMPLETED" ? "Event completed" : "Event cancelled");
+        await fetchEvents();
+        closeEventStatusDialog();
+      }
+    } catch {
+      toast.error("Failed to update event status");
+    } finally {
+      updatingEventStatus = false;
+    }
+  }
+
+  async function confirmEventStatusUpdate() {
+    if (!pendingEventStatusUpdate) return;
+    await updateEventStatus(pendingEventStatusUpdate.eventId, pendingEventStatusUpdate.status);
+  }
+
   // Compute event display status based on current time
   interface EventDisplayStatus {
     label: string;
     variant: "default" | "secondary" | "destructive" | "outline";
-    icon: "clock" | "play" | "check";
+    icon: "clock" | "play" | "check" | "x";
   }
 
   function getEventDisplayStatus(event: MaintenanceEvent): EventDisplayStatus {
+    // Terminal statuses no longer follow time — the stored status wins
+    if (event.status === "CANCELLED") {
+      return {
+        label: "Cancelled",
+        variant: "destructive",
+        icon: "x"
+      };
+    }
+    if (event.status === "COMPLETED") {
+      return {
+        label: "Completed",
+        variant: "secondary",
+        icon: "check"
+      };
+    }
+
     const now = new Date();
     const startDate = new Date(event.start_date_time * 1000);
     const endDate = new Date(event.end_date_time * 1000);
@@ -478,7 +561,7 @@
     return monitor?.name || tag;
   }
 
-  $effect(() => {
+  onMount(() => {
     fetchMaintenance();
     fetchAvailableMonitors();
   });
@@ -665,7 +748,7 @@
                 <div class="flex flex-col gap-2">
                   <Label class="text-muted-foreground text-xs">Quick Patterns:</Label>
                   <div class="flex flex-wrap gap-2">
-                    {#each sampleRrules as sample}
+                    {#each sampleRrules as sample (sample.value)}
                       <Button
                         variant={customRrule === sample.value ? "default" : "outline"}
                         size="sm"
@@ -683,7 +766,7 @@
                 <div class="bg-background rounded-md border p-3">
                   <Label class="text-muted-foreground text-xs">Upcoming Occurrences:</Label>
                   <ul class="mt-2 space-y-1 text-sm">
-                    {#each previewDates as date}
+                    {#each previewDates as date (date)}
                       <li class="flex items-center gap-2">
                         <CalendarIcon class="text-muted-foreground size-3" />
                         {date}
@@ -704,7 +787,7 @@
           <div class="rounded-md border p-3">
             <Label class="text-muted-foreground mb-2 block text-xs">Select monitors to add:</Label>
             <div class="grid max-h-32 grid-cols-2 gap-2 overflow-y-auto">
-              {#each availableMonitors as monitor}
+              {#each availableMonitors as monitor (monitor.tag)}
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id="monitor-{monitor.tag}"
@@ -727,7 +810,7 @@
             <div class="rounded-md border p-3">
               <Label class="text-muted-foreground mb-2 block text-xs">Monitor status during maintenance:</Label>
               <div class="space-y-2">
-                {#each selectedMonitors as selectedMonitor, index}
+                {#each selectedMonitors as selectedMonitor, index (selectedMonitor.tag)}
                   {@const currentStatus = selectedMonitor.status}
                   <div class="bg-muted/30 flex items-center justify-between gap-3 rounded border p-2">
                     <span class="text-sm font-medium">{getMonitorName(selectedMonitor.tag)}</span>
@@ -822,7 +905,7 @@
             </p>
           {:else}
             <div class="space-y-3">
-              {#each events as event}
+              {#each events as event (event.id)}
                 {@const displayStatus = getEventDisplayStatus(event)}
                 <div class="flex items-center justify-between rounded-md border p-4">
                   <div class="flex items-center gap-3">
@@ -831,6 +914,8 @@
                         <PlayCircleIcon class="text-primary size-4" />
                       {:else if displayStatus.icon === "check"}
                         <CheckCircleIcon class="text-muted-foreground size-4" />
+                      {:else if displayStatus.icon === "x"}
+                        <XCircleIcon class="text-muted-foreground size-4" />
                       {:else}
                         <ClockIcon class="text-muted-foreground size-4" />
                       {/if}
@@ -846,9 +931,23 @@
                       </p>
                     </div>
                   </div>
-                  <Button variant="ghost" size="icon" onclick={() => deleteEvent(event.id)}>
-                    <TrashIcon class="size-4" />
-                  </Button>
+                  <div class="flex items-center gap-2">
+                    {#if event.status === "ONGOING"}
+                      <Button variant="outline" size="sm" onclick={() => openEventStatusDialog(event.id, "COMPLETED")}>
+                        <CheckCircleIcon class="size-4" />
+                        Complete
+                      </Button>
+                    {/if}
+                    {#if event.status === "SCHEDULED" || event.status === "READY" || event.status === "ONGOING"}
+                      <Button variant="outline" size="sm" onclick={() => openEventStatusDialog(event.id, "CANCELLED")}>
+                        <XCircleIcon class="size-4" />
+                        Cancel
+                      </Button>
+                    {/if}
+                    <Button variant="ghost" size="icon" onclick={() => deleteEvent(event.id)}>
+                      <TrashIcon class="size-4" />
+                    </Button>
+                  </div>
                 </div>
               {/each}
             </div>
@@ -858,3 +957,27 @@
     {/if}
   {/if}
 </div>
+
+<Dialog.Root bind:open={eventStatusDialogOpen}>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title>{eventStatusDialogCopy.title}</Dialog.Title>
+      <Dialog.Description>{eventStatusDialogCopy.description}</Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Button variant="outline" onclick={closeEventStatusDialog} disabled={updatingEventStatus}>
+        {eventStatusDialogCopy.cancelLabel}
+      </Button>
+      <Button
+        variant={eventStatusDialogCopy.confirmVariant}
+        onclick={confirmEventStatusUpdate}
+        disabled={updatingEventStatus || !pendingEventStatusUpdate}
+      >
+        {#if updatingEventStatus}
+          <Loader class="size-4 animate-spin" />
+        {/if}
+        {eventStatusDialogCopy.confirmLabel}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/static/api-references/v4.json
+++ b/static/api-references/v4.json
@@ -1514,7 +1514,8 @@
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           }
-        }
+        },
+        "description": "Either edit the event window (start_date_time and end_date_time) or transition its status (COMPLETED or CANCELLED). The two modes cannot be combined in one request."
       },
       "delete": {
         "tags": ["Maintenance Events"],
@@ -2360,18 +2361,37 @@
         ]
       },
       "UpdateMaintenanceEventRequest": {
-        "type": "object",
-        "required": ["start_date_time", "end_date_time"],
-        "properties": {
-          "start_date_time": {
-            "type": "integer"
+        "description": "Two mutually exclusive modes: edit the event window (both start_date_time and end_date_time required), or transition the event status (status alone). Combining status with time fields returns 400.",
+        "oneOf": [
+          {
+            "title": "Window edit",
+            "type": "object",
+            "required": ["start_date_time", "end_date_time"],
+            "properties": {
+              "start_date_time": {
+                "type": "integer"
+              },
+              "end_date_time": {
+                "type": "integer",
+                "description": "Must be greater than start_date_time"
+              }
+            },
+            "additionalProperties": false
           },
-          "end_date_time": {
-            "type": "integer",
-            "description": "Must be greater than start_date_time"
+          {
+            "title": "Status transition",
+            "type": "object",
+            "required": ["status"],
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["COMPLETED", "CANCELLED"],
+                "description": "Allowed transitions: ONGOING to COMPLETED; SCHEDULED, READY or ONGOING to CANCELLED. Both target statuses are terminal. Transitioning an ONGOING event moves its end_date_time to the moment of the transition; cancelling an event that has not started keeps its planned window. Invalid transitions return 400."
+              }
+            },
+            "additionalProperties": false
           }
-        },
-        "additionalProperties": false
+        ]
       },
       "PageSettings": {
         "type": "object",


### PR DESCRIPTION
… occurrences

- Introduce functionality to manually complete or cancel ongoing maintenance events.
- Update event status to COMPLETED or CANCELLED, adjusting end_date_time accordingly.
- Ensure terminal statuses prevent further modifications and notify subscribers of changes.
- Revise API to support status transitions alongside window edits, enforcing mutual exclusivity.
- Document behavior and consequences of manual transitions in ADR.

implements #722 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to manually complete or cancel individual maintenance events with confirmation workflow
  * New event action buttons (Complete/Cancel) in the maintenance management interface

* **Documentation**
  * Substantially updated maintenance, incidents, and event documentation with clearer lifecycle guidance and workflows
  * Added detailed information on manual event management, cancellation behavior, and notification handling
  * Corrected documentation navigation links for v4 structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->