### PR TITLE
fix: notify subscribers when incident comments are posted

### DIFF
--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -17,6 +17,11 @@ import type {
 } from "../types/db.js";
 import GC from "../../global-constants.js";
 import { getUnixTime, differenceInSeconds } from "date-fns";
+import { siteDataToVariables } from "../notification/notification_utils.js";
+import { GetAllSiteData } from "./controller.js";
+import subscriberQueue from "../queues/subscriberQueue.js";
+import mdToHTML from "../../marked.js";
+import type { SubscriptionVariableMap } from "../notification/types.js";
 
 interface IncidentsDashboardInput {
   page: number;
@@ -322,11 +327,6 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
 
   let newIncident = await db.createIncident(incident);
 
-  //we need to
-  // queueController.PushDataToQueue(newIncident.id, "createIncident", {
-  //   message: `${incident.incident_type} Created`,
-  //   ...incident,
-  // });
   return {
     incident_id: newIncident.id,
   };
@@ -353,25 +353,6 @@ export const UpdateIncident = async (incident_id: number, data: IncidentUpdateIn
     end_date_time: data.end_date_time || incidentExists.end_date_time,
     is_global: data.is_global !== undefined ? data.is_global : incidentExists.is_global,
   };
-
-  //check if updateObject same as incidentExists
-  // if (
-  //   JSON.stringify(updateObject) ===
-  //   JSON.stringify({
-  //     id: incidentExists.id,
-  //     title: incidentExists.title,
-  //     start_date_time: incidentExists.start_date_time,
-  //     status: incidentExists.status,
-  //     state: incidentExists.state,
-  //     end_date_time: incidentExists.end_date_time,
-  //   })
-  // ) {
-  //   queueController.PushDataToQueue(incident_id, "updateIncident", {
-  //     message: `${incidentExists.incident_type} has been updated to ${updateObject.state}`,
-  //     incident_type: incidentExists.incident_type,
-  //     title: incidentExists.title,
-  //   });
-  // }
 
   return await db.updateIncident(updateObject as IncidentRecord);
 };
@@ -402,11 +383,6 @@ export const AddIncidentMonitor = async (
     throw new Error(`Incident with id ${incident_id} does not exist`);
   }
 
