### PR TITLE
feat: content localisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Type check
+        run: npm run check
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -24,7 +26,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+# Cancel superseded runs on the same branch / PR to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ config/server.yaml
 /package
 .env
 .vscode
+.idea
 .env.*
 !.env.example
 vite.config.js.timestamp-*
@@ -40,3 +41,4 @@ translation-report.json
 CONTEXT.md
 docs/adr/
 docs/superpowers/
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,13 @@ npm run check        # Svelte + TypeScript type checking
 npm run prettify     # Format all files with Prettier
 npm run migrate      # Run database migrations via Knex
 npm run seed         # Run database seeds (migrations run automatically first)
+npm test             # Run all tests (server unit + browser component projects)
+npm run test:server  # Server-side unit tests only (Node)
+npm run test:client  # Component tests only (headless Chromium via Playwright)
+npm run test:watch   # Watch mode
 ```
+
+Component tests need a one-time `npx playwright install chromium`.
 
 ## Architecture
 

--- a/migrations/20260716120000_add_content_translations.ts
+++ b/migrations/20260716120000_add_content_translations.ts
@@ -1,0 +1,25 @@
+import type { Knex } from "knex";
+
+const TABLES = ["monitors", "incidents", "incident_comments", "maintenances"] as const;
+
+export async function up(knex: Knex): Promise<void> {
+  for (const tableName of TABLES) {
+    const hasCol = await knex.schema.hasColumn(tableName, "translations");
+    if (!hasCol) {
+      await knex.schema.alterTable(tableName, (table) => {
+        table.text("translations").nullable();
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for (const tableName of TABLES) {
+    const hasCol = await knex.schema.hasColumn(tableName, "translations");
+    if (hasCol) {
+      await knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn("translations");
+      });
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,8 @@
         "vaul-svelte": "^1.0.0-next.7",
         "vite": "^7.2.2",
         "vite-node": "^5.3.0",
-        "vite-plugin-devtools-json": "^1.0.0"
+        "vite-plugin-devtools-json": "^1.0.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2666,6 +2667,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2713,6 +2725,13 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2900,6 +2919,129 @@
         "@codemirror/view": ">=6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.8",
       "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
@@ -3025,6 +3167,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-function": {
@@ -3539,6 +3691,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3804,6 +3966,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -5016,6 +5185,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -9490,6 +9669,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -9614,6 +9800,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -9638,6 +9831,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10215,6 +10415,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -10229,6 +10446,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tlds": {
@@ -10729,6 +10956,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -10862,6 +11179,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "@types/mustache": "^4.2.6",
         "@types/node": "^25.0.3",
         "@types/nodemailer": "^7.0.4",
+        "@vitest/browser-playwright": "^4.1.10",
         "autoprefixer": "^10.4.22",
         "clsx": "^2.1.1",
         "concurrently": "^9.2.1",
@@ -127,7 +128,8 @@
         "vite": "^7.2.2",
         "vite-node": "^5.3.0",
         "vite-plugin-devtools-json": "^1.0.0",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "vitest-browser-svelte": "^3.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -157,6 +159,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.0",
@@ -2646,6 +2655,19 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.3.tgz",
+      "integrity": "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -2917,6 +2939,63 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8470,6 +8549,56 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pngjs": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
@@ -11046,6 +11175,23 @@
         }
       }
     },
+    "node_modules/vitest-browser-svelte": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vitest-browser-svelte/-/vitest-browser-svelte-3.0.0.tgz",
+      "integrity": "sha512-BKM9iBGNsEQzigWuSZFAiw6AJDqQqMttApoD8gM8LTI6vxfd423rDMN8GqUHJyGbhH3XcOo9N9u/4hu47Nxhsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/svelte-core": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vitest": "^4.0.0"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -11220,6 +11366,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "preview": "vite preview",
     "schedule": "vite-node src/lib/server/startup.ts",
     "seed": "npx knex seed:run",
-    "start": "node build/main.js"
+    "start": "node build/main.js",
+    "test": "vitest run",
+    "test:server": "vitest run --project=server",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@internationalized/date": "^3.10.0",
@@ -92,7 +95,8 @@
     "vaul-svelte": "^1.0.0-next.7",
     "vite": "^7.2.2",
     "vite-node": "^5.3.0",
-    "vite-plugin-devtools-json": "^1.0.0"
+    "vite-plugin-devtools-json": "^1.0.0",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "schedule": "vite-node src/lib/server/startup.ts",
     "seed": "npx knex seed:run",
     "start": "node build/main.js",
-    "test": "vitest run",
+    "test": "cross-env TZ=UTC vitest run",
     "test:client": "vitest run --project=client",
-    "test:server": "vitest run --project=server",
-    "test:watch": "vitest"
+    "test:server": "cross-env TZ=UTC vitest run --project=server",
+    "test:watch": "cross-env TZ=UTC vitest"
   },
   "devDependencies": {
     "@internationalized/date": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "seed": "npx knex seed:run",
     "start": "node build/main.js",
     "test": "vitest run",
+    "test:client": "vitest run --project=client",
     "test:server": "vitest run --project=server",
     "test:watch": "vitest"
   },
@@ -72,6 +73,7 @@
     "@types/mustache": "^4.2.6",
     "@types/node": "^25.0.3",
     "@types/nodemailer": "^7.0.4",
+    "@vitest/browser-playwright": "^4.1.10",
     "autoprefixer": "^10.4.22",
     "clsx": "^2.1.1",
     "concurrently": "^9.2.1",
@@ -96,7 +98,8 @@
     "vite": "^7.2.2",
     "vite-node": "^5.3.0",
     "vite-plugin-devtools-json": "^1.0.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "vitest-browser-svelte": "^3.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/lib/client/manage-locales.ts
+++ b/src/lib/client/manage-locales.ts
@@ -1,0 +1,30 @@
+import { resolve } from "$app/paths";
+import clientResolver from "$lib/client/resolver.js";
+import { availableLocalesList } from "$lib/stores/i18n";
+
+export interface TranslatableLocalesInfo {
+  defaultLocaleName: string;
+  locales: { code: string; name: string }[];
+}
+
+/**
+ * Enabled locales minus the site default — the set an admin can author
+ * content translations for. Empty when only the default language is enabled.
+ */
+export async function fetchTranslatableLocales(): Promise<TranslatableLocalesInfo> {
+  const response = await fetch(clientResolver(resolve, "/manage/api"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "getAllSiteData" }),
+  });
+  const result = await response.json();
+  const names = new Map(availableLocalesList.map((l) => [l.code, l.name]));
+  const defaultLocale: string = result?.i18n?.defaultLocale || "en";
+  const enabled: { code: string; name?: string; selected?: boolean }[] = result?.i18n?.locales || [];
+  return {
+    defaultLocaleName: names.get(defaultLocale) ?? defaultLocale,
+    locales: enabled
+      .filter((l) => l.selected && l.code !== defaultLocale)
+      .map((l) => ({ code: l.code, name: names.get(l.code) ?? l.name ?? l.code })),
+  };
+}

--- a/src/lib/client/manage-locales.ts
+++ b/src/lib/client/manage-locales.ts
@@ -17,6 +17,12 @@ export async function fetchTranslatableLocales(): Promise<TranslatableLocalesInf
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ action: "getAllSiteData" }),
   });
+  // Without this guard an auth/server error parses into an empty locale set, which is
+  // indistinguishable from "only the default language is enabled" — silently hiding
+  // every translation control. Callers catch and log instead.
+  if (!response.ok) {
+    throw new Error(`Failed to load site locales: ${response.status}`);
+  }
   const result = await response.json();
   const names = new Map(availableLocalesList.map((l) => [l.code, l.name]));
   const defaultLocale: string = result?.i18n?.defaultLocale || "en";

--- a/src/lib/components/CopyButton.svelte.test.ts
+++ b/src/lib/components/CopyButton.svelte.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
 import CopyButton from "./CopyButton.svelte";
 
@@ -6,6 +6,17 @@ import CopyButton from "./CopyButton.svelte";
 // grant clipboard-read permission, and the component's contract is "calls
 // navigator.clipboard.writeText and flips to the copied state".
 describe("CopyButton", () => {
+  beforeAll(() => {
+    // navigator.clipboard only exists in secure contexts; provide a minimal
+    // stand-in when absent so the spies below always have a target.
+    if (!("clipboard" in navigator)) {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: async () => {} },
+        configurable: true,
+      });
+    }
+  });
+
   beforeEach(() => {
     vi.restoreAllMocks();
   });

--- a/src/lib/components/CopyButton.svelte.test.ts
+++ b/src/lib/components/CopyButton.svelte.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import CopyButton from "./CopyButton.svelte";
+
+// The clipboard is spied on rather than read back: headless Chromium does not
+// grant clipboard-read permission, and the component's contract is "calls
+// navigator.clipboard.writeText and flips to the copied state".
+describe("CopyButton", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("copies the text prop and shows the copied state on click", async () => {
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    const screen = await render(CopyButton, { text: "copy-me" });
+    const copiedTooltip = screen.getByText("Copied");
+
+    // Hidden before the click (class-based visibility)
+    await expect.element(copiedTooltip).toHaveClass(/opacity-0/);
+
+    await screen.getByRole("button").click();
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith("copy-me");
+    await expect.element(copiedTooltip).toHaveClass(/scale-100/);
+  });
+
+  it("invokes the onclick callback", async () => {
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    const onclick = vi.fn();
+
+    const screen = await render(CopyButton, { text: "x", onclick });
+    await screen.getByRole("button").click();
+
+    expect(onclick).toHaveBeenCalledOnce();
+  });
+
+  it("does not touch the clipboard when no text is provided", async () => {
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    const screen = await render(CopyButton, {});
+    await screen.getByRole("button").click();
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/IncidentItem.svelte
+++ b/src/lib/components/IncidentItem.svelte
@@ -5,7 +5,7 @@
   import ArrowRight from "@lucide/svelte/icons/arrow-right";
   import * as Popover from "$lib/components/ui/popover/index.js";
   import * as Avatar from "$lib/components/ui/avatar/index.js";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { formatDate, formatDuration } from "$lib/stores/datetime";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -46,7 +46,7 @@
       <span class="text-xs font-medium text-{incident.state.toLowerCase()}">{$t(incident.state)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">
         <a {target} class="hover:underline" href={clientResolver(resolve, `/incidents/${incident.id}`)}>
-          {incident.title}
+          {$lt(incident.translations, "title", incident.title)}
         </a>
       </Item.Title>
     </div>
@@ -61,7 +61,7 @@
                   variant="outline"
                   class="border-{monitor.monitor_impact.toLowerCase()}   cursor-pointer rounded-none border-0 border-b px-0  text-sm font-normal"
                 >
-                  {monitor.monitor_name}
+                  {$lt(monitor.monitor_translations, "name", monitor.monitor_name)}
                 </Badge>
               </Popover.Trigger>
               <Popover.Content
@@ -71,12 +71,17 @@
                   <div class="flex items-center gap-3">
                     <Avatar.Root>
                       {#if monitor.monitor_image}
-                        <Avatar.Image src={clientResolver(resolve, monitor.monitor_image)} alt={monitor.monitor_name} />
+                        <Avatar.Image
+                          src={clientResolver(resolve, monitor.monitor_image)}
+                          alt={$lt(monitor.monitor_translations, "name", monitor.monitor_name)}
+                        />
                       {/if}
-                      <Avatar.Fallback>{GetInitials(monitor.monitor_name)}</Avatar.Fallback>
+                      <Avatar.Fallback
+                        >{GetInitials($lt(monitor.monitor_translations, "name", monitor.monitor_name))}</Avatar.Fallback
+                      >
                     </Avatar.Root>
                     <div class="flex flex-col">
-                      <span class="font-medium">{monitor.monitor_name}</span>
+                      <span class="font-medium">{$lt(monitor.monitor_translations, "name", monitor.monitor_name)}</span>
                       <span class="text-muted-foreground text-xs">{monitor.monitor_tag}</span>
                     </div>
                   </div>
@@ -174,7 +179,7 @@
               class="prose prose-sm dark:prose-invert max-w-none min-w-0 overflow-x-auto wrap-break-word"
               style="font-size: 14px;"
             >
-              <SveltePurify html={mdToHTML(comment.comment)} />
+              <SveltePurify html={mdToHTML($lt(comment.translations, "comment", comment.comment))} />
             </div>
           </div>
         {/each}

--- a/src/lib/components/MaintenanceItem.svelte
+++ b/src/lib/components/MaintenanceItem.svelte
@@ -6,7 +6,7 @@
   import * as Avatar from "$lib/components/ui/avatar/index.js";
   import { Badge } from "$lib/components/ui/badge/index.js";
   import STATUS_ICON from "$lib/icons";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { formatDate, formatDuration } from "$lib/stores/datetime";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -38,7 +38,7 @@
       <span class="text-xs font-medium text-{maintenance.status.toLowerCase()}">{$t(maintenance.status)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">
         <a {target} class="hover:underline" href={clientResolver(resolve, `/maintenances/${maintenance.id}`)}
-          >{maintenance.title}</a
+          >{$lt(maintenance.translations, "title", maintenance.title)}</a
         >
       </Item.Title>
     </div>
@@ -47,7 +47,7 @@
       <div
         class="prose prose-sm dark:prose-invert text-muted-foreground mt-1 max-w-none min-w-0 overflow-x-auto text-sm wrap-break-word"
       >
-        <SveltePurify html={mdToHTML(maintenance.description)} />
+        <SveltePurify html={mdToHTML($lt(maintenance.translations, "description", maintenance.description))} />
       </div>
     {/if}
 
@@ -60,7 +60,7 @@
                 variant="outline"
                 class="border-{monitor.monitor_impact.toLowerCase()}   cursor-pointer rounded-none border-0 border-b px-0  text-sm font-normal"
               >
-                {monitor.monitor_name}
+                {$lt(monitor.monitor_translations, "name", monitor.monitor_name)}
               </Badge>
             </Popover.Trigger>
             <Popover.Content class="w-64">
@@ -68,12 +68,17 @@
                 <div class="flex items-center gap-3">
                   <Avatar.Root>
                     {#if monitor.monitor_image}
-                      <Avatar.Image src={clientResolver(resolve, monitor.monitor_image)} alt={monitor.monitor_name} />
+                      <Avatar.Image
+                        src={clientResolver(resolve, monitor.monitor_image)}
+                        alt={$lt(monitor.monitor_translations, "name", monitor.monitor_name)}
+                      />
                     {/if}
-                    <Avatar.Fallback>{GetInitials(monitor.monitor_name)}</Avatar.Fallback>
+                    <Avatar.Fallback
+                      >{GetInitials($lt(monitor.monitor_translations, "name", monitor.monitor_name))}</Avatar.Fallback
+                    >
                   </Avatar.Root>
                   <div class="flex flex-col">
-                    <span class="font-medium">{monitor.monitor_name}</span>
+                    <span class="font-medium">{$lt(monitor.monitor_translations, "name", monitor.monitor_name)}</span>
                     <span class="text-muted-foreground text-xs">{monitor.monitor_tag}</span>
                   </div>
                 </div>

--- a/src/lib/components/MonitorBar.svelte
+++ b/src/lib/components/MonitorBar.svelte
@@ -10,7 +10,7 @@
   import { formatDate } from "$lib/stores/datetime";
   import { GetInitials } from "$lib/clientTools.js";
   import GroupMonitorPopover from "./GroupMonitorPopover.svelte";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { page } from "$app/state";
 
   interface Props {
@@ -104,18 +104,26 @@
         <Item.Media variant="image" class="hidden sm:block">
           <Avatar.Root class="size-10">
             {#if data.image}
-              <Avatar.Image src={clientResolver(resolve, data.image)} alt={data.name} class="  " />
+              <Avatar.Image
+                src={clientResolver(resolve, data.image)}
+                alt={$lt(data.translations, "name", data.name)}
+                class="  "
+              />
             {/if}
-            <Avatar.Fallback>{GetInitials(data.name)}</Avatar.Fallback>
+            <Avatar.Fallback>{GetInitials($lt(data.translations, "name", data.name))}</Avatar.Fallback>
           </Avatar.Root>
         </Item.Media>
       {/if}
       <Item.Content class="min-w-0 flex-1">
         <Item.Title class="w-full truncate">
-          <a class="hover:underline" href={clientResolver(resolve, `/monitors/${tag}`)}>{data.name}</a>
+          <a class="hover:underline" href={clientResolver(resolve, `/monitors/${tag}`)}
+            >{$lt(data.translations, "name", data.name)}</a
+          >
         </Item.Title>
         {#if data.description}
-          <Item.Description class="line-clamp-2 wrap-break-word">{data.description}</Item.Description>
+          <Item.Description class="line-clamp-2 wrap-break-word"
+            >{$lt(data.translations, "description", data.description)}</Item.Description
+          >
         {/if}
       </Item.Content>
 

--- a/src/lib/components/StatusBarCalendar.svelte.test.ts
+++ b/src/lib/components/StatusBarCalendar.svelte.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-svelte";
+import StatusBarCalendar from "./StatusBarCalendar.svelte";
+import type { TimestampStatusCount } from "$lib/server/types/db";
+
+// Noon UTC keeps the rendered calendar date stable for any machine timezone
+// with an offset within ±11 hours (the timezone store defaults to browser TZ).
+const NOON_UTC = 1768478400; // 2026-01-15T12:00:00Z
+
+const day = (overrides: Partial<TimestampStatusCount>): TimestampStatusCount => ({
+  ts: NOON_UTC,
+  countOfUp: 0,
+  countOfDown: 0,
+  countOfDegraded: 0,
+  countOfMaintenance: 0,
+  avgLatency: 0,
+  maxLatency: 0,
+  minLatency: 0,
+  ...overrides,
+});
+
+describe("StatusBarCalendar", () => {
+  it("labels the canvas with the number of days", async () => {
+    const data = [day({ countOfUp: 10 }), day({ countOfUp: 10 }), day({ countOfUp: 10 })];
+    const screen = await render(StatusBarCalendar, { data, monitorTag: "test-monitor", disableClick: true });
+
+    await expect.element(screen.getByLabelText("Status calendar showing 3-day uptime data")).toBeInTheDocument();
+  });
+
+  it("shows status summary, date, and latency in the tooltip of the hovered day", async () => {
+    // Three bars: hovering the canvas center lands on the middle bar (index 1),
+    // which is 90% down => "Major System Outage" (>= 75% threshold).
+    const data = [
+      day({ countOfUp: 100 }),
+      day({ countOfDown: 90, countOfUp: 10, avgLatency: 250 }),
+      day({ countOfUp: 90, countOfDegraded: 10 }),
+    ];
+    const screen = await render(StatusBarCalendar, { data, monitorTag: "test-monitor", disableClick: true });
+
+    await screen.getByLabelText("Status calendar showing 3-day uptime data").hover();
+
+    await expect.element(screen.getByText("Major System Outage")).toBeInTheDocument();
+    // page.data.dateAndTimeFormat.dateOnly is mocked as "yyyy-MM-dd" in vitest-setup-client.ts
+    await expect.element(screen.getByText("2026-01-15", { exact: false })).toBeInTheDocument();
+    await expect.element(screen.getByText("250ms")).toBeInTheDocument();
+  });
+
+  it("reports a partial outage when downtime is below the 75% threshold", async () => {
+    const data = [day({ countOfUp: 100 }), day({ countOfDown: 20, countOfUp: 80 }), day({ countOfUp: 100 })];
+    const screen = await render(StatusBarCalendar, { data, monitorTag: "test-monitor", disableClick: true });
+
+    await screen.getByLabelText("Status calendar showing 3-day uptime data").hover();
+
+    await expect.element(screen.getByText("Partial System Outage")).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/StatusBarCalendar.svelte.test.ts
+++ b/src/lib/components/StatusBarCalendar.svelte.test.ts
@@ -3,8 +3,8 @@ import { render } from "vitest-browser-svelte";
 import StatusBarCalendar from "./StatusBarCalendar.svelte";
 import type { TimestampStatusCount } from "$lib/server/types/db";
 
-// Noon UTC keeps the rendered calendar date stable for any machine timezone
-// with an offset within ±11 hours (the timezone store defaults to browser TZ).
+// The browser context is pinned to UTC (see vite.config.ts), so the timezone store
+// (which defaults to browser TZ) is deterministic; noon UTC keeps fixtures safe too.
 const NOON_UTC = 1768478400; // 2026-01-15T12:00:00Z
 
 const day = (overrides: Partial<TimestampStatusCount>): TimestampStatusCount => ({

--- a/src/lib/components/manage/TranslationsButton.svelte
+++ b/src/lib/components/manage/TranslationsButton.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import * as Dialog from "$lib/components/ui/dialog/index.js";
+  import { Button } from "$lib/components/ui/button/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
+  import { Label } from "$lib/components/ui/label/index.js";
+  import { Textarea } from "$lib/components/ui/textarea/index.js";
+  import GlobeIcon from "@lucide/svelte/icons/globe";
+  import type { ContentTranslations } from "$lib/types/common";
+
+  interface Props {
+    translations: ContentTranslations;
+    field: string;
+    defaultValue: string;
+    defaultLocaleName: string;
+    locales: { code: string; name: string }[];
+    multiline?: boolean;
+  }
+
+  let {
+    translations = $bindable(),
+    field,
+    defaultValue,
+    defaultLocaleName,
+    locales,
+    multiline = false
+  }: Props = $props();
+
+  let open = $state(false);
+
+  const filledCount = $derived(locales.filter((l) => (translations[l.code]?.[field] ?? "").trim() !== "").length);
+
+  function valueFor(code: string): string {
+    return translations[code]?.[field] ?? "";
+  }
+
+  function setValue(code: string, value: string) {
+    const next = { ...translations };
+    if (value.trim() === "") {
+      // Empty inputs are dropped, never stored
+      if (next[code]) {
+        const { [field]: _removed, ...rest } = next[code];
+        if (Object.keys(rest).length === 0) {
+          delete next[code];
+        } else {
+          next[code] = rest;
+        }
+      }
+    } else {
+      next[code] = { ...next[code], [field]: value };
+    }
+    translations = next;
+  }
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Trigger>
+    {#snippet child({ props })}
+      <Button {...props} type="button" size="sm" variant="ghost" class="h-6 gap-1 px-2 text-xs">
+        <GlobeIcon class="size-3.5" />
+        {filledCount}/{locales.length}
+      </Button>
+    {/snippet}
+  </Dialog.Trigger>
+  <Dialog.Content class="max-h-[80vh] overflow-y-auto">
+    <Dialog.Header>
+      <Dialog.Title>Translations</Dialog.Title>
+      <Dialog.Description>
+        Provide translations for this field. Empty entries fall back to the default-language text.
+      </Dialog.Description>
+    </Dialog.Header>
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-2">
+        <Label>{defaultLocaleName} (default)</Label>
+        {#if multiline}
+          <Textarea value={defaultValue} readonly rows={3} class="bg-muted" />
+        {:else}
+          <Input value={defaultValue} readonly class="bg-muted" />
+        {/if}
+      </div>
+      {#each locales as locale (locale.code)}
+        <div class="flex flex-col gap-2">
+          <Label for={`translation-${field}-${locale.code}`}>{locale.name}</Label>
+          {#if multiline}
+            <Textarea
+              id={`translation-${field}-${locale.code}`}
+              value={valueFor(locale.code)}
+              oninput={(e) => setValue(locale.code, e.currentTarget.value)}
+              rows={3}
+            />
+          {:else}
+            <Input
+              id={`translation-${field}-${locale.code}`}
+              value={valueFor(locale.code)}
+              oninput={(e) => setValue(locale.code, e.currentTarget.value)}
+            />
+          {/if}
+        </div>
+      {/each}
+    </div>
+    <Dialog.Footer>
+      <Button type="button" onclick={() => (open = false)}>Done</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/content-i18n.test.ts
+++ b/src/lib/content-i18n.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseContentTranslations, resolveTranslation } from "./content-i18n";
+
+describe("parseContentTranslations", () => {
+  it("returns objects as-is", () => {
+    expect(parseContentTranslations({ de: { name: "Webseite" } })).toEqual({ de: { name: "Webseite" } });
+  });
+
+  it("parses JSON strings", () => {
+    expect(parseContentTranslations('{"de":{"name":"Webseite"}}')).toEqual({ de: { name: "Webseite" } });
+  });
+
+  it("returns null for null, undefined and empty strings", () => {
+    expect(parseContentTranslations(null)).toBeNull();
+    expect(parseContentTranslations(undefined)).toBeNull();
+    expect(parseContentTranslations("")).toBeNull();
+    expect(parseContentTranslations("   ")).toBeNull();
+  });
+
+  it("returns null for malformed JSON and non-object values", () => {
+    expect(parseContentTranslations("{not json")).toBeNull();
+    expect(parseContentTranslations("42")).toBeNull();
+    expect(parseContentTranslations('["a"]')).toBeNull();
+    expect(parseContentTranslations(7)).toBeNull();
+  });
+});
+
+describe("resolveTranslation", () => {
+  const translations = { de: { name: "Webseite", description: "" }, fr: { name: "Site web" } };
+
+  it("returns the translated value on locale + field hit", () => {
+    expect(resolveTranslation(translations, "de", "name", "Website")).toBe("Webseite");
+    expect(resolveTranslation(translations, "fr", "name", "Website")).toBe("Site web");
+  });
+
+  it("falls back on locale miss", () => {
+    expect(resolveTranslation(translations, "es", "name", "Website")).toBe("Website");
+  });
+
+  it("falls back on field miss", () => {
+    expect(resolveTranslation(translations, "fr", "description", "Base desc")).toBe("Base desc");
+  });
+
+  it("falls back on empty or whitespace-only values", () => {
+    expect(resolveTranslation(translations, "de", "description", "Base desc")).toBe("Base desc");
+    expect(resolveTranslation({ de: { name: "   " } }, "de", "name", "Website")).toBe("Website");
+  });
+
+  it("falls back on null/undefined/malformed translations input", () => {
+    expect(resolveTranslation(null, "de", "name", "Website")).toBe("Website");
+    expect(resolveTranslation(undefined, "de", "name", "Website")).toBe("Website");
+    expect(resolveTranslation("{broken", "de", "name", "Website")).toBe("Website");
+  });
+
+  it("resolves translations passed as a JSON string", () => {
+    expect(resolveTranslation('{"de":{"name":"Webseite"}}', "de", "name", "Website")).toBe("Webseite");
+  });
+
+  it("falls back when a locale entry or value has the wrong shape", () => {
+    expect(resolveTranslation({ de: "oops" } as never, "de", "name", "Website")).toBe("Website");
+    expect(resolveTranslation({ de: { name: 42 } } as never, "de", "name", "Website")).toBe("Website");
+  });
+});

--- a/src/lib/content-i18n.test.ts
+++ b/src/lib/content-i18n.test.ts
@@ -46,6 +46,13 @@ describe("resolveTranslation", () => {
     expect(resolveTranslation({ de: { name: "   " } }, "de", "name", "Website")).toBe("Website");
   });
 
+  it("returns the translation when the base text is empty", () => {
+    // Detail pages guard their name/description blocks on the resolved value, so a
+    // translation must still surface when the base column was left blank.
+    expect(resolveTranslation(translations, "fr", "name", "")).toBe("Site web");
+    expect(resolveTranslation(translations, "es", "name", "")).toBe("");
+  });
+
   it("falls back on null/undefined/malformed translations input", () => {
     expect(resolveTranslation(null, "de", "name", "Website")).toBe("Website");
     expect(resolveTranslation(undefined, "de", "name", "Website")).toBe("Website");

--- a/src/lib/content-i18n.ts
+++ b/src/lib/content-i18n.ts
@@ -1,0 +1,41 @@
+import type { ContentTranslations } from "$lib/types/common";
+
+/**
+ * Normalize a raw translations value (DB JSON string, already-parsed object,
+ * or null/undefined) into a ContentTranslations object. Never throws;
+ * malformed input degrades to null ("no translations").
+ */
+export function parseContentTranslations(value: unknown): ContentTranslations | null {
+  if (value === null || value === undefined) return null;
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    if (value.trim() === "") return null;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  return parsed as ContentTranslations;
+}
+
+/**
+ * Resolve one translated field. Returns translations[locale][field] when it is
+ * a non-empty string, else the fallback (base-language) text. Accepts the raw
+ * DB string form so payloads that pass records through whole need no parsing.
+ */
+export function resolveTranslation(
+  translations: ContentTranslations | string | null | undefined,
+  locale: string,
+  field: string,
+  fallback: string,
+): string {
+  const parsed = parseContentTranslations(translations);
+  if (!parsed) return fallback;
+  const localeFields = parsed[locale];
+  if (typeof localeFields !== "object" || localeFields === null || Array.isArray(localeFields)) return fallback;
+  const value = (localeFields as Record<string, unknown>)[field];
+  if (typeof value === "string" && value.trim() !== "") return value;
+  return fallback;
+}

--- a/src/lib/server/api-server/monitor-bar/get.ts
+++ b/src/lib/server/api-server/monitor-bar/get.ts
@@ -4,6 +4,7 @@ import db from "$lib/server/db/db";
 import { GetMinuteStartNowTimestampUTC } from "$lib/server/tool";
 import type { StatusType } from "$lib/global-constants";
 import type { TimestampStatusCount } from "$lib/server/types/db";
+import type { ContentTranslations } from "$lib/types/common";
 import { buildMonitorBarResponse } from "./shared";
 
 const DEFAULT_DAYS = 90;
@@ -26,6 +27,7 @@ export interface MonitorBarResponse {
   toTimeStamp: number;
   maxLatency: string;
   minLatency: string;
+  translations: ContentTranslations | null;
 }
 
 /**

--- a/src/lib/server/api-server/monitor-bar/shared.ts
+++ b/src/lib/server/api-server/monitor-bar/shared.ts
@@ -2,6 +2,7 @@ import db from "$lib/server/db/db";
 import GC, { type StatusType } from "$lib/global-constants";
 import type { MonitorRecord, TimestampStatusCount } from "$lib/server/types/db";
 import { UptimeCalculator } from "$lib/server/tool";
+import { parseContentTranslations } from "$lib/content-i18n";
 import type { MonitorBarResponse } from "./get";
 
 interface ParsedMonitorSettings {
@@ -97,5 +98,6 @@ export const buildMonitorBarResponseFromRawData = (
     avgLatency: uptimeCalculationResult.avgLatency,
     maxLatency: uptimeCalculationResult.maxLatency,
     minLatency: uptimeCalculationResult.minLatency,
+    translations: parseContentTranslations(monitor.translations),
   };
 };

--- a/src/lib/server/content-i18n.test.ts
+++ b/src/lib/server/content-i18n.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  INCIDENT_TRANSLATABLE_FIELDS,
+  MAINTENANCE_TRANSLATABLE_FIELDS,
+  MONITOR_TRANSLATABLE_FIELDS,
+  serializeContentTranslations,
+  validateContentTranslations,
+} from "./content-i18n";
+
+describe("validateContentTranslations", () => {
+  it("accepts valid translations for shipped locales and allowed fields", () => {
+    expect(
+      validateContentTranslations({ de: { name: "Webseite" }, fr: { name: "Site web" } }, MONITOR_TRANSLATABLE_FIELDS),
+    ).toEqual({ de: { name: "Webseite" }, fr: { name: "Site web" } });
+  });
+
+  it("returns null for null/undefined/empty input", () => {
+    expect(validateContentTranslations(null, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+    expect(validateContentTranslations(undefined, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+    expect(validateContentTranslations({}, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+    expect(validateContentTranslations("", MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+
+  it("accepts already-serialized JSON strings (idempotent write path)", () => {
+    expect(validateContentTranslations('{"de":{"title":"Wartung"}}', MAINTENANCE_TRANSLATABLE_FIELDS)).toEqual({
+      de: { title: "Wartung" },
+    });
+  });
+
+  it("rejects locales Kener does not ship", () => {
+    expect(() => validateContentTranslations({ xx: { name: "Nope" } }, MONITOR_TRANSLATABLE_FIELDS)).toThrow(
+      /unknown locale/i,
+    );
+  });
+
+  it("rejects fields outside the entity's allowed set", () => {
+    expect(() => validateContentTranslations({ de: { comment: "Hi" } }, INCIDENT_TRANSLATABLE_FIELDS)).toThrow(
+      /not translatable/i,
+    );
+  });
+
+  it("rejects non-string values and non-object shapes", () => {
+    expect(() => validateContentTranslations({ de: { name: 42 } }, MONITOR_TRANSLATABLE_FIELDS)).toThrow(
+      /must be a string/i,
+    );
+    expect(() => validateContentTranslations({ de: "oops" }, MONITOR_TRANSLATABLE_FIELDS)).toThrow(/object/i);
+    expect(() => validateContentTranslations(["de"], MONITOR_TRANSLATABLE_FIELDS)).toThrow(/object/i);
+    expect(() => validateContentTranslations("{broken", MONITOR_TRANSLATABLE_FIELDS)).toThrow(/JSON/i);
+  });
+
+  it("enforces length caps (255 for name/title, 65535 for description/comment)", () => {
+    expect(() =>
+      validateContentTranslations({ de: { name: "x".repeat(256) } }, MONITOR_TRANSLATABLE_FIELDS),
+    ).toThrow(/255/);
+    expect(
+      validateContentTranslations({ de: { name: "x".repeat(255) } }, MONITOR_TRANSLATABLE_FIELDS),
+    ).toEqual({ de: { name: "x".repeat(255) } });
+    expect(() =>
+      validateContentTranslations({ de: { description: "x".repeat(65536) } }, MONITOR_TRANSLATABLE_FIELDS),
+    ).toThrow(/65535/);
+  });
+
+  it("drops empty/whitespace-only values and empty locales", () => {
+    expect(
+      validateContentTranslations(
+        { de: { name: "  ", description: "Echt" }, fr: { name: "" } },
+        MONITOR_TRANSLATABLE_FIELDS,
+      ),
+    ).toEqual({ de: { description: "Echt" } });
+    expect(validateContentTranslations({ de: { name: "   " } }, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+});
+
+describe("serializeContentTranslations", () => {
+  it("stringifies validated translations", () => {
+    expect(serializeContentTranslations({ de: { name: "Webseite" } }, MONITOR_TRANSLATABLE_FIELDS)).toBe(
+      '{"de":{"name":"Webseite"}}',
+    );
+  });
+
+  it("returns null when nothing survives validation", () => {
+    expect(serializeContentTranslations(null, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+    expect(serializeContentTranslations({ de: { name: " " } }, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+});

--- a/src/lib/server/content-i18n.test.ts
+++ b/src/lib/server/content-i18n.test.ts
@@ -3,6 +3,7 @@ import {
   INCIDENT_TRANSLATABLE_FIELDS,
   MAINTENANCE_TRANSLATABLE_FIELDS,
   MONITOR_TRANSLATABLE_FIELDS,
+  resolveTranslationsForUpdate,
   serializeContentTranslations,
   validateContentTranslations,
 } from "./content-i18n";
@@ -49,12 +50,12 @@ describe("validateContentTranslations", () => {
   });
 
   it("enforces length caps (255 for name/title, 65535 for description/comment)", () => {
-    expect(() =>
-      validateContentTranslations({ de: { name: "x".repeat(256) } }, MONITOR_TRANSLATABLE_FIELDS),
-    ).toThrow(/255/);
-    expect(
-      validateContentTranslations({ de: { name: "x".repeat(255) } }, MONITOR_TRANSLATABLE_FIELDS),
-    ).toEqual({ de: { name: "x".repeat(255) } });
+    expect(() => validateContentTranslations({ de: { name: "x".repeat(256) } }, MONITOR_TRANSLATABLE_FIELDS)).toThrow(
+      /255/,
+    );
+    expect(validateContentTranslations({ de: { name: "x".repeat(255) } }, MONITOR_TRANSLATABLE_FIELDS)).toEqual({
+      de: { name: "x".repeat(255) },
+    });
     expect(() =>
       validateContentTranslations({ de: { description: "x".repeat(65536) } }, MONITOR_TRANSLATABLE_FIELDS),
     ).toThrow(/65535/);
@@ -81,5 +82,34 @@ describe("serializeContentTranslations", () => {
   it("returns null when nothing survives validation", () => {
     expect(serializeContentTranslations(null, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
     expect(serializeContentTranslations({ de: { name: " " } }, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+});
+
+describe("resolveTranslationsForUpdate", () => {
+  it("keeps the existing raw string when incoming is undefined", () => {
+    expect(resolveTranslationsForUpdate(undefined, '{"de":{"name":"Webseite"}}', MONITOR_TRANSLATABLE_FIELDS)).toBe(
+      '{"de":{"name":"Webseite"}}',
+    );
+  });
+
+  it("returns null when incoming is undefined and there is no existing value", () => {
+    expect(resolveTranslationsForUpdate(undefined, null, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+    expect(resolveTranslationsForUpdate(undefined, undefined, MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+
+  it("clears translations when incoming is explicitly null, even if an existing value is present", () => {
+    expect(resolveTranslationsForUpdate(null, '{"de":{"name":"Webseite"}}', MONITOR_TRANSLATABLE_FIELDS)).toBeNull();
+  });
+
+  it("serializes an incoming object regardless of what existed before", () => {
+    expect(
+      resolveTranslationsForUpdate({ de: { name: "Neu" } }, '{"de":{"name":"Alt"}}', MONITOR_TRANSLATABLE_FIELDS),
+    ).toBe('{"de":{"name":"Neu"}}');
+  });
+
+  it("throws when incoming is an invalid object, regardless of existing value", () => {
+    expect(() => resolveTranslationsForUpdate({ de: { comment: "Hi" } }, null, MONITOR_TRANSLATABLE_FIELDS)).toThrow(
+      /not translatable/i,
+    );
   });
 });

--- a/src/lib/server/content-i18n.ts
+++ b/src/lib/server/content-i18n.ts
@@ -1,0 +1,80 @@
+/**
+ * Server-side validation for per-entity content translations.
+ * Locale codes are valid iff Kener ships a locale file for them — NOT
+ * restricted to currently-enabled locales, so toggling a locale off never
+ * invalidates stored data.
+ */
+
+import { isLocaleAvailable } from "./i18n.js";
+import type { ContentTranslations } from "../types/common.js";
+
+export const MONITOR_TRANSLATABLE_FIELDS = ["name", "description"] as const;
+export const INCIDENT_TRANSLATABLE_FIELDS = ["title"] as const;
+export const INCIDENT_COMMENT_TRANSLATABLE_FIELDS = ["comment"] as const;
+export const MAINTENANCE_TRANSLATABLE_FIELDS = ["title", "description"] as const;
+
+// Caps match the smallest supported column type of the base fields.
+const FIELD_LENGTH_CAPS: Record<string, number> = {
+  name: 255,
+  title: 255,
+  description: 65535,
+  comment: 65535,
+};
+
+export function validateContentTranslations(
+  input: unknown,
+  allowedFields: readonly string[],
+): ContentTranslations | null {
+  if (input === null || input === undefined) return null;
+
+  let value: unknown = input;
+  if (typeof value === "string") {
+    if (value.trim() === "") return null;
+    try {
+      value = JSON.parse(value);
+    } catch {
+      throw new Error("translations must be valid JSON");
+    }
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("translations must be an object keyed by locale code");
+  }
+
+  const result: ContentTranslations = {};
+  for (const [locale, fields] of Object.entries(value as Record<string, unknown>)) {
+    if (!isLocaleAvailable(locale)) {
+      throw new Error(`Unknown locale "${locale}" in translations`);
+    }
+    if (typeof fields !== "object" || fields === null || Array.isArray(fields)) {
+      throw new Error(`translations["${locale}"] must be an object of field to string`);
+    }
+    const localeResult: Record<string, string> = {};
+    for (const [field, text] of Object.entries(fields as Record<string, unknown>)) {
+      if (!allowedFields.includes(field)) {
+        throw new Error(`Field "${field}" is not translatable for this content`);
+      }
+      if (typeof text !== "string") {
+        throw new Error(`translations["${locale}"]["${field}"] must be a string`);
+      }
+      const cap = FIELD_LENGTH_CAPS[field] ?? 255;
+      if (text.length > cap) {
+        throw new Error(`translations["${locale}"]["${field}"] exceeds ${cap} characters`);
+      }
+      if (text.trim() === "") continue; // empty values are never stored
+      localeResult[field] = text;
+    }
+    if (Object.keys(localeResult).length > 0) {
+      result[locale] = localeResult;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function serializeContentTranslations(
+  input: unknown,
+  allowedFields: readonly string[],
+): string | null {
+  const validated = validateContentTranslations(input, allowedFields);
+  return validated ? JSON.stringify(validated) : null;
+}

--- a/src/lib/server/content-i18n.ts
+++ b/src/lib/server/content-i18n.ts
@@ -71,10 +71,23 @@ export function validateContentTranslations(
   return Object.keys(result).length > 0 ? result : null;
 }
 
-export function serializeContentTranslations(
-  input: unknown,
-  allowedFields: readonly string[],
-): string | null {
+export function serializeContentTranslations(input: unknown, allowedFields: readonly string[]): string | null {
   const validated = validateContentTranslations(input, allowedFields);
   return validated ? JSON.stringify(validated) : null;
+}
+
+/**
+ * Resolves what to persist for a `translations` column on an UPDATE, giving the field
+ * keep-on-undefined semantics: an omitted key preserves whatever is already stored, while an
+ * explicit value (object or null) always replaces it. Callers whose input omits `translations`
+ * entirely (e.g. cards that only edit unrelated settings) must not silently null out authored
+ * translations.
+ */
+export function resolveTranslationsForUpdate(
+  incoming: unknown,
+  existingRaw: string | null | undefined,
+  allowedFields: readonly string[],
+): string | null {
+  if (incoming === undefined) return existingRaw ?? null;
+  return serializeContentTranslations(incoming, allowedFields);
 }

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -22,6 +22,11 @@ import { GetAllSiteData } from "./siteDataController.js";
 import subscriberQueue from "../queues/subscriberQueue.js";
 import mdToHTML from "../../marked.js";
 import type { SubscriptionVariableMap } from "../notification/types.js";
+import {
+  serializeContentTranslations,
+  INCIDENT_TRANSLATABLE_FIELDS,
+  INCIDENT_COMMENT_TRANSLATABLE_FIELDS,
+} from "../content-i18n.js";
 
 interface IncidentsDashboardInput {
   page: number;
@@ -40,6 +45,7 @@ export interface IncidentInput {
   incident_type?: string;
   incident_source?: string;
   is_global?: string;
+  translations?: unknown;
 }
 
 interface IncidentUpdateInput {
@@ -49,6 +55,7 @@ interface IncidentUpdateInput {
   status?: string;
   state?: string;
   is_global?: string;
+  translations?: unknown;
 }
 
 export const GetIncidentsOpenHome = async (
@@ -313,6 +320,7 @@ export const CreateIncident = async (data: IncidentInput): Promise<{ incident_id
     incident_type: !!data.incident_type ? data.incident_type : "INCIDENT",
     incident_source: !!data.incident_source ? data.incident_source : "DASHBOARD",
     is_global: data.is_global || "YES",
+    translations: serializeContentTranslations(data.translations, INCIDENT_TRANSLATABLE_FIELDS),
   };
 
   //incident_type == INCIDENT delete endDateTime
@@ -352,6 +360,10 @@ export const UpdateIncident = async (incident_id: number, data: IncidentUpdateIn
     state: data.state || incidentExists.state,
     end_date_time: data.end_date_time || incidentExists.end_date_time,
     is_global: data.is_global !== undefined ? data.is_global : incidentExists.is_global,
+    translations:
+      data.translations !== undefined
+        ? serializeContentTranslations(data.translations, INCIDENT_TRANSLATABLE_FIELDS)
+        : incidentExists.translations,
   };
 
   return await db.updateIncident(updateObject as IncidentRecord);
@@ -396,6 +408,7 @@ export const UpdateCommentByID = async (
   comment: string,
   state: string,
   commented_at: number,
+  translations?: unknown,
 ): Promise<number> => {
   let incidentExists = await db.getIncidentById(incident_id);
   if (!incidentExists) {
@@ -405,7 +418,15 @@ export const UpdateCommentByID = async (
   if (!commentExists) {
     throw new Error(`Comment with id ${comment_id} does not exist`);
   }
-  let c = await db.updateIncidentCommentByID(comment_id, comment, state, commented_at);
+  let c = await db.updateIncidentCommentByID(
+    comment_id,
+    comment,
+    state,
+    commented_at,
+    translations !== undefined
+      ? serializeContentTranslations(translations, INCIDENT_COMMENT_TRANSLATABLE_FIELDS)
+      : (commentExists.translations ?? null),
+  );
   if (c) {
     let incidentUpdate: IncidentUpdateInput = {
       state: state,
@@ -458,6 +479,7 @@ export const AddIncidentComment = async (
   comment: string,
   state: string,
   commented_at: number,
+  translations?: unknown,
 ): Promise<IncidentCommentRecord> => {
   let incidentExists = await db.getIncidentById(incident_id);
   if (!incidentExists) {
@@ -468,7 +490,13 @@ export const AddIncidentComment = async (
     state = incidentExists.state;
   }
 
-  let c = await db.insertIncidentComment(incident_id, comment, state, commented_at);
+  let c = await db.insertIncidentComment(
+    incident_id,
+    comment,
+    state,
+    commented_at,
+    serializeContentTranslations(translations, INCIDENT_COMMENT_TRANSLATABLE_FIELDS),
+  );
   let incidentType = incidentExists.incident_type;
   //update incident state
   if (c && incidentType === GC.INCIDENT) {

--- a/src/lib/server/controllers/maintenanceController.ts
+++ b/src/lib/server/controllers/maintenanceController.ts
@@ -17,6 +17,7 @@ import { GetAllSiteData } from "./controller.js";
 import subscriberQueue from "../queues/subscriberQueue.js";
 import GC from "../../global-constants";
 import seedSiteData from "../db/seedSiteData.js";
+import { serializeContentTranslations, MAINTENANCE_TRANSLATABLE_FIELDS } from "../content-i18n.js";
 
 // ============ Input Interfaces ============
 
@@ -34,6 +35,7 @@ export interface CreateMaintenanceInput {
   // Monitors with their status during maintenance
   monitors?: MonitorWithStatusInput[];
   is_global?: string;
+  translations?: unknown;
 }
 
 export interface UpdateMaintenanceInput {
@@ -45,6 +47,7 @@ export interface UpdateMaintenanceInput {
   status?: "ACTIVE" | "INACTIVE";
   monitors?: MonitorWithStatusInput[];
   is_global?: string;
+  translations?: unknown;
 }
 
 export interface CreateMaintenanceEventInput {
@@ -258,6 +261,7 @@ export const CreateMaintenance = async (data: CreateMaintenanceInput): Promise<{
     duration_seconds: data.duration_seconds,
     status: "ACTIVE",
     is_global: data.is_global || "YES",
+    translations: serializeContentTranslations(data.translations, MAINTENANCE_TRANSLATABLE_FIELDS),
   });
 
   // Add monitors with their status to the maintenance if provided
@@ -359,7 +363,11 @@ export const UpdateMaintenance = async (id: number, data: UpdateMaintenanceInput
   }
 
   // Extract monitors separately as it's not part of the record
-  const { monitors, ...updateData } = data;
+  const { monitors, translations, ...rest } = data;
+  const updateData: Partial<MaintenanceRecordInsert> = { ...rest };
+  if (translations !== undefined) {
+    updateData.translations = serializeContentTranslations(translations, MAINTENANCE_TRANSLATABLE_FIELDS);
+  }
 
   // Determine the rrule after update (use new value if provided, otherwise existing)
   const effectiveRrule = data.rrule !== undefined ? data.rrule : existing.rrule;

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -211,8 +211,8 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
  * callers on the UPDATE path whose payload omits `translations` entirely and must therefore
  * preserve whatever is already persisted (see resolveTranslationsForUpdate).
  */
-async function getExistingRawTranslations(tag: string): Promise<string | null> {
-  const existing = await db.getMonitorsByTag(tag);
+async function getExistingRawTranslations(id: number): Promise<string | null> {
+  const [existing] = await db.getMonitors({ id });
   return existing?.translations ?? null;
 }
 
@@ -220,7 +220,7 @@ export const CreateUpdateMonitor = async (monitor: MonitorInput): Promise<number
   const monitorData = { ...monitor };
   if (monitorData.id) {
     const existingRaw =
-      monitor.translations === undefined ? await getExistingRawTranslations(monitorData.tag) : undefined;
+      monitor.translations === undefined ? await getExistingRawTranslations(monitorData.id) : undefined;
     const translations = resolveTranslationsForUpdate(monitor.translations, existingRaw, MONITOR_TRANSLATABLE_FIELDS);
     return await db.updateMonitor({ ...monitorData, translations } as MonitorRecord);
   } else {
@@ -309,8 +309,7 @@ export const UpdateMonitor = async (monitor: MonitorInput): Promise<number> => {
   if (!!!monitorData.id || monitorData.id === 0) {
     throw new Error("monitor id cannot be empty or 0");
   }
-  const existingRaw =
-    monitor.translations === undefined ? await getExistingRawTranslations(monitorData.tag) : undefined;
+  const existingRaw = monitor.translations === undefined ? await getExistingRawTranslations(monitorData.id) : undefined;
   const translations = resolveTranslationsForUpdate(monitor.translations, existingRaw, MONITOR_TRANSLATABLE_FIELDS);
   return await db.updateMonitor({ ...monitorData, translations } as MonitorRecord);
 };

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -28,7 +28,11 @@ import { GetLastMonitoringValue, SetLastHeartbeat, DeleteMonitorCaches } from ".
 import { CollapseStatusCounts } from "../../clientTools.js";
 import { translate, isLocaleAvailable } from "../i18n.js";
 import type { HeartbeatMonitor, GroupMonitorTypeData } from "../types/monitor.js";
-import { serializeContentTranslations, MONITOR_TRANSLATABLE_FIELDS } from "../content-i18n.js";
+import {
+  serializeContentTranslations,
+  resolveTranslationsForUpdate,
+  MONITOR_TRANSLATABLE_FIELDS,
+} from "../content-i18n.js";
 import { parseContentTranslations } from "../../content-i18n.js";
 
 interface GroupUpdateData {
@@ -38,8 +42,13 @@ interface GroupUpdateData {
   latency: number;
 }
 
-interface MonitorInput extends MonitorRecordInsert {
+// `translations` is retyped to `unknown` here (vs. MonitorRecordInsert's stored-shape
+// `string | null`) because callers pass a raw ContentTranslations object, an already-serialized
+// string, undefined (omitted), or explicit null — mirroring IncidentInput/CreateMaintenanceInput.
+// MonitorRecordInsert/MonitorRecord themselves are left untouched since they describe actual DB rows.
+interface MonitorInput extends Omit<MonitorRecordInsert, "translations"> {
   id?: number;
+  translations?: unknown;
 }
 
 /**
@@ -197,25 +206,38 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
   return parsedMonitors;
 };
 
+/**
+ * Looks up the raw (still-serialized) translations string currently stored for a monitor, for
+ * callers on the UPDATE path whose payload omits `translations` entirely and must therefore
+ * preserve whatever is already persisted (see resolveTranslationsForUpdate).
+ */
+async function getExistingRawTranslations(tag: string): Promise<string | null> {
+  const existing = await db.getMonitorsByTag(tag);
+  return existing?.translations ?? null;
+}
+
 export const CreateUpdateMonitor = async (monitor: MonitorInput): Promise<number | number[]> => {
-  let monitorData = { ...monitor };
-  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
+  const monitorData = { ...monitor };
   if (monitorData.id) {
-    return await db.updateMonitor(monitorData as MonitorRecord);
+    const existingRaw =
+      monitor.translations === undefined ? await getExistingRawTranslations(monitorData.tag) : undefined;
+    const translations = resolveTranslationsForUpdate(monitor.translations, existingRaw, MONITOR_TRANSLATABLE_FIELDS);
+    return await db.updateMonitor({ ...monitorData, translations } as MonitorRecord);
   } else {
     validateMonitorTag(monitorData.tag);
-    return await db.insertMonitor(monitorData);
+    const translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
+    return await db.insertMonitor({ ...monitorData, translations });
   }
 };
 
 export const CreateMonitor = async (monitor: MonitorInput): Promise<number[]> => {
-  let monitorData = { ...monitor };
-  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
+  const monitorData = { ...monitor };
   if (monitorData.id) {
     throw new Error("monitor id must be empty or 0");
   }
   validateMonitorTag(monitorData.tag);
-  return await db.insertMonitor(monitorData);
+  const translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
+  return await db.insertMonitor({ ...monitorData, translations });
 };
 
 interface CloneMonitorInput {
@@ -283,12 +305,14 @@ export const CloneMonitor = async ({ sourceTag, newTag, newName }: CloneMonitorI
 };
 
 export const UpdateMonitor = async (monitor: MonitorInput): Promise<number> => {
-  let monitorData = { ...monitor };
-  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
+  const monitorData = { ...monitor };
   if (!!!monitorData.id || monitorData.id === 0) {
     throw new Error("monitor id cannot be empty or 0");
   }
-  return await db.updateMonitor(monitorData as MonitorRecord);
+  const existingRaw =
+    monitor.translations === undefined ? await getExistingRawTranslations(monitorData.tag) : undefined;
+  const translations = resolveTranslationsForUpdate(monitor.translations, existingRaw, MONITOR_TRANSLATABLE_FIELDS);
+  return await db.updateMonitor({ ...monitorData, translations } as MonitorRecord);
 };
 
 export const GetMonitors = async (data: MonitorFilter): Promise<MonitorRecord[]> => {

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -28,6 +28,8 @@ import { GetLastMonitoringValue, SetLastHeartbeat, DeleteMonitorCaches } from ".
 import { CollapseStatusCounts } from "../../clientTools.js";
 import { translate, isLocaleAvailable } from "../i18n.js";
 import type { HeartbeatMonitor, GroupMonitorTypeData } from "../types/monitor.js";
+import { serializeContentTranslations, MONITOR_TRANSLATABLE_FIELDS } from "../content-i18n.js";
+import { parseContentTranslations } from "../../content-i18n.js";
 
 interface GroupUpdateData {
   monitor_tag: string;
@@ -156,6 +158,7 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
       ...monitorData,
       type_data: {},
       monitor_settings_json: {},
+      translations: null,
     };
 
     if (monitorData.type_data) {
@@ -186,6 +189,8 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
       };
     }
 
+    monitorTyped.translations = parseContentTranslations(monitorData.translations);
+
     return monitorTyped;
   });
 
@@ -194,6 +199,7 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
 
 export const CreateUpdateMonitor = async (monitor: MonitorInput): Promise<number | number[]> => {
   let monitorData = { ...monitor };
+  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
   if (monitorData.id) {
     return await db.updateMonitor(monitorData as MonitorRecord);
   } else {
@@ -204,6 +210,7 @@ export const CreateUpdateMonitor = async (monitor: MonitorInput): Promise<number
 
 export const CreateMonitor = async (monitor: MonitorInput): Promise<number[]> => {
   let monitorData = { ...monitor };
+  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
   if (monitorData.id) {
     throw new Error("monitor id must be empty or 0");
   }
@@ -270,6 +277,7 @@ export const CloneMonitor = async ({ sourceTag, newTag, newName }: CloneMonitorI
     include_degraded_in_downtime: source.include_degraded_in_downtime,
     is_hidden: source.is_hidden,
     monitor_settings_json: source.monitor_settings_json,
+    translations: source.translations,
     external_url: source.external_url,
   });
 };

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -284,6 +284,7 @@ export const CloneMonitor = async ({ sourceTag, newTag, newName }: CloneMonitorI
 
 export const UpdateMonitor = async (monitor: MonitorInput): Promise<number> => {
   let monitorData = { ...monitor };
+  monitorData.translations = serializeContentTranslations(monitorData.translations, MONITOR_TRANSLATABLE_FIELDS);
   if (!!!monitorData.id || monitorData.id === 0) {
     throw new Error("monitor id cannot be empty or 0");
   }
@@ -438,6 +439,7 @@ async function removeTagFromGroupMonitors(tag: string): Promise<void> {
         typeof group.monitor_settings_json === "string"
           ? group.monitor_settings_json
           : JSON.stringify(group.monitor_settings_json),
+      translations: group.translations ? JSON.stringify(group.translations) : null,
       external_url: group.external_url,
     };
 

--- a/src/lib/server/controllers/validators.test.ts
+++ b/src/lib/server/controllers/validators.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { IsValidI18n } from "./validators";
+
+/**
+ * The i18n site-data value drives the public locale picker and, through
+ * fetchTranslatableLocales(), which locales an admin can author content translations for. Until
+ * now IsValidI18n only asked whether the string parsed as JSON, so `"[]"`, `"null"` and `"42"` all
+ * counted as valid configuration.
+ *
+ * The shape the admin UI writes is the contract these rules must not break: every available locale
+ * is written out, each carrying code/name/selected/disabled, with `selected` false for the ones
+ * that are off. So a valid value is NOT "only enabled locales" and entries must not be required to
+ * be selected.
+ */
+describe("IsValidI18n", () => {
+  const uiShape = (defaultLocale = "en") =>
+    JSON.stringify({
+      defaultLocale,
+      locales: [
+        { code: "en", name: "English", selected: true, disabled: false },
+        { code: "de", name: "Deutsch", selected: true, disabled: false },
+        { code: "fr", name: "Français", selected: false, disabled: false },
+      ],
+    });
+
+  it("accepts the shape the internationalization page saves", () => {
+    expect(IsValidI18n(uiShape())).toBe(true);
+  });
+
+  it("accepts a minimal value carrying only the fields that are read", () => {
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: [{ code: "en" }] }))).toBe(true);
+  });
+
+  it("accepts entries whose optional fields are present and well-typed", () => {
+    const value = JSON.stringify({
+      defaultLocale: "de",
+      locales: [{ code: "de", name: "Deutsch", selected: true, disabled: false }],
+    });
+    expect(IsValidI18n(value)).toBe(true);
+  });
+
+  it("rejects a string that is not JSON", () => {
+    expect(IsValidI18n("not json")).toBe(false);
+  });
+
+  it("rejects JSON that is not an object", () => {
+    expect(IsValidI18n("[]")).toBe(false);
+    expect(IsValidI18n("null")).toBe(false);
+    expect(IsValidI18n("42")).toBe(false);
+    expect(IsValidI18n('"en"')).toBe(false);
+  });
+
+  it("rejects a missing or empty defaultLocale", () => {
+    expect(IsValidI18n(JSON.stringify({ locales: [{ code: "en" }] }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "", locales: [{ code: "en" }] }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "   ", locales: [{ code: "en" }] }))).toBe(false);
+  });
+
+  it("rejects a non-string defaultLocale", () => {
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: 1, locales: [{ code: "en" }] }))).toBe(false);
+  });
+
+  it("rejects a missing, non-array or empty locales list", () => {
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en" }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: {} }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: [] }))).toBe(false);
+  });
+
+  it("rejects a locales entry that is not an object with a usable code", () => {
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: ["en"] }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: [{ name: "English" }] }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: [{ code: "" }] }))).toBe(false);
+    expect(IsValidI18n(JSON.stringify({ defaultLocale: "en", locales: [{ code: 42 }] }))).toBe(false);
+  });
+
+  it("rejects a defaultLocale that is not among the listed locales", () => {
+    expect(IsValidI18n(uiShape("ja"))).toBe(false);
+  });
+
+  it("rejects an optional field of the wrong type", () => {
+    const selectedAsString = JSON.stringify({
+      defaultLocale: "en",
+      locales: [{ code: "en", selected: "true" }],
+    });
+    expect(IsValidI18n(selectedAsString)).toBe(false);
+  });
+});

--- a/src/lib/server/controllers/validators.ts
+++ b/src/lib/server/controllers/validators.ts
@@ -76,14 +76,43 @@ export function IsValidFooterHTML(html: unknown): boolean {
   return typeof html === "string";
 }
 
+/**
+ * Validates the i18n site-data value: `{ defaultLocale, locales: [{ code, name?, selected?,
+ * disabled? }] }`.
+ *
+ * Previously this only asked whether the string parsed as JSON, so `"[]"`, `"null"` and `"42"` were
+ * all accepted as configuration and surfaced as a broken locale picker instead of a rejected save.
+ *
+ * Deliberately NOT enforced: that every entry is `selected`, or that the list contains only enabled
+ * locales. The internationalization page writes out every available locale with `selected` false
+ * for the ones that are off, so either rule would reject the shape the app itself saves.
+ */
 export function IsValidI18n(i18n: string): boolean {
+  let parsed: unknown;
   try {
-    JSON.parse(i18n);
+    parsed = JSON.parse(i18n);
   } catch (error) {
     return false;
   }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return false;
 
-  return true;
+  const { defaultLocale, locales } = parsed as { defaultLocale?: unknown; locales?: unknown };
+  if (typeof defaultLocale !== "string" || defaultLocale.trim() === "") return false;
+  if (!Array.isArray(locales) || locales.length === 0) return false;
+
+  const codes = new Set<string>();
+  for (const entry of locales) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
+    const { code, name, selected, disabled } = entry as Record<string, unknown>;
+    if (typeof code !== "string" || code.trim() === "") return false;
+    if (name !== undefined && typeof name !== "string") return false;
+    if (selected !== undefined && typeof selected !== "boolean") return false;
+    if (disabled !== undefined && typeof disabled !== "boolean") return false;
+    codes.add(code);
+  }
+
+  // A default the picker cannot offer leaves the site with no usable default locale.
+  return codes.has(defaultLocale);
 }
 
 export function IsValidAnalytics(analytics: string): boolean {

--- a/src/lib/server/db/repositories/incidents.ts
+++ b/src/lib/server/db/repositories/incidents.ts
@@ -135,6 +135,7 @@ export class IncidentsRepository extends BaseRepository {
       incident_type: data.incident_type,
       incident_source: data.incident_source,
       is_global: data.is_global || "YES",
+      translations: data.translations ?? null,
     };
 
     if (dbType === "postgresql") {
@@ -233,6 +234,7 @@ export class IncidentsRepository extends BaseRepository {
       status: data.status,
       state: data.state,
       is_global: data.is_global,
+      translations: data.translations ?? null,
       updated_at: this.knex.fn.now(),
     });
   }
@@ -261,6 +263,7 @@ export class IncidentsRepository extends BaseRepository {
         "state",
         "incident_type",
         "is_global",
+        "translations",
       )
       .where("id", id)
       .first();
@@ -759,6 +762,7 @@ export class IncidentsRepository extends BaseRepository {
     comment: string,
     state: string,
     commented_at: number,
+    translations: string | null,
   ): Promise<IncidentCommentRecord> {
     const dbType = GetDbType();
 
@@ -767,6 +771,7 @@ export class IncidentsRepository extends BaseRepository {
       incident_id,
       state,
       commented_at,
+      translations,
       created_at: this.knex.fn.now(),
       updated_at: this.knex.fn.now(),
     };
@@ -798,11 +803,18 @@ export class IncidentsRepository extends BaseRepository {
     return await this.knex("incident_comments").where({ incident_id, id }).first();
   }
 
-  async updateIncidentCommentByID(id: number, comment: string, state: string, commented_at: number): Promise<number> {
+  async updateIncidentCommentByID(
+    id: number,
+    comment: string,
+    state: string,
+    commented_at: number,
+    translations: string | null,
+  ): Promise<number> {
     return await this.knex("incident_comments").where({ id }).update({
       comment,
       state,
       commented_at,
+      translations,
       updated_at: this.knex.fn.now(),
     });
   }

--- a/src/lib/server/db/repositories/incidents.ts
+++ b/src/lib/server/db/repositories/incidents.ts
@@ -27,6 +27,8 @@ interface IncidentRowWithMonitor {
   monitor_tag: string;
   monitor_name: string;
   monitor_image: string | null;
+  translations?: string | null;
+  monitor_translations?: string | null;
 }
 
 /**
@@ -52,6 +54,7 @@ export class IncidentsRepository extends BaseRepository {
           updated_at: row.updated_at,
           status: row.status,
           state: row.state,
+          translations: row.translations,
           monitors: [],
         });
       }
@@ -64,6 +67,7 @@ export class IncidentsRepository extends BaseRepository {
           monitor_impact: row.monitor_impact,
           monitor_name: row.monitor_name,
           monitor_image: row.monitor_image,
+          monitor_translations: row.monitor_translations,
         });
       }
     }
@@ -465,6 +469,8 @@ export class IncidentsRepository extends BaseRepository {
         "incident_monitors.monitor_tag",
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
+        "incidents.translations",
+        "monitors.translations as monitor_translations",
       )
       .leftJoin("incident_monitors", "incidents.id", "incident_monitors.incident_id")
       .leftJoin("monitors", "incident_monitors.monitor_tag", "monitors.tag")
@@ -497,6 +503,8 @@ export class IncidentsRepository extends BaseRepository {
         "incident_monitors.monitor_tag",
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
+        "incidents.translations",
+        "monitors.translations as monitor_translations",
       )
       .leftJoin("incident_monitors", "incidents.id", "incident_monitors.incident_id")
       .leftJoin("monitors", "incident_monitors.monitor_tag", "monitors.tag");
@@ -624,6 +632,8 @@ export class IncidentsRepository extends BaseRepository {
         "incident_monitors.monitor_tag",
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
+        "incidents.translations",
+        "monitors.translations as monitor_translations",
       )
       .leftJoin("incident_monitors", "incidents.id", "incident_monitors.incident_id")
       .leftJoin("monitors", "incident_monitors.monitor_tag", "monitors.tag")
@@ -733,6 +743,7 @@ export class IncidentsRepository extends BaseRepository {
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
         "monitors.description as monitor_description",
+        "monitors.translations as monitor_translations",
       );
   }
 
@@ -859,6 +870,8 @@ export class IncidentsRepository extends BaseRepository {
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
         "monitors.is_hidden as monitor_is_hidden",
+        "incidents.translations",
+        "monitors.translations as monitor_translations",
       )
       .leftJoin("incident_monitors", "incidents.id", "incident_monitors.incident_id")
       .leftJoin("monitors", "incident_monitors.monitor_tag", "monitors.tag")
@@ -922,6 +935,8 @@ export class IncidentsRepository extends BaseRepository {
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
         "monitors.is_hidden as monitor_is_hidden",
+        "incidents.translations",
+        "monitors.translations as monitor_translations",
       )
       .leftJoin("incident_monitors", "incidents.id", "incident_monitors.incident_id")
       .leftJoin("monitors", "incident_monitors.monitor_tag", "monitors.tag")
@@ -977,6 +992,7 @@ export class IncidentsRepository extends BaseRepository {
           updated_at: row.updated_at,
           status: row.status,
           state: row.state,
+          translations: row.translations,
           monitors: [],
         });
       }
@@ -989,6 +1005,7 @@ export class IncidentsRepository extends BaseRepository {
           monitor_impact: row.monitor_impact,
           monitor_name: row.monitor_name,
           monitor_image: row.monitor_image,
+          monitor_translations: row.monitor_translations,
         });
       }
     }

--- a/src/lib/server/db/repositories/maintenances.ts
+++ b/src/lib/server/db/repositories/maintenances.ts
@@ -31,6 +31,7 @@ export class MaintenancesRepository extends BaseRepository {
       duration_seconds: data.duration_seconds,
       status: data.status || GC.ACTIVE,
       is_global: data.is_global || "YES",
+      translations: data.translations ?? null,
       created_at: this.knex.fn.now(),
       updated_at: this.knex.fn.now(),
     };

--- a/src/lib/server/db/repositories/maintenances.ts
+++ b/src/lib/server/db/repositories/maintenances.ts
@@ -192,6 +192,7 @@ export class MaintenancesRepository extends BaseRepository {
         "monitors.name as monitor_name",
         "monitors.image as monitor_image",
         "monitors.description as monitor_description",
+        "monitors.translations as monitor_translations",
       );
   }
 
@@ -485,6 +486,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.updated_at",
         "maintenances_events.status as status",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -519,6 +522,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.updated_at",
         "maintenances_events.status as status",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -568,6 +573,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.created_at",
         "maintenances_events.updated_at",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -611,6 +618,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.updated_at",
         "maintenances_events.status as status",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -654,6 +663,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.updated_at",
         "maintenances_events.status as status",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -693,6 +704,8 @@ export class MaintenancesRepository extends BaseRepository {
         "maintenances_events.updated_at",
         "maintenances_events.status as status",
         "maintenances.is_global as is_global",
+        "maintenances.translations",
+        "monitors.translations as monitor_translations",
       )
       .join("maintenances", "maintenances_events.maintenance_id", "maintenances.id")
       .leftJoin("maintenance_monitors", "maintenances_events.maintenance_id", "maintenance_monitors.maintenance_id")
@@ -718,6 +731,7 @@ export class MaintenancesRepository extends BaseRepository {
           id: row.id,
           title: row.title,
           description: row.description,
+          translations: row.translations,
           start_date_time: row.start_date_time,
           end_date_time: row.end_date_time,
           status: row.status,
@@ -734,6 +748,7 @@ export class MaintenancesRepository extends BaseRepository {
         maintenance.monitors.push({
           monitor_tag: row.monitor_tag,
           monitor_name: row.monitor_name,
+          monitor_translations: row.monitor_translations,
           monitor_image: row.monitor_image,
           monitor_impact: row.monitor_impact,
         });

--- a/src/lib/server/db/repositories/monitors.ts
+++ b/src/lib/server/db/repositories/monitors.ts
@@ -43,6 +43,7 @@ export class MonitorsRepository extends BaseRepository {
       include_degraded_in_downtime: data.include_degraded_in_downtime,
       is_hidden: data.is_hidden || "NO",
       monitor_settings_json: data.monitor_settings_json,
+      translations: data.translations ?? null,
       created_at: this.knex.fn.now(),
       updated_at: this.knex.fn.now(),
       external_url: data.external_url,
@@ -67,6 +68,7 @@ export class MonitorsRepository extends BaseRepository {
       include_degraded_in_downtime: data.include_degraded_in_downtime,
       is_hidden: data.is_hidden,
       monitor_settings_json: data.monitor_settings_json,
+      translations: data.translations ?? null,
       updated_at: this.knex.fn.now(),
       external_url: data.external_url,
     });

--- a/src/lib/server/tool.test.ts
+++ b/src/lib/server/tool.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BeginningOfDay,
   BeginningOfMinute,
+  checkIfDuplicateExists,
   DurationInMinutes,
   GetDayStartTimestampUTC,
   GetDayStartWithOffset,
@@ -9,11 +10,25 @@ import {
   GetMinuteStartTimestampUTC,
   GetNowTimestampUTC,
   GetNowTimestampUTCInMs,
+  GetRequiredSecrets,
+  GetWordsStartingWithDollar,
+  HashString,
+  IsStringURLSafe,
+  IsValidHost,
+  IsValidHTTPMethod,
+  IsValidNameServer,
+  IsValidURL,
   IsValidUptimeFormula,
+  MaskString,
   ParsePercentage,
   ParseUptime,
+  ReplaceAllOccurrences,
   UnparsePercentage,
   UptimeCalculator,
+  ValidateEmail,
+  ValidateIpAddress,
+  ValidateMonitorAlerts,
+  ValidateURL,
 } from "./tool";
 import type { TimestampStatusCount } from "./types/db";
 
@@ -202,5 +217,162 @@ describe("UptimeCalculator", () => {
     const result = UptimeCalculator(data);
     expect(result.uptime).toBe("100");
     expect(result.avgLatency).toBe("100ms"); // (0 + 100) / 1 entry with latency > 0
+  });
+});
+
+describe("ValidateIpAddress", () => {
+  it("classifies IPv4, IPv6, domain names, and invalid input", () => {
+    expect(ValidateIpAddress("192.168.1.1")).toBe("IPv4");
+    expect(ValidateIpAddress("8.8.8.8")).toBe("IPv4");
+    expect(ValidateIpAddress("2001:0db8:85a3:0000:0000:8a2e:0370:7334")).toBe("IPv6");
+    expect(ValidateIpAddress("example.com")).toBe("Domain Name");
+    expect(ValidateIpAddress("kener.ing")).toBe("Domain Name");
+    expect(ValidateIpAddress("not valid")).toBe("Invalid");
+  });
+
+  it("documents quirks: permissive IPv4 octets, no shortened IPv6", () => {
+    // The regex does not range-check octets:
+    expect(ValidateIpAddress("999.999.999.999")).toBe("IPv4");
+    // Only full-form IPv6 is recognized:
+    expect(ValidateIpAddress("::1")).toBe("Invalid");
+  });
+});
+
+describe("host / nameserver / URL / method validators", () => {
+  it("IsValidHost accepts dotted domains with a TLD", () => {
+    expect(IsValidHost("example.com")).toBe(true);
+    expect(IsValidHost("sub.domain.co.uk")).toBe(true);
+    expect(IsValidHost("my-site.example.org")).toBe(true);
+    expect(IsValidHost("localhost")).toBe(false);
+    expect(IsValidHost("-bad.com")).toBe(false);
+    expect(IsValidHost("")).toBe(false);
+  });
+
+  it("IsValidNameServer accepts only dotted-quad IPs", () => {
+    expect(IsValidNameServer("8.8.8.8")).toBe(true);
+    expect(IsValidNameServer("example.com")).toBe(false);
+    expect(IsValidNameServer("8.8.8")).toBe(false);
+  });
+
+  it("IsValidURL requires http(s) and no spaces", () => {
+    expect(IsValidURL("https://example.com")).toBe(true);
+    expect(IsValidURL("http://example.com/path?q=1")).toBe(true);
+    expect(IsValidURL("ftp://example.com")).toBe(false);
+    expect(IsValidURL("https://exa mple.com")).toBe(false);
+  });
+
+  it("ValidateURL parses with the URL constructor and allows only http(s)", () => {
+    expect(ValidateURL("https://example.com")).toBe(true);
+    expect(ValidateURL("http://localhost:3000")).toBe(true);
+    expect(ValidateURL("ftp://example.com")).toBe(false);
+    expect(ValidateURL("javascript:alert(1)")).toBe(false);
+    expect(ValidateURL("not a url")).toBe(false);
+  });
+
+  it("IsValidHTTPMethod is uppercase-only", () => {
+    expect(IsValidHTTPMethod("GET")).toBe(true);
+    expect(IsValidHTTPMethod("PATCH")).toBe(true);
+    expect(IsValidHTTPMethod("get")).toBe(false);
+    expect(IsValidHTTPMethod("FETCH")).toBe(false);
+  });
+
+  it("IsStringURLSafe allows unreserved URL characters only", () => {
+    expect(IsStringURLSafe("abc-123_~.")).toBe(true);
+    expect(IsStringURLSafe("a b")).toBe(false);
+    expect(IsStringURLSafe("a/b")).toBe(false);
+  });
+});
+
+describe("ValidateEmail", () => {
+  it("accepts common address shapes", () => {
+    expect(ValidateEmail("user@example.com")).toBe(true);
+    expect(ValidateEmail("first.last@sub.example.co")).toBe(true);
+    expect(ValidateEmail("user+tag@example.com")).toBe(true);
+  });
+
+  it("rejects malformed addresses", () => {
+    expect(ValidateEmail("no-at.example.com")).toBe(false);
+    expect(ValidateEmail("user@")).toBe(false);
+    expect(ValidateEmail("user@nodot")).toBe(false);
+    expect(ValidateEmail("@example.com")).toBe(false);
+  });
+});
+
+describe("string helpers", () => {
+  it("MaskString masks everything but the last 4 characters", () => {
+    expect(MaskString("secret123")).toBe("*****t123");
+    expect(MaskString("abcd")).toBe("****");
+    expect(MaskString("ab")).toBe("**");
+    expect(MaskString("")).toBe("");
+  });
+
+  it("HashString returns the sha256 hex digest", () => {
+    expect(HashString("hello")).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  });
+
+  it("GetWordsStartingWithDollar extracts $-prefixed words", () => {
+    expect(GetWordsStartingWithDollar("run $FOO with $BAR_2")).toEqual(["$FOO", "$BAR_2"]);
+    expect(GetWordsStartingWithDollar("nothing here")).toEqual([]);
+  });
+
+  it("ReplaceAllOccurrences replaces every occurrence of a $-token", () => {
+    expect(ReplaceAllOccurrences("a $X b $X", "$X", "y")).toBe("a y b y");
+  });
+
+  it("checkIfDuplicateExists detects duplicates", () => {
+    expect(checkIfDuplicateExists([1, 2, 2])).toBe(true);
+    expect(checkIfDuplicateExists(["a", "b"])).toBe(false);
+  });
+});
+
+describe("GetRequiredSecrets", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves $-tokens that exist in the environment", () => {
+    vi.stubEnv("KENER_TEST_SECRET", "s3cret");
+    expect(GetRequiredSecrets("token: $KENER_TEST_SECRET")).toEqual([
+      { find: "$KENER_TEST_SECRET", replace: "s3cret" },
+    ]);
+  });
+
+  it("ignores tokens with no matching environment variable", () => {
+    expect(GetRequiredSecrets("token: $KENER_TEST_DEFINITELY_UNSET_VAR")).toEqual([]);
+  });
+});
+
+describe("ValidateMonitorAlerts", () => {
+  beforeEach(() => {
+    // The function console.logs every rejection reason; keep test output clean.
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const validAlert = { triggers: [1], failureThreshold: 1, successThreshold: 2 };
+
+  it("accepts DOWN and/or DEGRADED alerts with triggers and integer thresholds", () => {
+    expect(ValidateMonitorAlerts({ DOWN: validAlert })).toBe(true);
+    expect(ValidateMonitorAlerts({ DOWN: validAlert, DEGRADED: validAlert })).toBe(true);
+  });
+
+  it("rejects missing/empty/unknown-key alert objects", () => {
+    expect(ValidateMonitorAlerts(null)).toBe(false);
+    expect(ValidateMonitorAlerts({})).toBe(false);
+    expect(ValidateMonitorAlerts({ UP: validAlert } as never)).toBe(false);
+  });
+
+  it("rejects missing or empty triggers", () => {
+    expect(ValidateMonitorAlerts({ DOWN: { failureThreshold: 1, successThreshold: 1 } })).toBe(false);
+    expect(ValidateMonitorAlerts({ DOWN: { ...validAlert, triggers: [] } })).toBe(false);
+  });
+
+  it("rejects missing, non-integer, or non-positive thresholds", () => {
+    expect(ValidateMonitorAlerts({ DOWN: { triggers: [1] } })).toBe(false);
+    expect(ValidateMonitorAlerts({ DOWN: { ...validAlert, failureThreshold: 1.5 } })).toBe(false);
+    expect(ValidateMonitorAlerts({ DOWN: { ...validAlert, successThreshold: 0 } })).toBe(false);
   });
 });

--- a/src/lib/server/tool.test.ts
+++ b/src/lib/server/tool.test.ts
@@ -9,7 +9,13 @@ import {
   GetMinuteStartTimestampUTC,
   GetNowTimestampUTC,
   GetNowTimestampUTCInMs,
+  IsValidUptimeFormula,
+  ParsePercentage,
+  ParseUptime,
+  UnparsePercentage,
+  UptimeCalculator,
 } from "./tool";
+import type { TimestampStatusCount } from "./types/db";
 
 // All fixed timestamps are at 12:00 UTC so that local-date-based functions
 // (GetDayStartTimestampUTC mixes local date parts with Date.UTC) produce the
@@ -77,5 +83,124 @@ describe("timestamp helpers", () => {
   it("BeginningOfMinute strips seconds", () => {
     const date = new Date("2026-01-15T12:00:45Z");
     expect(BeginningOfMinute({ date, timeZone: "UTC" })).toBe(NOON_UTC);
+  });
+});
+
+describe("ParseUptime", () => {
+  it("returns '-' when there is no data", () => {
+    expect(ParseUptime(0, 0)).toBe("-");
+  });
+
+  it("returns '0' when nothing is up", () => {
+    expect(ParseUptime(0, 10)).toBe("0");
+  });
+
+  it("returns whole numbers without decimals", () => {
+    expect(ParseUptime(10, 10)).toBe("100");
+    expect(ParseUptime(5, 10)).toBe("50");
+  });
+
+  it("keeps 4 decimal places and strips trailing zeros", () => {
+    expect(ParseUptime(1, 3)).toBe("33.3333");
+    expect(ParseUptime(2, 3)).toBe("66.6667");
+    expect(ParseUptime(1, 8)).toBe("12.5");
+    expect(ParseUptime(999, 1000)).toBe("99.9");
+  });
+});
+
+describe("ParsePercentage / UnparsePercentage", () => {
+  it("formats numbers as percentage strings", () => {
+    expect(ParsePercentage(NaN)).toBe("-");
+    expect(ParsePercentage(0)).toBe("0");
+    expect(ParsePercentage(100)).toBe("100");
+    expect(ParsePercentage(99.9)).toBe("99.9000");
+  });
+
+  it("parses percentage strings back to numbers", () => {
+    expect(UnparsePercentage("99.9")).toBe(99.9);
+    expect(UnparsePercentage("0")).toBe(0);
+    expect(Number.isNaN(UnparsePercentage("-"))).toBe(true);
+  });
+});
+
+describe("IsValidUptimeFormula", () => {
+  it("accepts single variables and operator chains", () => {
+    expect(IsValidUptimeFormula("up")).toBe(true);
+    expect(IsValidUptimeFormula("up + down")).toBe(true);
+    expect(IsValidUptimeFormula("up+down+degraded+maintenance")).toBe(true);
+    expect(IsValidUptimeFormula("up - down * maintenance / degraded")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(IsValidUptimeFormula("UP + Maintenance")).toBe(true);
+  });
+
+  it("rejects malformed formulas", () => {
+    expect(IsValidUptimeFormula("")).toBe(false);
+    expect(IsValidUptimeFormula("   ")).toBe(false);
+    expect(IsValidUptimeFormula("up +")).toBe(false);
+    expect(IsValidUptimeFormula("+ up")).toBe(false);
+    expect(IsValidUptimeFormula("banana + up")).toBe(false);
+    expect(IsValidUptimeFormula("up ** down")).toBe(false);
+    expect(IsValidUptimeFormula("up down")).toBe(false);
+    expect(IsValidUptimeFormula("42")).toBe(false);
+  });
+});
+
+describe("UptimeCalculator", () => {
+  const day = (overrides: Partial<TimestampStatusCount>): TimestampStatusCount => ({
+    ts: 0,
+    countOfUp: 0,
+    countOfDown: 0,
+    countOfDegraded: 0,
+    countOfMaintenance: 0,
+    avgLatency: 0,
+    maxLatency: 0,
+    minLatency: 0,
+    ...overrides,
+  });
+
+  it("computes uptime and latency aggregates with the default formulas", () => {
+    // Defaults (global-constants): numerator "up + maintenance + degraded",
+    // denominator "up + down + degraded + maintenance"
+    const data = [
+      day({ countOfUp: 30, countOfDown: 10, avgLatency: 100, maxLatency: 150, minLatency: 50 }),
+      day({ countOfUp: 50, countOfDegraded: 10, avgLatency: 200, maxLatency: 300, minLatency: 80 }),
+    ];
+    expect(UptimeCalculator(data)).toEqual({
+      uptime: "90", // (80 up + 0 maintenance + 10 degraded) / 100 total
+      avgLatency: "150ms", // (100 + 200) / 2
+      maxLatency: "300ms",
+      minLatency: "50ms",
+    });
+  });
+
+  it("supports a custom numerator formula", () => {
+    const data = [day({ countOfUp: 30, countOfDown: 10 }), day({ countOfUp: 50, countOfDegraded: 10 })];
+    expect(UptimeCalculator(data, "up").uptime).toBe("80");
+  });
+
+  it("falls back to the default formula when the custom one is invalid", () => {
+    const data = [day({ countOfUp: 30, countOfDown: 10 }), day({ countOfUp: 50, countOfDegraded: 10 })];
+    expect(UptimeCalculator(data, "banana + up").uptime).toBe("90");
+  });
+
+  it("returns '-' uptime and empty latencies for no data", () => {
+    expect(UptimeCalculator([])).toEqual({
+      uptime: "-",
+      avgLatency: "",
+      maxLatency: "",
+      minLatency: "",
+    });
+  });
+
+  it("only counts entries with a positive avgLatency toward the average", () => {
+    const data = [
+      day({ countOfUp: 10, avgLatency: 0 }),
+      day({ countOfUp: 10, avgLatency: 100, maxLatency: 100, minLatency: 100 }),
+    ];
+    const result = UptimeCalculator(data);
+    expect(result.uptime).toBe("100");
+    expect(result.avgLatency).toBe("100ms"); // (0 + 100) / 1 entry with latency > 0
   });
 });

--- a/src/lib/server/tool.test.ts
+++ b/src/lib/server/tool.test.ts
@@ -32,9 +32,9 @@ import {
 } from "./tool";
 import type { TimestampStatusCount } from "./types/db";
 
-// All fixed timestamps are at 12:00 UTC so that local-date-based functions
-// (GetDayStartTimestampUTC mixes local date parts with Date.UTC) produce the
-// same result on any machine with a UTC offset between -11 and +11 hours.
+// The npm scripts pin TZ=UTC, so local-date-based functions (GetDayStartTimestampUTC
+// mixes local date parts with Date.UTC) are deterministic here. Fixtures still use
+// noon UTC so the tests stay safe even if vitest is run directly without the pin.
 const NOON_UTC = 1768478400; // 2026-01-15T12:00:00Z
 const DAY_START = 1768435200; // 2026-01-15T00:00:00Z
 

--- a/src/lib/server/tool.test.ts
+++ b/src/lib/server/tool.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BeginningOfDay,
+  BeginningOfMinute,
+  DurationInMinutes,
+  GetDayStartTimestampUTC,
+  GetDayStartWithOffset,
+  GetMinuteStartNowTimestampUTC,
+  GetMinuteStartTimestampUTC,
+  GetNowTimestampUTC,
+  GetNowTimestampUTCInMs,
+} from "./tool";
+
+// All fixed timestamps are at 12:00 UTC so that local-date-based functions
+// (GetDayStartTimestampUTC mixes local date parts with Date.UTC) produce the
+// same result on any machine with a UTC offset between -11 and +11 hours.
+const NOON_UTC = 1768478400; // 2026-01-15T12:00:00Z
+const DAY_START = 1768435200; // 2026-01-15T00:00:00Z
+
+describe("timestamp helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("GetNowTimestampUTC returns the current epoch in seconds", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    expect(GetNowTimestampUTC()).toBe(NOON_UTC);
+  });
+
+  it("GetNowTimestampUTCInMs returns the current epoch in milliseconds", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    expect(GetNowTimestampUTCInMs()).toBe(NOON_UTC * 1000);
+  });
+
+  it("GetMinuteStartTimestampUTC floors a timestamp to the start of its minute", () => {
+    expect(GetMinuteStartTimestampUTC(NOON_UTC + 45)).toBe(NOON_UTC);
+    expect(GetMinuteStartTimestampUTC(NOON_UTC)).toBe(NOON_UTC);
+    expect(GetMinuteStartTimestampUTC(NOON_UTC + 59)).toBe(NOON_UTC);
+  });
+
+  it("GetMinuteStartNowTimestampUTC floors the current time to the minute", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:45Z"));
+    expect(GetMinuteStartNowTimestampUTC()).toBe(NOON_UTC);
+  });
+
+  it("GetDayStartTimestampUTC returns midnight UTC of the timestamp's day", () => {
+    expect(GetDayStartTimestampUTC(NOON_UTC)).toBe(DAY_START);
+    expect(GetDayStartTimestampUTC(DAY_START + 12 * 3600 + 61)).toBe(DAY_START);
+  });
+
+  it("DurationInMinutes floors the difference to whole minutes", () => {
+    expect(DurationInMinutes(0, 600)).toBe(10);
+    expect(DurationInMinutes(0, 59)).toBe(0);
+    expect(DurationInMinutes(DAY_START, NOON_UTC)).toBe(720);
+  });
+
+  it("GetDayStartWithOffset shifts the UTC day start by positive offsets", () => {
+    // 330 minutes = UTC+5:30 (e.g. IST)
+    expect(GetDayStartWithOffset(NOON_UTC, 330)).toBe(DAY_START + 330 * 60);
+    expect(GetDayStartWithOffset(NOON_UTC, 0)).toBe(DAY_START);
+  });
+
+  it("GetDayStartWithOffset moves to the next day for negative offsets", () => {
+    expect(GetDayStartWithOffset(NOON_UTC, -330)).toBe(DAY_START + 86400 - 330 * 60);
+  });
+
+  it("BeginningOfDay returns midnight in the given timezone", () => {
+    const date = new Date("2026-01-15T12:00:00Z");
+    expect(BeginningOfDay({ date, timeZone: "UTC" })).toBe(DAY_START);
+    // Midnight in New York (UTC-5 in January) is 05:00 UTC
+    expect(BeginningOfDay({ date, timeZone: "America/New_York" })).toBe(DAY_START + 5 * 3600);
+  });
+
+  it("BeginningOfMinute strips seconds", () => {
+    const date = new Date("2026-01-15T12:00:45Z");
+    expect(BeginningOfMinute({ date, timeZone: "UTC" })).toBe(NOON_UTC);
+  });
+});

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -545,6 +545,7 @@ export interface MaintenanceRecord {
   created_at: Date;
   updated_at: Date;
   is_global: string;
+  translations?: string | null;
 }
 
 export interface MaintenanceRecordInsert {
@@ -555,6 +556,7 @@ export interface MaintenanceRecordInsert {
   duration_seconds: number;
   status?: "ACTIVE" | "INACTIVE";
   is_global?: string;
+  translations?: string | null;
 }
 
 // ============ maintenance_monitors table ============

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -1,6 +1,7 @@
 // Server-only database types (based on migrations schema)
 import type { Knex } from "knex";
 import type { PageMonitorLayoutStyle } from "$lib/types/api";
+import type { ContentTranslations } from "../../types/common.js";
 
 // ============ monitoring_data table ============
 export interface MonitoringData {
@@ -84,6 +85,7 @@ export interface MonitorRecord {
   include_degraded_in_downtime?: string;
   is_hidden: string;
   monitor_settings_json: string | null;
+  translations?: string | null;
   created_at?: Date;
   updated_at?: Date;
 }
@@ -142,6 +144,7 @@ export interface MonitorRecordTyped {
   include_degraded_in_downtime?: string;
   is_hidden: string;
   monitor_settings_json: MonitorSettings | null;
+  translations: ContentTranslations | null;
   created_at?: Date;
   updated_at?: Date;
   external_url?: string | null;
@@ -166,6 +169,7 @@ export interface MonitorRecordInsert {
   include_degraded_in_downtime?: string;
   is_hidden?: string;
   monitor_settings_json?: string | null;
+  translations?: string | null;
   external_url?: string | null;
 }
 

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -580,6 +580,7 @@ export interface MaintenanceMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
+  monitor_translations?: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -592,6 +593,7 @@ export interface MaintenanceMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
+  monitor_translations?: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -650,6 +652,7 @@ export interface MaintenanceMonitorImpact {
   monitor_name: string;
   monitor_image: string | null;
   monitor_impact: string;
+  monitor_translations?: string | null;
 }
 
 export interface MaintenanceEventsMonitorList {
@@ -663,6 +666,7 @@ export interface MaintenanceEventsMonitorList {
   monitors: MaintenanceMonitorImpact[];
   created_at: Date;
   updated_at: Date;
+  translations?: string | null;
 }
 
 // ============ monitor_alerts_config table ============

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -340,6 +340,7 @@ export interface IncidentMonitorImpact {
   monitor_impact: string;
   monitor_name: string;
   monitor_image: string | null;
+  monitor_translations?: string | null;
 }
 
 export interface IncidentForMonitorList {
@@ -351,6 +352,7 @@ export interface IncidentForMonitorList {
   updated_at: Date;
   status: string;
   state: string;
+  translations?: string | null;
   monitors: IncidentMonitorImpact[];
 }
 
@@ -393,6 +395,7 @@ export interface IncidentMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
+  monitor_translations?: string | null;
   created_at: Date;
   updated_at: Date;
   incident_id: number;

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -332,6 +332,7 @@ export interface IncidentRecord {
   incident_type: string;
   incident_source: string;
   is_global: string;
+  translations?: string | null;
 }
 
 export interface IncidentMonitorImpact {
@@ -366,6 +367,7 @@ export interface IncidentRecordInsert {
   incident_type?: string;
   incident_source?: string;
   is_global?: string;
+  translations?: string | null;
 }
 
 // ============ incident_monitors table ============
@@ -406,6 +408,7 @@ export interface IncidentCommentRecord {
   updated_at: Date;
   status: string;
   state: string;
+  translations?: string | null;
 }
 
 // ============ Filter types ============

--- a/src/lib/stores/i18n.test.ts
+++ b/src/lib/stores/i18n.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { get } from "svelte/store";
+import { i18n, lt } from "./i18n";
+
+describe("lt derived store", () => {
+  it("resolves against the active locale and falls back to the base text", async () => {
+    await i18n.init(
+      [
+        { code: "en", name: "English" },
+        { code: "de", name: "Deutsch" },
+      ],
+      "en",
+      globalThis.fetch,
+    );
+    const translations = { de: { name: "Webseite" } };
+
+    expect(get(lt)(translations, "name", "Website")).toBe("Website");
+
+    await i18n.setLocale("de");
+    expect(get(lt)(translations, "name", "Webseite-fallback")).toBe("Webseite");
+    expect(get(lt)(translations, "description", "Base description")).toBe("Base description");
+    expect(get(lt)(null, "name", "Website")).toBe("Website");
+  });
+});

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -2,7 +2,6 @@ import { writable, derived, get } from "svelte/store";
 import { resolveTranslation } from "$lib/content-i18n";
 import type { ContentTranslations } from "$lib/types/common";
 
-
 // Pre-import locale JSON files at build time for SSR (avoids fetch during SSR)
 const localeModules = import.meta.glob("/src/lib/locales/*.json", {
   eager: true,
@@ -208,9 +207,6 @@ export const t = derived(i18n, ($i18n) => {
  * Usage: {$lt(monitor.translations, "name", monitor.name)}
  */
 export const lt = derived(i18n, ($i18n) => {
-  return (
-    translations: ContentTranslations | string | null | undefined,
-    field: string,
-    fallback: string,
-  ): string => resolveTranslation(translations, $i18n.currentLocale, field, fallback);
+  return (translations: ContentTranslations | string | null | undefined, field: string, fallback: string): string =>
+    resolveTranslation(translations, $i18n.currentLocale, field, fallback);
 });

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -1,4 +1,7 @@
 import { writable, derived, get } from "svelte/store";
+import { resolveTranslation } from "$lib/content-i18n";
+import type { ContentTranslations } from "$lib/types/common";
+
 
 // Pre-import locale JSON files at build time for SSR (avoids fetch during SSR)
 const localeModules = import.meta.glob("/src/lib/locales/*.json", {
@@ -195,4 +198,19 @@ export const t = derived(i18n, ($i18n) => {
       return key;
     }
   };
+});
+
+/**
+ * Derived store resolving per-entity content translations (localised
+ * user-entered content) against the active locale. Unlike `t` it takes a
+ * per-entity translations object (or its raw JSON-string form) and never
+ * warns on missing translations — partial translation is the expected state.
+ * Usage: {$lt(monitor.translations, "name", monitor.name)}
+ */
+export const lt = derived(i18n, ($i18n) => {
+  return (
+    translations: ContentTranslations | string | null | undefined,
+    field: string,
+    fallback: string,
+  ): string => resolveTranslation(translations, $i18n.currentLocale, field, fallback);
 });

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -4,6 +4,7 @@
 import type { MonitorRecordTyped } from "$lib/server/types/db";
 import type { MonitorPublicView } from "$lib/types/monitor";
 import type GC from "$lib/global-constants";
+import type { ContentTranslations } from "$lib/types/common";
 
 export type ApiError = {
   code: string;
@@ -121,6 +122,7 @@ export interface CreateMonitorRequest {
   is_hidden?: string;
   confirmation_threshold?: number | null;
   monitor_settings_json?: MonitorSettings | null;
+  translations?: ContentTranslations | null;
   external_url?: string | null;
 }
 
@@ -142,6 +144,7 @@ export interface UpdateMonitorRequest {
   is_hidden?: string;
   confirmation_threshold?: number | null;
   monitor_settings_json?: MonitorSettings | null;
+  translations?: ContentTranslations | null;
   external_url?: string | null;
 }
 

--- a/src/lib/types/common.ts
+++ b/src/lib/types/common.ts
@@ -14,3 +14,9 @@ export interface MonitorTableRow {
   responseTime: string;
   uptimes: MonitorTableUptime[];
 }
+
+/**
+ * Per-entity content translations: locale code -> field name -> translated text.
+ * Example: { "de": { "name": "Webseite" }, "fr": { "name": "Site web" } }
+ */
+export type ContentTranslations = Record<string, Record<string, string>>;

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/+server.ts
@@ -143,6 +143,9 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
     incident_type: existingIncident.incident_type,
     incident_source: "", // Not used by updateIncident
     is_global: existingIncident.is_global,
+    // This REST endpoint doesn't accept translations input, so keep whatever was
+    // already stored rather than letting db.updateIncident() null it out.
+    translations: existingIncident.translations ?? null,
   };
 
   // Update the incident

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
@@ -147,6 +147,8 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     incident_type: incident.incident_type,
     incident_source: "",
     is_global: incident.is_global,
+    // Preserve stored translations — this state-sync update never intends to change them.
+    translations: incident.translations ?? null,
   });
 
   const response: CreateCommentResponse = {

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
@@ -124,7 +124,15 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   }
 
   // Create comment
-  const createdComment = await db.insertIncidentComment(incident.id, body.comment.trim(), body.state, timestamp);
+  // translations: this REST endpoint doesn't accept translations input yet, so new
+  // comments created here stay untranslated (null) until a future task wires it up.
+  const createdComment = await db.insertIncidentComment(
+    incident.id,
+    body.comment.trim(),
+    body.state,
+    timestamp,
+    null,
+  );
 
   // Update incident state to match the comment state
   await db.updateIncident({

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/comments/[comment_id]/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/comments/[comment_id]/+server.ts
@@ -178,7 +178,15 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
     body.timestamp !== undefined ? GetMinuteStartTimestampUTC(body.timestamp) : existingComment.commented_at;
 
   // Update the comment (does NOT change incident state)
-  await db.updateIncidentCommentByID(commentId, updateComment, updateState, updateTimestamp);
+  // translations: this REST endpoint doesn't accept translations input yet, so keep
+  // whatever was already stored on the comment rather than wiping it.
+  await db.updateIncidentCommentByID(
+    commentId,
+    updateComment,
+    updateState,
+    updateTimestamp,
+    existingComment.translations ?? null,
+  );
 
   // Fetch updated comment
   const updatedComment = await db.getIncidentCommentByIDAndIncident(incident.id, commentId);

--- a/src/routes/(api)/api/v4/monitors/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/+server.ts
@@ -9,6 +9,7 @@ import type {
 } from "$lib/types/api";
 import type { MonitorRecord } from "$lib/server/types/db";
 import { GetMonitorsParsed } from "$lib/server/controllers/monitorsController";
+import { serializeContentTranslations, MONITOR_TRANSLATABLE_FIELDS } from "$lib/server/content-i18n";
 
 function formatDateToISO(date: Date | string): string {
   if (date instanceof Date) {
@@ -114,6 +115,16 @@ export const POST: RequestHandler = async ({ request }) => {
     confirmationThreshold = ct;
   }
 
+  let translations: string | null = null;
+  try {
+    translations = serializeContentTranslations(body.translations, MONITOR_TRANSLATABLE_FIELDS);
+  } catch (e) {
+    const errorResponse: BadRequestResponse = {
+      error: { code: "BAD_REQUEST", message: e instanceof Error ? e.message : "Invalid translations" },
+    };
+    return json(errorResponse, { status: 400 });
+  }
+
   // Prepare monitor data for insertion
   const monitorData = {
     tag: body.tag.trim(),
@@ -130,6 +141,7 @@ export const POST: RequestHandler = async ({ request }) => {
     is_hidden: body.is_hidden ?? "NO",
     confirmation_threshold: confirmationThreshold,
     monitor_settings_json: body.monitor_settings_json ? JSON.stringify(body.monitor_settings_json) : null,
+    translations,
     external_url: body.external_url ?? null,
   };
 

--- a/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
 import db from "$lib/server/db/db";
 import { GetMonitorsParsed, DeleteMonitorCompletelyUsingTag } from "$lib/server/controllers/monitorsController";
+import { serializeContentTranslations, MONITOR_TRANSLATABLE_FIELDS } from "$lib/server/content-i18n";
 import type {
   GetMonitorResponse,
   MonitorResponse,
@@ -138,6 +139,23 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
     }
   } else {
     updateData.monitor_settings_json = JSON.stringify(existingMonitor.monitor_settings_json);
+  }
+
+  if (body.translations !== undefined) {
+    if (body.translations === null) {
+      updateData.translations = null;
+    } else {
+      try {
+        updateData.translations = serializeContentTranslations(body.translations, MONITOR_TRANSLATABLE_FIELDS);
+      } catch (e) {
+        const errorResponse: BadRequestResponse = {
+          error: { code: "BAD_REQUEST", message: e instanceof Error ? e.message : "Invalid translations" },
+        };
+        return json(errorResponse, { status: 400 });
+      }
+    }
+  } else {
+    updateData.translations = existingMonitor.translations ? JSON.stringify(existingMonitor.translations) : null;
   }
 
   await db.updateMonitor(updateData as unknown as Parameters<typeof db.updateMonitor>[0]);

--- a/src/routes/(kener)/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(kener)/incidents/[incident_id]/+page.svelte
@@ -10,7 +10,7 @@
   import mdToHTML from "$lib/marked";
   import ThemePlus from "$lib/components/ThemePlus.svelte";
   import { SveltePurify } from "@humanspeak/svelte-purify";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { formatDate, formatDuration } from "$lib/stores/datetime";
   import clientResolver, { absoluteResolve } from "$lib/client/resolver.js";
   import { page } from "$app/state";
@@ -39,7 +39,9 @@
     <Item.Root class="mb-4 px-0">
       <Item.Content class="min-w-0 flex-1 px-0">
         <h1>
-          <Item.Title class="text-3xl wrap-break-word">{data.incident.title}</Item.Title>
+          <Item.Title class="text-3xl wrap-break-word"
+            >{$lt(data.incident.translations, "title", data.incident.title)}</Item.Title
+          >
         </h1>
       </Item.Content>
     </Item.Root>
@@ -73,7 +75,7 @@
                   </span>
                 </div>
                 <div class="prose prose-sm dark:prose-invert max-w-none min-w-0 overflow-x-auto wrap-break-word">
-                  <SveltePurify html={mdToHTML(comment.comment)} />
+                  <SveltePurify html={mdToHTML($lt(comment.translations, "comment", comment.comment))} />
                 </div>
               </div>
             {/each}
@@ -115,7 +117,7 @@
                     </Tooltip.Root>
                   </Item.Media>
                   <Item.Content>
-                    <Item.Title>{monitor.monitor_name}</Item.Title>
+                    <Item.Title>{$lt(monitor.monitor_translations, "name", monitor.monitor_name)}</Item.Title>
                     <Item.Description>
                       {#if monitor.monitor_impact}
                         <span class="text-{monitor.monitor_impact.toLowerCase()}">

--- a/src/routes/(kener)/maintenances/[maintenance_id]/+page.server.ts
+++ b/src/routes/(kener)/maintenances/[maintenance_id]/+page.server.ts
@@ -61,6 +61,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
     monitor_name: string;
     monitor_image: string | null;
     monitor_impact: string;
+    monitor_translations: string | null;
   }> = [];
 
   if (monitorTags.length > 0) {
@@ -72,6 +73,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
         monitor_name: m.name,
         monitor_image: m.image || null,
         monitor_impact: monitorRecords.find((mr) => mr.monitor_tag === m.tag)?.monitor_impact || "",
+        monitor_translations: m.translations ?? null,
       }));
   }
 

--- a/src/routes/(kener)/maintenances/[maintenance_id]/+page.svelte
+++ b/src/routes/(kener)/maintenances/[maintenance_id]/+page.svelte
@@ -13,7 +13,7 @@
   import mdToHTML from "$lib/marked";
   import ThemePlus from "$lib/components/ThemePlus.svelte";
   import STATUS_ICON from "$lib/icons";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { formatDate, formatDuration } from "$lib/stores/datetime";
   import clientResolver, { absoluteResolve } from "$lib/client/resolver.js";
   import { SveltePurify } from "@humanspeak/svelte-purify";
@@ -84,7 +84,9 @@
     <Item.Root class="mb-4 flex-col items-start px-0 sm:flex-row sm:items-center">
       <Item.Content class="min-w-0 flex-1 px-0">
         <h1>
-          <Item.Title class="text-3xl wrap-break-word">{data.maintenance.title}</Item.Title>
+          <Item.Title class="text-3xl wrap-break-word"
+            >{$lt(data.maintenance.translations, "title", data.maintenance.title)}</Item.Title
+          >
         </h1>
       </Item.Content>
     </Item.Root>
@@ -123,7 +125,9 @@
       {#if data.maintenance.description}
         <div class="bg-background min-w-0 rounded-3xl border">
           <div class="prose prose-sm dark:prose-invert max-w-none min-w-0 overflow-x-auto p-4 wrap-break-word">
-            <SveltePurify html={mdToHTML(data.maintenance.description)} />
+            <SveltePurify
+              html={mdToHTML($lt(data.maintenance.translations, "description", data.maintenance.description))}
+            />
           </div>
         </div>
       {/if}
@@ -206,7 +210,7 @@
                     </Tooltip.Root>
                   </Item.Media>
                   <Item.Content>
-                    <Item.Title>{monitor.monitor_name}</Item.Title>
+                    <Item.Title>{$lt(monitor.monitor_translations, "name", monitor.monitor_name)}</Item.Title>
                     <Item.Description>
                       <span class="text-{monitor.monitor_impact.toLowerCase()}">
                         {$t(monitor.monitor_impact)}

--- a/src/routes/(kener)/maintenances/[maintenance_id]/+page.svelte
+++ b/src/routes/(kener)/maintenances/[maintenance_id]/+page.svelte
@@ -23,6 +23,10 @@
 
   const MaintenanceIcon = STATUS_ICON.MAINTENANCE;
 
+  const maintenanceDescription = $derived(
+    $lt(data.maintenance.translations, "description", data.maintenance.description ?? "")
+  );
+
   // Reference for the scrollable container
   let eventsContainer: HTMLDivElement | undefined = $state();
 
@@ -122,12 +126,10 @@
     <!-- Description and Events (Main Content) -->
     <div class="min-w-0 space-y-6 lg:col-span-2">
       <!-- Description -->
-      {#if data.maintenance.description}
+      {#if maintenanceDescription}
         <div class="bg-background min-w-0 rounded-3xl border">
           <div class="prose prose-sm dark:prose-invert max-w-none min-w-0 overflow-x-auto p-4 wrap-break-word">
-            <SveltePurify
-              html={mdToHTML($lt(data.maintenance.translations, "description", data.maintenance.description))}
-            />
+            <SveltePurify html={mdToHTML(maintenanceDescription)} />
           </div>
         </div>
       {/if}

--- a/src/routes/(kener)/monitors/[monitor_tag]/+page.server.ts
+++ b/src/routes/(kener)/monitors/[monitor_tag]/+page.server.ts
@@ -102,6 +102,7 @@ export const load: PageServerLoad = async ({ params, parent }) => {
       monitorName: monitor.name,
       monitorImage: monitor.image,
       monitorDescription: monitor.description,
+      monitorTranslations: monitor.translations,
       monitorId: monitor.id,
       monitorLastStatus: GetStatusSummary(item),
       textClass: GetStatusColor(item),

--- a/src/routes/(kener)/monitors/[monitor_tag]/+page.svelte
+++ b/src/routes/(kener)/monitors/[monitor_tag]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as Item from "$lib/components/ui/item/index.js";
-  import { t } from "$lib/stores/i18n";
+  import { t, lt } from "$lib/stores/i18n";
   import { formatDate } from "$lib/stores/datetime";
   import { Button } from "$lib/components/ui/button/index.js";
   import ThemePlus from "$lib/components/ThemePlus.svelte";
@@ -17,6 +17,8 @@
   // State
   let descriptionExpanded = $state(false);
   let showInlineEvents = $derived(data.eventDisplaySettings?.showInlineEvents === true);
+  const monitorName = $derived($lt(data.monitorTranslations, "name", data.monitorName));
+  const monitorDescription = $derived($lt(data.monitorTranslations, "description", data.monitorDescription ?? ""));
 
   function toggleDescription(expanded: boolean) {
     descriptionExpanded = expanded;
@@ -52,7 +54,7 @@
     {#if data.monitorImage}
       <img
         src={clientResolver(resolve, data.monitorImage)}
-        alt={data.monitorName || "Monitor icon"}
+        alt={monitorName || "Monitor icon"}
         class="aspect-auto w-12 rounded object-cover"
       />
     {/if}
@@ -60,7 +62,7 @@
       <Item.Content>
         {#if data.monitorName}
           <h1>
-            <Item.Title class="text-3xl">{data.monitorName}</Item.Title>
+            <Item.Title class="text-3xl">{monitorName}</Item.Title>
           </h1>
         {/if}
         {#if data.monitorDescription}
@@ -68,16 +70,16 @@
             <Item.Description
               class="text-muted-foreground w-full {descriptionExpanded ? 'line-clamp-none' : ''} text-pretty"
             >
-              {#if data.monitorDescription.length > 150 && !descriptionExpanded}
-                {data.monitorDescription.slice(0, 150)}...
+              {#if monitorDescription.length > 150 && !descriptionExpanded}
+                {monitorDescription.slice(0, 150)}...
                 <button
                   class="text-accent-foreground inline font-medium hover:underline"
                   onclick={() => toggleDescription(true)}
                 >
                   {$t("Read more")}
                 </button>
-              {:else if data.monitorDescription.length > 150}
-                {data.monitorDescription}
+              {:else if monitorDescription.length > 150}
+                {monitorDescription}
                 <button
                   class="text-accent-foreground inline font-medium hover:underline"
                   onclick={() => toggleDescription(false)}
@@ -85,7 +87,7 @@
                   {$t("Read less")}
                 </button>
               {:else}
-                {data.monitorDescription}
+                {monitorDescription}
               {/if}
             </Item.Description>
           </h2>

--- a/src/routes/(kener)/monitors/[monitor_tag]/+page.svelte
+++ b/src/routes/(kener)/monitors/[monitor_tag]/+page.svelte
@@ -60,12 +60,12 @@
     {/if}
     <Item.Root class="px-0 py-0 ">
       <Item.Content>
-        {#if data.monitorName}
+        {#if monitorName}
           <h1>
             <Item.Title class="text-3xl">{monitorName}</Item.Title>
           </h1>
         {/if}
-        {#if data.monitorDescription}
+        {#if monitorDescription}
           <h2 class="">
             <Item.Description
               class="text-muted-foreground w-full {descriptionExpanded ? 'line-clamp-none' : ''} text-pretty"

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -288,11 +288,18 @@ export async function POST({ request, cookies }) {
     } else if (action == "getComments") {
       resp = await GetIncidentActiveComments(data.incident_id);
     } else if (action == "addComment") {
-      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at);
+      resp = await AddIncidentComment(data.incident_id, data.comment, data.state, data.commented_at, data.translations);
     } else if (action == "deleteComment") {
       resp = await UpdateCommentStatusByID(data.incident_id, data.comment_id, "INACTIVE");
     } else if (action == "updateComment") {
-      resp = await UpdateCommentByID(data.incident_id, data.comment_id, data.comment, data.state, data.commented_at);
+      resp = await UpdateCommentByID(
+        data.incident_id,
+        data.comment_id,
+        data.comment,
+        data.state,
+        data.commented_at,
+        data.translations,
+      );
     } else if (action == "testTrigger") {
       const trigger = await GetTriggerByID(data.trigger_id);
       const siteData = await GetAllSiteData();

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -488,6 +488,7 @@
   function cancelEditComment() {
     editingCommentId = null;
     commentText = "";
+    commentTranslations = {};
     commentState = incident.state;
     commentDateTime = "";
   }
@@ -506,6 +507,7 @@
   function cancelAddComment() {
     addingNewComment = false;
     commentText = "";
+    commentTranslations = {};
     commentState = incident.state;
     commentDateTime = "";
   }

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -30,6 +30,10 @@
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
   import { SveltePurify } from "@humanspeak/svelte-purify";
+  import { parseContentTranslations } from "$lib/content-i18n";
+  import { fetchTranslatableLocales, type TranslatableLocalesInfo } from "$lib/client/manage-locales";
+  import type { ContentTranslations } from "$lib/types/common";
+  import TranslationsButton from "$lib/components/manage/TranslationsButton.svelte";
 
   import CodeMirror from "svelte-codemirror-editor";
   import { markdown } from "@codemirror/lang-markdown";
@@ -60,12 +64,15 @@
     state: GC.INVESTIGATING,
     is_global: "YES"
   });
+  let incidentTranslations = $state<ContentTranslations>({});
+  let localeInfo = $state<TranslatableLocalesInfo>({ defaultLocaleName: "", locales: [] });
 
   // For datetime inputs (convert to/from local datetime string)
   let startDateTimeLocal = $state("");
 
   // First comment for new incidents
   let firstComment = $state("");
+  let firstCommentTranslations = $state<ContentTranslations>({});
 
   // Comments for existing incidents
   let comments = $state<IncidentCommentRecord[]>([]);
@@ -84,6 +91,7 @@
   let addingNewComment = $state(false);
   let editingCommentId = $state<number | null>(null);
   let commentText = $state<string>("");
+  let commentTranslations = $state<ContentTranslations>({});
   let commentState = $state<string>(GC.INVESTIGATING);
   let commentDateTime = $state<string>("");
   let savingComment = $state<boolean>(false);
@@ -153,6 +161,7 @@
           state: result.state,
           is_global: result.is_global || "YES"
         };
+        incidentTranslations = parseContentTranslations(result.translations) ?? {};
         // Fetch comments and monitors
         await Promise.all([fetchComments(), fetchIncidentMonitors()]);
       } else {
@@ -233,6 +242,15 @@
     }
   }
 
+  // Fetch translatable locale info
+  async function fetchLocaleInfo() {
+    try {
+      localeInfo = await fetchTranslatableLocales();
+    } catch (e) {
+      console.error("Failed to fetch translatable locales:", e);
+    }
+  }
+
   // Save incident (create or update)
   async function saveIncident() {
     if (!isValid) return;
@@ -254,7 +272,8 @@
               status: "OPEN",
               state: GC.INVESTIGATING,
               incident_type: GC.INCIDENT,
-              is_global: incident.is_global
+              is_global: incident.is_global,
+              translations: Object.keys(incidentTranslations).length > 0 ? incidentTranslations : null
             }
           })
         });
@@ -291,7 +310,8 @@
                   incident_id: incidentId,
                   comment: firstComment,
                   state: GC.INVESTIGATING,
-                  commented_at: incident.start_date_time
+                  commented_at: incident.start_date_time,
+                  translations: Object.keys(firstCommentTranslations).length > 0 ? firstCommentTranslations : null
                 }
               })
             });
@@ -312,7 +332,8 @@
               start_date_time: incident.start_date_time,
               end_date_time: null,
               status: "OPEN",
-              is_global: incident.is_global
+              is_global: incident.is_global,
+              translations: Object.keys(incidentTranslations).length > 0 ? incidentTranslations : null
             }
           })
         });
@@ -458,6 +479,7 @@
   function startEditComment(comment: IncidentCommentRecord) {
     editingCommentId = comment.id;
     commentText = comment.comment;
+    commentTranslations = parseContentTranslations(comment.translations) ?? {};
     commentState = comment.state;
     commentDateTime = timestampToLocalDatetime(comment.commented_at);
   }
@@ -475,6 +497,7 @@
     addingNewComment = true;
     editingCommentId = null;
     commentText = "";
+    commentTranslations = {};
     commentState = incident.state;
     commentDateTime = timestampToLocalDatetime(Math.floor(Date.now() / 1000));
   }
@@ -504,7 +527,8 @@
               comment_id: editingCommentId,
               comment: commentText,
               state: commentState,
-              commented_at: localDatetimeToTimestamp(commentDateTime)
+              commented_at: localDatetimeToTimestamp(commentDateTime),
+              translations: Object.keys(commentTranslations).length > 0 ? commentTranslations : null
             }
           })
         });
@@ -528,7 +552,8 @@
               incident_id: incident.id,
               comment: commentText,
               state: commentState,
-              commented_at: localDatetimeToTimestamp(commentDateTime)
+              commented_at: localDatetimeToTimestamp(commentDateTime),
+              translations: Object.keys(commentTranslations).length > 0 ? commentTranslations : null
             }
           })
         });
@@ -675,6 +700,7 @@
   $effect(() => {
     fetchIncident();
     fetchAvailableMonitors();
+    fetchLocaleInfo();
   });
 </script>
 
@@ -780,7 +806,18 @@
 
         <!-- Title -->
         <div class="flex flex-col gap-2">
-          <Label for="incident-title">Title <span class="text-destructive">*</span></Label>
+          <div class="flex items-center justify-between">
+            <Label for="incident-title">Title <span class="text-destructive">*</span></Label>
+            {#if localeInfo.locales.length > 0}
+              <TranslationsButton
+                bind:translations={incidentTranslations}
+                field="title"
+                defaultValue={incident.title}
+                defaultLocaleName={localeInfo.defaultLocaleName}
+                locales={localeInfo.locales}
+              />
+            {/if}
+          </div>
           <Input id="incident-title" bind:value={incident.title} placeholder="Brief description of the incident" />
         </div>
 
@@ -814,7 +851,19 @@
         <!-- First Comment (only for new) -->
         {#if isNew}
           <div class="flex flex-col gap-2">
-            <Label for="first-comment">Initial Update (Optional)</Label>
+            <div class="flex items-center justify-between">
+              <Label for="first-comment">Initial Update (Optional)</Label>
+              {#if localeInfo.locales.length > 0}
+                <TranslationsButton
+                  bind:translations={firstCommentTranslations}
+                  field="comment"
+                  defaultValue={firstComment}
+                  defaultLocaleName={localeInfo.defaultLocaleName}
+                  locales={localeInfo.locales}
+                  multiline
+                />
+              {/if}
+            </div>
             <div class="overflow-hidden rounded-md border">
               <CodeMirror
                 bind:value={firstComment}
@@ -1003,7 +1052,19 @@
           {#if addingNewComment}
             <div class="mb-4 space-y-4 rounded-md border p-4">
               <div class="flex flex-col gap-2">
-                <Label>Update Message</Label>
+                <div class="flex items-center justify-between">
+                  <Label>Update Message</Label>
+                  {#if localeInfo.locales.length > 0}
+                    <TranslationsButton
+                      bind:translations={commentTranslations}
+                      field="comment"
+                      defaultValue={commentText}
+                      defaultLocaleName={localeInfo.defaultLocaleName}
+                      locales={localeInfo.locales}
+                      multiline
+                    />
+                  {/if}
+                </div>
                 <div class="overflow-hidden rounded-md border">
                   <CodeMirror
                     bind:value={commentText}
@@ -1069,7 +1130,19 @@
                     <!-- Inline edit mode -->
                     <div class="space-y-4">
                       <div class="flex flex-col gap-2">
-                        <Label>Update Message</Label>
+                        <div class="flex items-center justify-between">
+                          <Label>Update Message</Label>
+                          {#if localeInfo.locales.length > 0}
+                            <TranslationsButton
+                              bind:translations={commentTranslations}
+                              field="comment"
+                              defaultValue={commentText}
+                              defaultLocaleName={localeInfo.defaultLocaleName}
+                              locales={localeInfo.locales}
+                              multiline
+                            />
+                          {/if}
+                        </div>
                         <div class="overflow-hidden rounded-md border">
                           <CodeMirror
                             bind:value={commentText}

--- a/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
@@ -32,6 +32,10 @@
   import { rrulestr } from "rrule";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
+  import { parseContentTranslations } from "$lib/content-i18n";
+  import { fetchTranslatableLocales, type TranslatableLocalesInfo } from "$lib/client/manage-locales";
+  import type { ContentTranslations } from "$lib/types/common";
+  import TranslationsButton from "$lib/components/manage/TranslationsButton.svelte";
 
   let { params }: PageProps = $props();
   const isNew = $derived(params.id === "new");
@@ -74,6 +78,8 @@
     status: "ACTIVE",
     is_global: "YES"
   });
+  let maintenanceTranslations = $state<ContentTranslations>({});
+  let localeInfo = $state<TranslatableLocalesInfo>({ defaultLocaleName: "", locales: [] });
 
   // For datetime input
   let startDateTimeLocal = $state("");
@@ -273,6 +279,7 @@
           status: result.status,
           is_global: result.is_global || "YES"
         };
+        maintenanceTranslations = parseContentTranslations(result.translations) ?? {};
 
         // Parse RRULE for UI
         parseRrule(result.rrule);
@@ -355,7 +362,8 @@
           rrule,
           duration_seconds: calculatedDurationSeconds,
           monitors: selectedMonitors.map((m) => ({ monitor_tag: m.tag, monitor_impact: m.status })),
-          is_global: maintenance.is_global
+          is_global: maintenance.is_global,
+          translations: Object.keys(maintenanceTranslations).length > 0 ? maintenanceTranslations : null
         };
 
         const response = await fetch(clientResolver(resolve, "/manage/api"), {
@@ -380,7 +388,8 @@
           duration_seconds: calculatedDurationSeconds,
           status: maintenance.status,
           monitors: selectedMonitors.map((m) => ({ monitor_tag: m.tag, monitor_impact: m.status })),
-          is_global: maintenance.is_global
+          is_global: maintenance.is_global,
+          translations: Object.keys(maintenanceTranslations).length > 0 ? maintenanceTranslations : null
         };
 
         const response = await fetch(clientResolver(resolve, "/manage/api"), {
@@ -561,9 +570,19 @@
     return monitor?.name || tag;
   }
 
+  // Fetch translatable locale info
+  async function fetchLocaleInfo() {
+    try {
+      localeInfo = await fetchTranslatableLocales();
+    } catch (e) {
+      console.error("Failed to fetch translatable locales:", e);
+    }
+  }
+
   onMount(() => {
     fetchMaintenance();
     fetchAvailableMonitors();
+    fetchLocaleInfo();
   });
 </script>
 
@@ -646,13 +665,36 @@
 
         <!-- Title -->
         <div class="flex flex-col gap-2">
-          <Label for="title">Title <span class="text-destructive">*</span></Label>
+          <div class="flex items-center justify-between">
+            <Label for="title">Title <span class="text-destructive">*</span></Label>
+            {#if localeInfo.locales.length > 0}
+              <TranslationsButton
+                bind:translations={maintenanceTranslations}
+                field="title"
+                defaultValue={maintenance.title}
+                defaultLocaleName={localeInfo.defaultLocaleName}
+                locales={localeInfo.locales}
+              />
+            {/if}
+          </div>
           <Input id="title" bind:value={maintenance.title} placeholder="Scheduled maintenance window" />
         </div>
 
         <!-- Description -->
         <div class="flex flex-col gap-2">
-          <Label for="description">Description</Label>
+          <div class="flex items-center justify-between">
+            <Label for="description">Description</Label>
+            {#if localeInfo.locales.length > 0}
+              <TranslationsButton
+                bind:translations={maintenanceTranslations}
+                field="description"
+                defaultValue={maintenance.description ?? ""}
+                defaultLocaleName={localeInfo.defaultLocaleName}
+                locales={localeInfo.locales}
+                multiline
+              />
+            {/if}
+          </div>
           <Textarea
             id="description"
             bind:value={maintenance.description}

--- a/src/routes/(manage)/manage/app/monitors/[tag]/+page.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/+page.svelte
@@ -216,7 +216,11 @@
   }
 
   async function fetchLocaleInfo() {
-    localeInfo = await fetchTranslatableLocales();
+    try {
+      localeInfo = await fetchTranslatableLocales();
+    } catch (e) {
+      console.error("Failed to fetch translatable locales:", e);
+    }
   }
 
   $effect(() => {

--- a/src/routes/(manage)/manage/app/monitors/[tag]/+page.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/+page.svelte
@@ -19,6 +19,9 @@
   import { toast } from "svelte-sonner";
   import { goto } from "$app/navigation";
   import type { SiteSubMenuOptions } from "$lib/types/site";
+  import { parseContentTranslations } from "$lib/content-i18n";
+  import { fetchTranslatableLocales, type TranslatableLocalesInfo } from "$lib/client/manage-locales";
+  import type { ContentTranslations } from "$lib/types/common";
 
   // Card components
   import GeneralSettingsCard from "./components/GeneralSettingsCard.svelte";
@@ -79,6 +82,8 @@
     monitor_settings_json: "",
     external_url: ""
   });
+  let monitorTranslations = $state<ContentTranslations>({});
+  let localeInfo = $state<TranslatableLocalesInfo>({ defaultLocaleName: "", locales: [] });
 
   // Type-specific data
   let typeData = $state<Record<string, unknown>>({});
@@ -121,6 +126,7 @@
           monitor_settings_json: m.monitor_settings_json || "",
           external_url: m.external_url || ""
         };
+        monitorTranslations = parseContentTranslations(m.translations) ?? {};
         // Parse type_data
         if (m.type_data) {
           try {
@@ -209,11 +215,16 @@
     }
   }
 
+  async function fetchLocaleInfo() {
+    localeInfo = await fetchTranslatableLocales();
+  }
+
   $effect(() => {
     fetchMonitor();
     fetchAvailableMonitors();
     fetchPages();
     getSiteLevelSharingConfig();
+    fetchLocaleInfo();
   });
 
   let activeAccordionItem = $derived<string>(isNew ? "general" : "configuration");
@@ -342,7 +353,7 @@
         <Accordion.Trigger>General Settings</Accordion.Trigger>
         <Accordion.Content class="flex flex-col gap-4 text-balance">
           <!-- General Settings Card -->
-          <GeneralSettingsCard bind:monitor {typeData} {isNew} />
+          <GeneralSettingsCard bind:monitor bind:translations={monitorTranslations} {localeInfo} {typeData} {isNew} />
         </Accordion.Content>
       </Accordion.Item>
       {#if !isNew}

--- a/src/routes/(manage)/manage/app/monitors/[tag]/components/GeneralSettingsCard.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/components/GeneralSettingsCard.svelte
@@ -17,14 +17,19 @@
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
   import GC from "$lib/global-constants.js";
+  import TranslationsButton from "$lib/components/manage/TranslationsButton.svelte";
+  import type { ContentTranslations } from "$lib/types/common";
+  import type { TranslatableLocalesInfo } from "$lib/client/manage-locales";
 
   interface Props {
     monitor: MonitorRecord;
     typeData: Record<string, unknown>;
     isNew: boolean;
+    translations: ContentTranslations;
+    localeInfo: TranslatableLocalesInfo;
   }
 
-  let { monitor = $bindable(), typeData, isNew }: Props = $props();
+  let { monitor = $bindable(), typeData, isNew, translations = $bindable(), localeInfo }: Props = $props();
 
   let savingGeneral = $state(false);
   let uploadingImage = $state(false);
@@ -104,7 +109,8 @@
     try {
       const payload: Record<string, unknown> = {
         ...monitor,
-        type_data: JSON.stringify(typeData)
+        type_data: JSON.stringify(typeData),
+        translations: Object.keys(translations).length > 0 ? translations : null
       };
 
       // Include default uptime settings when creating a new monitor
@@ -147,7 +153,18 @@
   <Card.Content class="space-y-4">
     <div class="grid grid-cols-2 gap-4">
       <div class="flex flex-col gap-2">
-        <Label for="monitor-name">Name <span class="text-destructive">*</span></Label>
+        <div class="flex items-center justify-between">
+          <Label for="monitor-name">Name <span class="text-destructive">*</span></Label>
+          {#if localeInfo.locales.length > 0}
+            <TranslationsButton
+              bind:translations
+              field="name"
+              defaultValue={monitor.name}
+              defaultLocaleName={localeInfo.defaultLocaleName}
+              locales={localeInfo.locales}
+            />
+          {/if}
+        </div>
         <Input id="monitor-name" bind:value={monitor.name} placeholder="My API Monitor" />
       </div>
       <div class="flex flex-col gap-2">
@@ -158,7 +175,19 @@
     </div>
 
     <div class="flex flex-col gap-2">
-      <Label for="monitor-description">Description</Label>
+      <div class="flex items-center justify-between">
+        <Label for="monitor-description">Description</Label>
+        {#if localeInfo.locales.length > 0}
+          <TranslationsButton
+            bind:translations
+            field="description"
+            defaultValue={monitor.description ?? ""}
+            defaultLocaleName={localeInfo.defaultLocaleName}
+            locales={localeInfo.locales}
+            multiline
+          />
+        {/if}
+      </div>
       <Textarea
         id="monitor-description"
         bind:value={monitor.description}
@@ -278,7 +307,8 @@
           }}
         />
         <p class="text-muted-foreground text-xs">
-          Require this many consecutive checks before a status change is recorded. 1 = off (record every check immediately).
+          Require this many consecutive checks before a status change is recorded. 1 = off (record every check
+          immediately).
         </p>
       </div>
     </div>

--- a/static/api-references/v4.json
+++ b/static/api-references/v4.json
@@ -1785,6 +1785,18 @@
             "type": "object",
             "additionalProperties": true
           },
+          "translations": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-locale content translations, keyed by locale code, e.g. {\"de\": {\"name\": \"...\"}}"
+          },
           "external_url": {
             "oneOf": [
               {
@@ -1844,6 +1856,18 @@
           "monitor_settings_json": {
             "type": "object",
             "additionalProperties": true
+          },
+          "translations": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-locale content translations, keyed by locale code, e.g. {\"de\": {\"name\": \"...\"}}"
           },
           "external_url": {
             "oneOf": [
@@ -1912,6 +1936,18 @@
                 "type": "null"
               }
             ]
+          },
+          "translations": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-locale content translations, keyed by locale code, e.g. {\"de\": {\"name\": \"...\"}}"
           },
           "external_url": {
             "oneOf": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import tailwindcss from "@tailwindcss/vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 import version from "vite-plugin-package-version";
@@ -55,6 +56,19 @@ export default defineConfig(({ mode }) => {
     define: {
       __KENER_BUILD_ENV__: JSON.stringify(buildEnv),
       __KENER_IS_PROD__: JSON.stringify(isProduction),
+    },
+    test: {
+      projects: [
+        {
+          extends: "./vite.config.ts",
+          test: {
+            name: "server",
+            environment: "node",
+            include: ["src/**/*.{test,spec}.{js,ts}"],
+            exclude: ["src/**/*.svelte.{test,spec}.{js,ts}"],
+          },
+        },
+      ],
     },
   };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,7 @@ export default defineConfig(({ mode }) => {
     test: {
       projects: [
         {
-          extends: "./vite.config.ts",
+          extends: true,
           test: {
             name: "server",
             environment: "node",
@@ -71,7 +71,7 @@ export default defineConfig(({ mode }) => {
           },
         },
         {
-          extends: "./vite.config.ts",
+          extends: true,
           // Pre-bundle the component-test dependency graph: on a cold Vite cache
           // (every CI runner) a mid-run dep-optimization reload can flake the suite.
           optimizeDeps: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import version from "vite-plugin-package-version";
 import { defineConfig } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
+import { playwright } from "@vitest/browser-playwright";
 
 import * as dotenv from "dotenv";
 
@@ -66,6 +67,23 @@ export default defineConfig(({ mode }) => {
             environment: "node",
             include: ["src/**/*.{test,spec}.{js,ts}"],
             exclude: ["src/**/*.svelte.{test,spec}.{js,ts}"],
+          },
+        },
+        {
+          extends: "./vite.config.ts",
+          test: {
+            name: "client",
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright(),
+              instances: [{ browser: "chromium" }],
+              // Vitest's default browser API port (63315) can fall inside Windows
+              // Hyper-V excluded TCP port ranges; pin below the ephemeral range.
+              api: { port: 5180 },
+            },
+            include: ["src/**/*.svelte.{test,spec}.{js,ts}"],
+            setupFiles: ["./vitest-setup-client.ts"],
           },
         },
       ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,11 @@ export default defineConfig(({ mode }) => {
         },
         {
           extends: "./vite.config.ts",
+          // Pre-bundle the component-test dependency graph: on a cold Vite cache
+          // (every CI runner) a mid-run dep-optimization reload can flake the suite.
+          optimizeDeps: {
+            include: ["layerchart", "mode-watcher", "bits-ui", "d3-scale", "d3-shape"],
+          },
           test: {
             name: "client",
             browser: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import version from "vite-plugin-package-version";
 import { defineConfig } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
 import { playwright } from "@vitest/browser-playwright";
+import { configDefaults } from "vitest/config";
 
 import * as dotenv from "dotenv";
 
@@ -66,7 +67,7 @@ export default defineConfig(({ mode }) => {
             name: "server",
             environment: "node",
             include: ["src/**/*.{test,spec}.{js,ts}"],
-            exclude: ["src/**/*.svelte.{test,spec}.{js,ts}"],
+            exclude: [...configDefaults.exclude, "src/**/*.svelte.{test,spec}.{js,ts}"],
           },
         },
         {
@@ -76,7 +77,7 @@ export default defineConfig(({ mode }) => {
             browser: {
               enabled: true,
               headless: true,
-              provider: playwright(),
+              provider: playwright({ contextOptions: { timezoneId: "UTC" } }),
               instances: [{ browser: "chromium" }],
               // Vitest's default browser API port (63315) can fall inside Windows
               // Hyper-V excluded TCP port ranges; pin below the ephemeral range.

--- a/vitest-setup-client.ts
+++ b/vitest-setup-client.ts
@@ -1,0 +1,27 @@
+import { vi } from "vitest";
+
+// Shared stubs for SvelteKit runtime modules used by components under test.
+// Values are minimal but realistic; individual tests can override with their
+// own vi.mock(...) when they need different page data.
+vi.mock("$app/state", () => ({
+  page: {
+    data: {
+      siteStatusColors: { UP: "#22c55e", DOWN: "#ef4444", DEGRADED: "#eab308", MAINTENANCE: "#3b82f6" },
+      dateAndTimeFormat: { dateOnly: "yyyy-MM-dd", timeOnly: "HH:mm" },
+      nowAtTz: 1768478400, // 2026-01-15T12:00:00Z
+    },
+    url: new URL("http://localhost/"),
+    params: {},
+    route: { id: null },
+    status: 200,
+    error: null,
+    form: null,
+    state: {},
+  },
+}));
+
+vi.mock("$app/paths", () => ({
+  base: "",
+  assets: "",
+  resolve: (path: string) => path,
+}));


### PR DESCRIPTION
Adds a option for all user visible texts to enter texts in all (in internationalization configured) languages.

Example:
<img width="1423" height="532" alt="image" src="https://github.com/user-attachments/assets/2e37929f-fbb1-4cfa-bdf3-a52d74b38fe2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multilingual content support for monitors, incidents, comments, and maintenance records.
  - Added translation editing controls for names, titles, descriptions, and comments.
  - Added localized content display across public status, incident, maintenance, and monitor pages.
  - Added translation support to monitor API requests, responses, and documentation.
- **Bug Fixes**
  - Preserved existing translations during unrelated updates.
  - Improved validation and fallback handling for incomplete or invalid translations.
- **Tests**
  - Expanded automated coverage for translations, UI components, browser behavior, and utility functions.
- **Documentation**
  - Added testing commands and browser setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->