### PR TITLE
Render maintenance descriptions as sanitized HTML on list views

### DIFF
--- a/src/lib/components/MaintenanceItem.svelte
+++ b/src/lib/components/MaintenanceItem.svelte
@@ -12,6 +12,8 @@
   import clientResolver from "$lib/client/resolver.js";
   import { GetInitials } from "$lib/clientTools.js";
   import type { MaintenanceEventsMonitorList } from "$lib/server/types/db";
+  import { SveltePurify } from "@humanspeak/svelte-purify";
+  import mdToHTML from "$lib/marked";
   import { page } from "$app/state";
 
   interface Props {
@@ -42,9 +44,11 @@
     </div>
 
     {#if maintenance.description}
-      <p class="text-muted-foreground mt-1 text-sm">
-        {maintenance.description}
-      </p>
+      <div
+        class="prose prose-sm dark:prose-invert text-muted-foreground mt-1 max-w-none min-w-0 overflow-x-auto text-sm wrap-break-word"
+      >
+        <SveltePurify html={mdToHTML(maintenance.description)} />
+      </div>
     {/if}
 
     {#if maintenance.monitors && maintenance.monitors.length > 0 && !hideMonitors}


### PR DESCRIPTION
Fixes #713

Maintenance descriptions rendered as plain text in `MaintenanceItem`, so HTML tags and extra line breaks showed literally on the home page, while the maintenance detail page rendered them correctly.

This switches the list card to the same pattern already used by the detail page and incident comments: `SveltePurify` + `mdToHTML` inside a `prose prose-sm dark:prose-invert` wrapper. Sanitization is kept (no bare `@html`) since descriptions render to anonymous visitors. The single component fix covers all surfaces that use it: home page, custom pages, monitor pages, events pages, and embeds.

Verified locally with an HTML-rich description (`<b>`, `<br>`, `<ul>`): renders identically on the home page and detail page in light and dark mode, `svelte-check` passes, and an injected `<script>` tag is stripped by the sanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance descriptions now support formatted content and are rendered as HTML instead of plain text, enabling richer display options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->