### PR TITLE
Handle follow rediretc or not

### DIFF
--- a/src/lib/server/services/apiCall.ts
+++ b/src/lib/server/services/apiCall.ts
@@ -64,13 +64,18 @@ class ApiCall {
         console.log(e);
       }
     }
+  const followRedirects =
+    this.monitor.type_data.follow_redirects ?? true;
+
+  const maxRedirects =
+    this.monitor.type_data.max_redirects ?? 5;
 
     const options: AxiosRequestConfig = {
       method: method,
       headers: axiosHeaders,
       timeout: timeout,
       transformResponse: (r: string) => r,
-      maxRedirects: 5,
+      maxRedirects: followRedirects ? maxRedirects : 0,
       validateStatus: () => true,
       maxContentLength: Infinity,
       maxBodyLength: Infinity,

--- a/src/lib/server/types/monitor.ts
+++ b/src/lib/server/types/monitor.ts
@@ -26,6 +26,8 @@ export interface ApiMonitorTypeData {
   timeout?: number;
   eval?: string;
   allowSelfSignedCert?: boolean;
+  follow_redirects?: boolean;
+  max_redirects?: number;
 }
 
 export interface DnsMonitorTypeData {

--- a/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
@@ -118,6 +118,8 @@
       id="api-max-redirects"
       type="number"
       min="0"
+      max="20"
+      step="1"
       bind:value={data.max_redirects}
       disabled={!data.follow_redirects}
     />

--- a/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
@@ -25,6 +25,10 @@
   if (!data.eval) data.eval = DefaultAPIEval;
   if (data.allowSelfSignedCert === undefined) data.allowSelfSignedCert = false;
 
+  if (data.follow_redirects === undefined) data.follow_redirects = true;
+  if (data.max_redirects === undefined) data.max_redirects = 5;
+
+
   const methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
   function addHeader() {
@@ -102,6 +106,23 @@
     <Switch id="api-self-signed" bind:checked={data.allowSelfSignedCert} />
     <Label for="api-self-signed">Allow Self-Signed Certificates</Label>
   </div>
+
+  <div class="flex items-center space-x-2">
+    <Switch id="api-follow-redirects" bind:checked={data.follow_redirects} />
+    <Label for="api-follow-redirects">Follow Redirects</Label>
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <Label for="api-max-redirects">Max Redirects</Label>
+    <Input
+      id="api-max-redirects"
+      type="number"
+      min="0"
+      bind:value={data.max_redirects}
+      disabled={!data.follow_redirects}
+    />
+  </div>
+
 
   <div class="flex flex-col gap-2">
     <Label for="api-eval">Custom Eval Function</Label>


### PR DESCRIPTION
## Description

API monitors currently always follow HTTP redirects because `maxRedirects` is hardcoded to `5`.

In some environments (for example services protected by SSO), a request may be redirected several times before eventually returning an error page. As a result, Kener only sees the final response code instead of the original redirect response.

Example:

302 -> Login page -> 400

With the current behavior, the monitor only receives the final `400` response. To work around this, admin may be forced to treat error responses such as `400` as **UP**, which is not ideal and can lead to inaccurate monitoring results.

This PR adds two new API monitor settings:

- **Follow Redirects** (enabled by default to preserve existing behavior)
- **Max Redirects** (default: 5)

When redirect following is disabled, Kener returns the original HTTP response code (e.g. 301, 302, 307, 308), allowing users to create more accurate monitoring rules and custom evaluation functions.



<img width="1569" height="193" alt="image" src="https://github.com/user-attachments/assets/bfb90312-a3b0-4568-ae72-99d11289eadd" />


Hope this feature will help <3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redirect controls for API monitor settings, including a toggle to follow redirects and a limit for maximum redirects.
  * Default redirect behavior is now preconfigured for new or unset API monitor settings.
* **Bug Fixes**
  * API requests now respect the selected redirect settings instead of using a fixed redirect limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->