-  // queueController.PushDataToQueue(incident_id, "insertIncidentMonitor", {
-  //   title: incidentExists.title,
-  //   message: `Monitor ${monitor_tag} added to ${incidentExists.incident_type}. Impact is ${monitor_impact}`,
-  //   incident_type: incidentExists.incident_type,
-  // });
   return await db.insertIncidentMonitorWithMerge({
     incident_id,
     monitor_tag,
@@ -429,11 +405,6 @@ export const UpdateCommentByID = async (
   if (!commentExists) {
     throw new Error(`Comment with id ${comment_id} does not exist`);
   }
-  // queueController.PushDataToQueue(incident_id, "updateIncidentComment", {
-  //   title: incidentExists.title,
-  //   message: `${comment}`,
-  //   incident_type: incidentExists.incident_type,
-  // });
   let c = await db.updateIncidentCommentByID(comment_id, comment, state, commented_at);
   if (c) {
     let incidentUpdate: IncidentUpdateInput = {
@@ -450,6 +421,34 @@ export const UpdateCommentByID = async (
   }
   return c;
 };
+// Subscriber notifications are driven solely by incident comments: the comment
+// timeline is the incident's public communication channel, so posting a comment
+// is the one event that emails "incidents" subscribers — regardless of whether
+// the incident came from an alert, the dashboard, or the API. This is the single
+// choke point; alertingQueue must not push its own incident notifications, or
+// alert-driven incidents would notify twice.
+const notifySubscribersOfComment = async (
+  incident: Pick<IncidentRecord, "id" | "title">,
+  comment: IncidentCommentRecord,
+): Promise<void> => {
+  try {
+    const siteData = await GetAllSiteData();
+    const siteUrl = siteDataToVariables(siteData).site_url;
+    const variables: SubscriptionVariableMap = {
+      title: incident.title,
+      cta_url: `${siteUrl}incidents/${incident.id}`,
+      cta_text: "View Incident",
+      update_text: mdToHTML(comment.comment),
+      update_subject: `[#${incident.id}:${comment.state}] ${incident.title}`,
+      update_id: String(comment.id),
+      event_type: "incidents",
+    };
+    await subscriberQueue.push(variables);
+  } catch (err) {
+    console.error(`Error sending subscriber notification for incident ${incident.id}:`, err);
+  }
+};
+
 export const AddIncidentComment = async (
   incident_id: number,
   comment: string,
@@ -480,6 +479,7 @@ export const AddIncidentComment = async (
       }
     }
     await UpdateIncident(incident_id, incidentUpdate);
+    await notifySubscribersOfComment(incidentExists, c);
   }
 
   return c;

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -18,7 +18,7 @@ import type {
 import GC from "../../global-constants.js";
 import { getUnixTime, differenceInSeconds } from "date-fns";
 import { siteDataToVariables } from "../notification/notification_utils.js";
-import { GetAllSiteData } from "./controller.js";
+import { GetAllSiteData } from "./siteDataController.js";
 import subscriberQueue from "../queues/subscriberQueue.js";
 import mdToHTML from "../../marked.js";
 import type { SubscriptionVariableMap } from "../notification/types.js";
@@ -443,7 +443,11 @@ const notifySubscribersOfComment = async (
       update_id: String(comment.id),
       event_type: "incidents",
     };
-    await subscriberQueue.push(variables);
+    // Stable dedup id per comment so a retried/double push notifies once — without
+    // it subscriberQueue falls back to a Date.now()-suffixed id that never dedupes.
+    await subscriberQueue.push(variables, {
+      deduplication: { id: `subscriber-incidents-${comment.id}` },
+    });
   } catch (err) {
     console.error(`Error sending subscriber notification for incident ${incident.id}:`, err);
   }

--- a/src/lib/server/queues/alertingQueue.ts
+++ b/src/lib/server/queues/alertingQueue.ts
@@ -34,9 +34,7 @@ import sendWebhook from "$lib/server/notification/webhook_notification.js";
 import sendSlack from "$lib/server/notification/slack_notification.js";
 import sendDiscord from "$lib/server/notification/discord_notification.js";
 
-import type { SiteDataForNotification, SubscriptionVariableMap } from "../notification/types.js";
-import mdToHTML from "../../marked.js";
-import subscriberQueue from "./subscriberQueue.js";
+import type { SiteDataForNotification } from "../notification/types.js";
 let alertingQueue: Queue | null = null;
 
 let worker: Worker | null = null;
@@ -63,7 +61,6 @@ async function createNewIncident(
   config: MonitorAlertConfigRecord,
   monitorName: string,
   monitorTag: string,
-  siteUrl: string = "",
 ): Promise<{ incident_id: number }> {
   let startDateTime = getUnixTime(new Date(alert.created_at));
   let incidentInput: IncidentInput = {
@@ -72,6 +69,8 @@ async function createNewIncident(
     incident_source: "ALERT",
   };
 
+  // Subscriber notification comes from AddIncidentComment (via
+  // CreateNewIncidentWithCommentAndMonitor) — do not push here too.
   let update = IncidentCreateAlertMarkdown(alert, config, monitorName, monitorTag, GC.TRIGGERED);
   let incidentCreated = await CreateNewIncidentWithCommentAndMonitor(
     incidentInput,
@@ -80,23 +79,7 @@ async function createNewIncident(
     config.alert_value,
   );
 
-  const updateVariables: SubscriptionVariableMap = {
-    title: incidentInput.title,
-    cta_url: siteUrl + "incidents/" + incidentCreated.incident_id,
-    cta_text: "View Incident",
-    update_text: mdToHTML(update),
-    update_subject: `[#${incidentCreated.incident_id}:${GC.TRIGGERED}] ${incidentInput.title}`,
-    update_id: String(incidentCreated.incident_id),
-    event_type: "incidents",
-  };
-  subscriberQueue.push(updateVariables);
   return incidentCreated;
-
-  /*
-	
-	
-	
-		subscriberQueue.push(updateVariables);*/
 }
 
 async function closeIncident(
@@ -104,7 +87,6 @@ async function closeIncident(
   config: MonitorAlertConfigRecord,
   monitorName: string,
   monitorTag: string,
-  siteUrl: string = "",
 ): Promise<void> {
   //check if incident is already resolved
   if (!alert.incident_id) {
@@ -122,16 +104,7 @@ async function closeIncident(
   let incident_id = alert.incident_id;
   const comment = ClosureCommentAlertMarkdown(alert, config, monitorName, monitorTag, GC.RESOLVED);
   const updatedAt = getUnixTime(new Date(alert.updated_at));
-  const updateMessage: SubscriptionVariableMap = {
-    title: incident.title,
-    cta_url: `${siteUrl}incidents/${incident_id}`,
-    cta_text: "View Incident",
-    update_text: mdToHTML(comment),
-    update_subject: `[#${incident.id}:${GC.RESOLVED}] ${incident.title}`,
-    update_id: String(incident_id),
-    event_type: "incidents",
-  };
-  subscriberQueue.push(updateMessage);
+  // Subscriber notification comes from AddIncidentComment — do not push here too.
   await AddIncidentComment(incident_id, comment, GC.RESOLVED, updatedAt);
 }
 
@@ -253,7 +226,6 @@ const addWorker = () => {
               monitor_alerts_configured,
               monitor_name,
               monitor_tag,
-              templateSiteVars.site_url,
             );
             //update alert with incident number
             if (newIncidentNumber && newIncidentNumber.incident_id > 0) {
@@ -292,13 +264,7 @@ const addWorker = () => {
 
           // If alert has an incident, add closure comment
           if (activeAlert.incident_id) {
-            await closeIncident(
-              activeAlert,
-              monitor_alerts_configured,
-              monitor_name,
-              monitor_tag,
-              templateSiteVars.site_url,
-            );
+            await closeIncident(activeAlert, monitor_alerts_configured, monitor_name, monitor_tag);
           }
 
           // Send resolution notifications


### PR DESCRIPTION
Manually created/updated incidents never reached the subscriber notification workflow (#774): only alertingQueue pushed to subscriberQueue, so dashboard and API incidents stayed silent.

Make AddIncidentComment the single notification choke point: posting a comment on an INCIDENT-type incident notifies "incidents" subscribers, regardless of source (alert, dashboard, or API). Remove the two bespoke pushes in alertingQueue — alert-driven incidents now notify through the same path via their auto-created comments, instead of twice.

The dedup id is now the comment id (previously the incident id with a Date.now() suffix, which never deduplicated anything). Alert-created incident emails now carry the incident state (INVESTIGATING) instead of the alert status (TRIGGERED) in the subject; body content is unchanged.

Also drop the dead commented-out queueController blocks left from the old notification system.

Fixes #774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriber notifications now include new incident comment activity, so followers receive timely updates as discussions progress.

* **Bug Fixes**
  * Incident creation and closure notifications have been unified to follow the same comment-driven path, reducing missed and duplicate alerts.
  * Notification delivery failures are now handled gracefully and won’t interrupt incident workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->