### PR TITLE
fix(ui): wrap affected-monitor badges inside event cards

### DIFF
--- a/src/lib/components/IncidentItem.svelte
+++ b/src/lib/components/IncidentItem.svelte
@@ -52,14 +52,14 @@
     </div>
 
     {#if incident.monitors && incident.monitors.length > 0 && !hideMonitors}
-      <div class="my-1 overflow-x-auto p-1">
-        <div class="flex gap-2">
+      <div class="my-1 p-1">
+        <div class="flex flex-wrap gap-2">
           {#each incident.monitors as monitor (`${incident.id}-${monitor.monitor_tag}`)}
             <Popover.Root>
               <Popover.Trigger disabled={isEmbedded}>
                 <Badge
                   variant="outline"
-                  class="border-{monitor.monitor_impact.toLowerCase()}   cursor-pointer rounded-none border-0 border-b px-0  text-sm font-normal"
+                  class="border-{monitor.monitor_impact.toLowerCase()}   max-w-full cursor-pointer rounded-none border-0 border-b px-0 text-sm font-normal wrap-anywhere whitespace-normal"
                 >
                   {monitor.monitor_name}
                 </Badge>

--- a/src/lib/components/MaintenanceItem.svelte
+++ b/src/lib/components/MaintenanceItem.svelte
@@ -52,13 +52,13 @@
     {/if}
 
     {#if maintenance.monitors && maintenance.monitors.length > 0 && !hideMonitors}
-      <div class="flex gap-2">
+      <div class="flex flex-wrap gap-2">
         {#each maintenance.monitors as monitor}
           <Popover.Root>
             <Popover.Trigger disabled={isEmbedded}>
               <Badge
                 variant="outline"
-                class="border-{monitor.monitor_impact.toLowerCase()}   cursor-pointer rounded-none border-0 border-b px-0  text-sm font-normal"
+                class="border-{monitor.monitor_impact.toLowerCase()}   max-w-full cursor-pointer rounded-none border-0 border-b px-0 text-sm font-normal wrap-anywhere whitespace-normal"
               >
                 {monitor.monitor_name}
               </Badge>


### PR DESCRIPTION
Maintenance cards rendered affected monitors in a non-wrapping flex row, so with many monitors the badges ran past the card edge (#794). Incident cards had the same row hidden behind a horizontal scrollbar instead.

One rule for both now: badges wrap within the box. Also let badge text itself wrap, since the badge base is `whitespace-nowrap` and a single long monitor name could still bleed out on narrow viewports.

Verified locally against a seeded maintenance + incident with 16 monitors each: badges wrap onto multiple rows inside the card at 1900px and 375px, long unbroken names stay contained, normal names still render single-line on desktop.

Fixes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved monitor badge layouts in incident and maintenance views.
  * Long monitor names and badges now wrap cleanly instead of overflowing or being clipped.
  * Updated badge spacing and presentation for better readability across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->