### PR TITLE
fix: pass defaultMode to ModeWatcher so site theme is respected

### DIFF
--- a/src/routes/(account)/+layout.svelte
+++ b/src/routes/(account)/+layout.svelte
@@ -10,7 +10,7 @@
   import KenerNav from "$lib/components/KenerNav.svelte";
 </script>
 
-<ModeWatcher />
+<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
 <Toaster />
 
 <svelte:head>

--- a/src/routes/(embed)/+layout.svelte
+++ b/src/routes/(embed)/+layout.svelte
@@ -9,7 +9,7 @@
   let { children, data } = $props();
 </script>
 
-<ModeWatcher />
+<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
 <Toaster />
 
 <svelte:head>

--- a/src/routes/(kener)/+layout.svelte
+++ b/src/routes/(kener)/+layout.svelte
@@ -20,7 +20,7 @@
   });
 </script>
 
-<ModeWatcher />
+<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
 
 <Toaster />
 

--- a/src/routes/(manage)/+layout.server.ts
+++ b/src/routes/(manage)/+layout.server.ts
@@ -49,12 +49,14 @@ export const load: LayoutServerLoad = async ({ cookies, route }) => {
   const siteStatusColors = siteData.colors;
   const siteStatusColorsDark = siteData.colorsDark || siteStatusColors;
   const font = siteData.font || { cssSrc: "", family: "" };
+  const defaultSiteTheme = siteData.theme || "system";
   return {
     userDb: loggedInUser,
     userPermissions: [...userPermissions],
     siteStatusColors,
     siteStatusColorsDark,
     font,
+    defaultSiteTheme,
     canSendEmail: IsEmailSetup(),
     seedSiteData,
   };

--- a/src/routes/(manage)/+layout.svelte
+++ b/src/routes/(manage)/+layout.svelte
@@ -71,7 +71,7 @@
   let pageTitle = $derived(navItems.find((item) => page.url.pathname.startsWith(item.url))?.title || "Dashboard");
 </script>
 
-<ModeWatcher />
+<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
 <Toaster />
 
 <svelte:head>


### PR DESCRIPTION
Fix #776 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selection now follows your site’s saved default more consistently across account, embed, manage, and Kener pages.
  * If no theme is set, the interface now falls back to the system theme.
* **Bug Fixes**
  * Improved theme initialization so pages load with the expected light, dark, or system mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->