### PR TITLE
feat(api): expose external_url in monitors POST and PATCH endpoints

### DIFF
--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -121,6 +121,7 @@ export interface CreateMonitorRequest {
   is_hidden?: string;
   confirmation_threshold?: number | null;
   monitor_settings_json?: MonitorSettings | null;
+  external_url?: string | null;
 }
 
 export interface CreateMonitorResponse {
@@ -141,6 +142,7 @@ export interface UpdateMonitorRequest {
   is_hidden?: string;
   confirmation_threshold?: number | null;
   monitor_settings_json?: MonitorSettings | null;
+  external_url?: string | null;
 }
 
 export interface UpdateMonitorResponse {

--- a/src/routes/(api)/api/v4/monitors/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/+server.ts
@@ -130,6 +130,7 @@ export const POST: RequestHandler = async ({ request }) => {
     is_hidden: body.is_hidden ?? "NO",
     confirmation_threshold: confirmationThreshold,
     monitor_settings_json: body.monitor_settings_json ? JSON.stringify(body.monitor_settings_json) : null,
+    external_url: body.external_url ?? null,
   };
 
   await db.insertMonitor(monitorData);

--- a/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
@@ -79,6 +79,7 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
   updateData.monitor_type = body.monitor_type !== undefined ? body.monitor_type : existingMonitor.monitor_type;
 
   updateData.is_hidden = body.is_hidden !== undefined ? body.is_hidden : existingMonitor.is_hidden;
+  updateData.external_url = body.external_url !== undefined ? body.external_url : existingMonitor.external_url;
 
   if (body.confirmation_threshold === null) {
     // Explicit null resets the grace period to the default (1 = off); undefined keeps the existing value.

--- a/static/api-references/v4.json
+++ b/static/api-references/v4.json
@@ -1834,6 +1834,9 @@
           "monitor_settings_json": {
             "type": "object",
             "additionalProperties": true
+          },
+          "external_url": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -1887,6 +1890,16 @@
               {
                 "type": "object",
                 "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "external_url": {
+            "oneOf": [
+              {
+                "type": "string"
               },
               {
                 "type": "null"

--- a/static/api-references/v4.json
+++ b/static/api-references/v4.json
@@ -1836,7 +1836,14 @@
             "additionalProperties": true
           },
           "external_url": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary

- `external_url` was already stored in the DB, mapped through the controller, and present on `MonitorRecordTyped` — but missing from `CreateMonitorRequest` and `UpdateMonitorRequest`, so the API silently dropped it on create/update
- Added `external_url` to both request type interfaces in `src/lib/types/api.ts`
- Passed `external_url` through in the POST handler (`monitorData`) and PATCH handler (`updateData`)
- Added `external_url` to both schemas in `static/api-references/v4.json`

## Changes

| File | Change |
|---|---|
| `src/lib/types/api.ts` | `external_url?: string \| null` on `CreateMonitorRequest` and `UpdateMonitorRequest` |
| `src/routes/(api)/api/v4/monitors/+server.ts` | `external_url: body.external_url ?? null` in POST `monitorData` |
| `src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts` | `external_url` passthrough in PATCH `updateData` |
| `static/api-references/v4.json` | `external_url` field in both request schemas |

## Test plan

- [x] `POST /api/v4/monitors` with `external_url` → field present in response
- [x] `PATCH /api/v4/monitors/:tag` with new `external_url` → field updated in response
- [x] `PATCH /api/v4/monitors/:tag` with `external_url: null` → field nulled out
- [x] `GET /api/v4/monitors/:tag` → persisted value returned correctly
- [x] `npm run check` → 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitor create and update requests now support an optional `external_url` value.
* **Documentation**
  * Updated the v4 API reference to document `external_url` for monitor create/update, including support for `null`.
* **Bug Fixes**
  * When updating a monitor, the existing `external_url` is preserved if no new value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->