### PR TITLE
fix: updated outdated documentation links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,5 +44,5 @@ The documentation is available in the `docs` folder. You can view it by going to
 
 ## Where to Start
 
-1. Check out the [roadmap items](https://kener.ing/docs/roadmap/)
-2. Add language support by following the [i18n guide](https://kener.ing/docs/i18n/)
+1. Check out the [roadmap items](https://github.com/users/rajnandan1/projects/4)
+2. Add language support by following the [i18n guide](https://kener.ing/docs/v4/internationalization)

--- a/src/routes/(docs)/docs/content/v3/monitor-examples.md
+++ b/src/routes/(docs)/docs/content/v3/monitor-examples.md
@@ -125,7 +125,7 @@ Assuming `ORDER_ID` is present in env
 
 ## Eval Body
 
-Read more about [eval](https://kener.ing/docs/v3/monitors#eval)
+Read more about [eval](https://kener.ing/docs/v3/monitors-api#eval)
 
 Below example will call https://api.github.com/repos/rajnandan1/kener/issues. If the status code is 200 then it will be UP else DOWN. It will also check if the response time is greater than 2000ms then it will be DEGRADED.
 

--- a/src/routes/(docs)/docs/content/v3/monitor-examples.md
+++ b/src/routes/(docs)/docs/content/v3/monitor-examples.md
@@ -125,7 +125,7 @@ Assuming `ORDER_ID` is present in env
 
 ## Eval Body
 
-Read more about [eval](https://kener.ing/docs/monitors#eval)
+Read more about [eval](https://kener.ing/docs/v3/monitors#eval)
 
 Below example will call https://api.github.com/repos/rajnandan1/kener/issues. If the status code is 200 then it will be UP else DOWN. It will also check if the response time is greater than 2000ms then it will be DEGRADED.
 

--- a/src/routes/(manage)/manage/app/users/+page.svelte
+++ b/src/routes/(manage)/manage/app/users/+page.svelte
@@ -389,7 +389,7 @@
         {#if !canSendEmail}
           <p class="text-muted-foreground max-w-xs text-xs">
             Email service not configured. Cannot invite new users. Please go to
-            <a href={`${GC.DOCS_URL}/setup/email-setup`} target="_blank" class="text-blue-500 underline">
+            <a href={`${GC.DOCS_URL}/v4/setup/email-setup`} target="_blank" class="text-blue-500 underline">
               setup email
             </a>
             for more info.


### PR DESCRIPTION
Currently they lead to 404 pages.

Also, what do you think if i try to add i18n to all `/manage/*` pages?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guide links to the latest roadmap and versioned internationalization resources.
  * Corrected the monitor “eval” link to point to the version-specific v3 documentation.
  * Updated the user management “email service not configured” link to the current v4 email setup documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->