### PR TITLE
Refactor chartId to use $derived for reactive updates

### DIFF
--- a/src/lib/components/ui/chart/chart-container.svelte
+++ b/src/lib/components/ui/chart/chart-container.svelte
@@ -17,7 +17,7 @@
     config: ChartConfig;
   } = $props();
 
-  const chartId = `chart-${id || uid.replace(/:/g, "")}`;
+  const chartId = $derived(`chart-${id || uid.replace(/:/g, "")}`);
 
   setChartContext({
     get config() {

--- a/src/lib/components/ui/toggle-group/toggle-group.svelte
+++ b/src/lib/components/ui/toggle-group/toggle-group.svelte
@@ -5,8 +5,10 @@
 
 	type ToggleVariants = VariantProps<typeof toggleVariants>;
 
-	interface ToggleGroupContext extends ToggleVariants {
-		spacing?: number;
+	interface ToggleGroupContext {
+		get variant(): ToggleVariants["variant"];
+		get size(): ToggleVariants["size"];
+		get spacing(): number | undefined;
 	}
 
 	export function setToggleGroupCtx(props: ToggleGroupContext) {
@@ -33,9 +35,15 @@
 	}: ToggleGroupPrimitive.RootProps & ToggleVariants & { spacing?: number } = $props();
 
 	setToggleGroupCtx({
-		variant,
-		size,
-		spacing,
+		get variant() {
+			return variant;
+		},
+		get size() {
+			return size;
+		},
+		get spacing() {
+			return spacing;
+		},
 	});
 </script>
 

--- a/src/lib/server/dns.ts
+++ b/src/lib/server/dns.ts
@@ -2,7 +2,7 @@ import dns2 from "dns2";
 import dgram, { type Socket } from "dgram";
 import tls from "tls";
 import { Resolver as NodeResolver } from "node:dns/promises";
-import { AllRecordTypes, IsValidHost, ValidateIpAddress } from "../clientTools";
+import { AllRecordTypes, IsValidHost } from "../clientTools";
 
 interface DNSAnswer {
   name: string;
@@ -135,7 +135,6 @@ class DNSResolver {
     const port = options.tlsPort ?? DEFAULT_DOT_PORT;
     const timeoutMs = options.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
     const servername = this.resolveTlsServername(nameserver, options.tlsServername);
-    const ipType = ValidateIpAddress(nameserver);
 
     return new Promise((resolve, reject) => {
       let responseBuffer = Buffer.alloc(0);
@@ -146,7 +145,6 @@ class DNSResolver {
         port,
         servername,
         rejectUnauthorized: !options.allowSelfSignedCert,
-        family: ipType === "IP6" ? 6 : ipType === "IP4" ? 4 : undefined,
       });
 
       const timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary

This PR resolves Svelte and TypeScript diagnostics reported by the project check command.

## Issue

Running `npm run check` surfaced two categories of problems:

1. Svelte reactivity warnings in UI components where values were captured only during initial component setup.
2. A TypeScript overload error in the DNS-over-TLS implementation caused by passing an unsupported `family` option to `tls.connect`.

In the UI components, values such as `chartId`, `variant`, `size`, and `spacing` could become stale if their related props changed after initialization.

## Changes

- Updated chart ID generation to use `$derived`, ensuring `chartId` stays in sync with the `id` prop.
- Updated toggle group context values to use getters, ensuring child components read the latest `variant`, `size`, and `spacing` values.
- Removed the unsupported TLS `family` option from the DNS-over-TLS connection configuration.
- Removed the now-unused IP validation call associated with the removed TLS option.

## Rationale

`$derived` is the appropriate Svelte 5 pattern for computed values that depend on reactive inputs.

Using getters in context preserves reactivity for values consumed by child components, avoiding stale context state.

Removing the unsupported TLS option resolves the TypeScript overload error while preserving the existing DNS-over-TLS connection behavior.

## Validation

The issue was identified with:

```bash
npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart data identifiers now update automatically when their underlying values change.
  * Toggle groups now reliably reflect current variant, size, and spacing settings.
  * Improved DNS-over-TLS connection handling for more consistent secure DNS requests.

* **Refactor**
  * Updated internal toggle-group state handling to keep displayed settings synchronized with component values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->