### PR TITLE
feat: added UI support for ordinal weekdays

### DIFF
--- a/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
@@ -240,6 +240,29 @@ Occurrences:
 - Continues monthly...
 ```
 
+#### First Weekday of Month (Ordinal BYDAY) {#first-weekday-of-month}
+
+**RRULE:** `FREQ=MONTHLY;BYDAY=1WE`
+
+**Description:** Maintenance occurs on the first Wednesday of each month
+
+**Use Case:** Monthly patch windows tied to a specific weekday
+
+**Example:**
+
+```
+Title: Monthly Patch Window
+Start: June 3, 2026 at 2:30 PM
+RRULE: FREQ=MONTHLY;BYDAY=1WE
+Duration: 90 minutes
+
+Occurrences:
+- Jun 3, 2026 at 2:30 PM
+- Jul 1, 2026 at 2:30 PM
+- Aug 5, 2026 at 2:30 PM
+- Continues monthly...
+```
+
 #### Middle of Month {#middle-of-month}
 
 **RRULE:** `FREQ=MONTHLY;BYMONTHDAY=15`
@@ -362,15 +385,16 @@ Affected Monitors:
 Title: Monthly Security Updates
 Description: Critical security patches and system updates
 Start Date: Sunday, June 4, 2026 at 2:00 AM
-RRULE: FREQ=MONTHLY;BYMONTHDAY=1
+RRULE: FREQ=MONTHLY;BYDAY=1SU
 Duration: 3600 seconds (1 hour)
 Affected Monitors:
     - All Servers: MAINTENANCE
 ```
 
-**Note:** Since RRULE doesn't support "first Sunday", use BYMONTHDAY=1 and choose first occurrence that falls on Sunday, or use BYDAY with ordinal (not supported in Kener UI currently).
+**Note:** Use ordinal weekday syntax in `BYDAY` for "first X weekday" patterns:
 
-**Workaround:** Create as weekly and manage manually or use BYMONTHDAY for specific date.
+- First Sunday: `BYDAY=1SU`
+- First Wednesday: `BYDAY=1WE`
 
 ### Example 4: Business Hours Backup {#example-backup}
 
@@ -469,6 +493,7 @@ Start: 2:00 AM UTC
 ✅ `FREQ=WEEKLY;BYDAY=MO,WE,FR`
 ✅ `FREQ=WEEKLY;INTERVAL=2;BYDAY=SU`
 ✅ `FREQ=MONTHLY;BYMONTHDAY=1`
+✅ `FREQ=MONTHLY;BYDAY=1WE`
 ✅ `FREQ=MINUTELY;COUNT=1`
 
 ### Invalid RRULEs {#invalid-rrules}
@@ -602,6 +627,7 @@ Description: |
 | Every Sunday      | `FREQ=WEEKLY;BYDAY=SU`                 |
 | Bi-weekly Mondays | `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO`      |
 | First of month    | `FREQ=MONTHLY;BYMONTHDAY=1`            |
+| First Wednesday   | `FREQ=MONTHLY;BYDAY=1WE`               |
 | 15th of month     | `FREQ=MONTHLY;BYMONTHDAY=15`           |
 | Quarterly         | `FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1` |
 

--- a/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
+++ b/src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md
@@ -28,10 +28,11 @@ FREQ=frequency[;INTERVAL=n][;BYDAY=days][;BYMONTHDAY=day][;COUNT=n][;UNTIL=date]
 - Default: 1
 - Integer value: 2 = every other, 3 = every third, etc.
 
-**BYDAY** (Optional, for WEEKLY)
+**BYDAY** (Optional, for WEEKLY or MONTHLY with an ordinal prefix)
 
 - Day codes: `MO`, `TU`, `WE`, `TH`, `FR`, `SA`, `SU`
 - Multiple days: `MO,WE,FR`
+- With MONTHLY, prefix a day code with an ordinal to mean "the Nth such weekday of the month": `1WE` (first Wednesday), `1SU` (first Sunday)
 
 **BYMONTHDAY** (Optional, for MONTHLY)
 
@@ -240,7 +241,7 @@ Occurrences:
 - Continues monthly...
 ```
 
-#### First Weekday of Month (Ordinal BYDAY) {#first-weekday-of-month}
+#### Nth Day-of-Week of Month (Ordinal BYDAY) {#first-weekday-of-month}
 
 **RRULE:** `FREQ=MONTHLY;BYDAY=1WE`
 

--- a/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
@@ -28,7 +28,7 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { toast } from "svelte-sonner";
-  import { format, formatDistanceToNow, isPast, isFuture, isWithinInterval, addDays } from "date-fns";
+  import { format, formatDistanceToNow, isPast, isFuture, isWithinInterval } from "date-fns";
   import { rrulestr } from "rrule";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -193,9 +193,16 @@
       const dtstart = new Date(startDateTimeLocal);
       const fullRrule = `DTSTART:${dtstart.toISOString().replace(/[-:]/g, "").split(".")[0]}Z\nRRULE:${customRrule}`;
       const rule = rrulestr(fullRrule);
-      const now = new Date();
-      const windowEnd = addDays(now, 30);
-      const occurrences = rule.between(now, windowEnd, true).slice(0, 5);
+      const occurrences: Date[] = [];
+      let searchFrom = new Date();
+
+      for (let i = 0; i < 5; i++) {
+        const next = rule.after(searchFrom, i === 0);
+        if (!next) break;
+        occurrences.push(next);
+        searchFrom = new Date(next.getTime() + 1000);
+      }
+
       return occurrences.map((d) => format(d, "EEE, MMM d, yyyy 'at' h:mm a"));
     } catch (e) {
       return [];

--- a/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
@@ -200,7 +200,7 @@
         const next = rule.after(searchFrom, i === 0);
         if (!next) break;
         occurrences.push(next);
-        searchFrom = new Date(next.getTime() + 1000);
+        searchFrom = next;
       }
 
       return occurrences.map((d) => format(d, "EEE, MMM d, yyyy 'at' h:mm a"));


### PR DESCRIPTION
Added Support for ordinal weekdays in recurring maintenances.

Before:
<img width="1502" height="287" alt="image" src="https://github.com/user-attachments/assets/9413be5b-dfad-492d-82a7-678dba30db13" />

After:
<img width="1502" height="440" alt="image" src="https://github.com/user-attachments/assets/58cb4ebb-6691-400a-987b-fc53c33c56f3" />

Edited /src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte to support the ui change
Edited /src/routes/(docs)/docs/content/v4/maintenances/rrule-patterns.md for documentation change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Maintenance schedule previews now show the next five occurrences, including events scheduled beyond the next 30 days.
  - Added documentation and examples for ordinal weekday monthly recurrence patterns.

- **Bug Fixes**
  - Updated the monthly security patch example to use the correct first-Sunday recurrence syntax and removed outdated workaround guidance.
  - Expanded recurrence validation examples and reference guidance for supported ordinal weekday patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->