### PR TITLE
chore: enforce LF line endings via .gitattributes + gitignore updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ config/server.yaml
 /package
 .env
 .vscode
+.idea
 .env.*
 !.env.example
 vite.config.js.timestamp-*
@@ -40,3 +41,4 @@ translation-report.json
 CONTEXT.md
 docs/adr/
 docs/superpowers/
+.superpowers/


### PR DESCRIPTION
Shell scripts checked out with CRLF on Windows (core.autocrlf=true) broke the Docker entrypoint at container start.
Force LF for all text files at the git layer, matching the existing .editorconfig and Prettier settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository files to use automatic text detection and Unix line endings.
  * Updated ignored files to exclude additional local development and tooling directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->