### PR TITLE
perf: add covering index for monitor-bars status aggregation

### DIFF
--- a/migrations/20260617120000_add_monitoring_data_covering_index.ts
+++ b/migrations/20260617120000_add_monitoring_data_covering_index.ts
@@ -1,0 +1,28 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  // Covering index for the grouped status-count aggregation used by the
+  // monitor-bars dashboard endpoint. The query filters by
+  // (monitor_tag, timestamp range) and reads status + latency for every row.
+  // Including status and latency in the index lets the database satisfy the
+  // query from the index alone, avoiding a heap lookup per matched row.
+  try {
+    await knex.schema.alterTable("monitoring_data", (table) => {
+      table.index(
+        ["monitor_tag", "timestamp", "status", "latency"],
+        "idx_monitoring_data_monitor_tag_timestamp_status_latency",
+      );
+    });
+  } catch (_e) {
+    /* index already exists */
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("monitoring_data", (table) => {
+    table.dropIndex(
+      ["monitor_tag", "timestamp", "status", "latency"],
+      "idx_monitoring_data_monitor_tag_timestamp_status_latency",
+    );
+  });
+}


### PR DESCRIPTION
## Problem

The `/dashboard-apis/monitor-bars` endpoint aggregates daily status counts from `monitoring_data`, grouped by monitor and day bucket. For a status page tracking many monitors over a 90-day window this scans a large number of rows and can take multiple seconds on a cold cache.

The aggregation (`getStatusCountsByIntervalGroupedByMonitor`) filters by `monitor_tag IN (...) AND timestamp >= ? AND timestamp < ?` and reads `status` and `latency` for every matched row. The primary key `(monitor_tag, timestamp)` covers the filter but not `status`/`latency`, so the database performs a table (heap) lookup for each matched row.

## Change

Add a covering index `(monitor_tag, timestamp, status, latency)` so the aggregation can be served entirely from the index, eliminating the per-row heap lookups. Follows the existing idempotent migration pattern in`20260216095021_index_monitoring_data.ts` and is cross-database via knex's `table.index`.

## Measurements

Production SQLite instance (~1.1M rows, 41 tags, 90-day window):

| | Plan | Real | Sys (I/O) |
|---|---|---|---|
| Before | `SEARCH ... USING INDEX sqlite_autoindex (monitor_tag, timestamp)` | ~3.5s | ~1.16s |
| After  | `SEARCH ... USING COVERING INDEX` | ~1.7s | ~0.12s |

## Notes

- Adds roughly 40–50MB to a ~190MB database (index storage).
- Migration is reversible (`down` drops the index) and idempotent.
