### PR TITLE
Fix inline event flag

### DIFF
--- a/src/lib/components/IncidentItem.svelte
+++ b/src/lib/components/IncidentItem.svelte
@@ -44,7 +44,7 @@
   <Item.Content class="min-w-0 flex-1">
     <div class="flex flex-col items-start justify-start gap-0.5">
       <span class="text-muted-foreground text-xs font-medium uppercase">
-        INCIDENT
+        {$t("incident")}
       </span>
       <span class="text-xs font-medium text-{incident.state.toLowerCase()}">{$t(incident.state)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">

--- a/src/lib/components/IncidentItem.svelte
+++ b/src/lib/components/IncidentItem.svelte
@@ -43,6 +43,9 @@
 <Item.Root class="items-start  p-0 {className} sm:items-center">
   <Item.Content class="min-w-0 flex-1">
     <div class="flex flex-col items-start justify-start gap-0.5">
+      <span class="text-muted-foreground text-xs font-medium uppercase">
+        INCIDENT
+      </span>
       <span class="text-xs font-medium text-{incident.state.toLowerCase()}">{$t(incident.state)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">
         <a {target} class="hover:underline" href={clientResolver(resolve, `/incidents/${incident.id}`)}>

--- a/src/lib/components/MaintenanceItem.svelte
+++ b/src/lib/components/MaintenanceItem.svelte
@@ -36,7 +36,7 @@
   <Item.Content class="min-w-0 flex-1">
     <div class="flex flex-col items-start justify-start gap-0.5">
       <span class="text-muted-foreground text-xs font-medium uppercase">
-        MAINTENANCE
+        {$t("maintenance")}
       </span>
       <span class="text-xs font-medium text-{maintenance.status.toLowerCase()}">{$t(maintenance.status)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">

--- a/src/lib/components/MaintenanceItem.svelte
+++ b/src/lib/components/MaintenanceItem.svelte
@@ -35,6 +35,9 @@
 <Item.Root class="items-start p-0 {className} sm:items-center">
   <Item.Content class="min-w-0 flex-1">
     <div class="flex flex-col items-start justify-start gap-0.5">
+      <span class="text-muted-foreground text-xs font-medium uppercase">
+        MAINTENANCE
+      </span>
       <span class="text-xs font-medium text-{maintenance.status.toLowerCase()}">{$t(maintenance.status)}</span>
       <Item.Title class="min-w-0 text-base wrap-break-word break-all">
         <a {target} class="hover:underline" href={clientResolver(resolve, `/maintenances/${maintenance.id}`)}


### PR DESCRIPTION
## Description

Add event type flags to inline events to improve visibility and consistency with the Events panel.

Several end users reported that it is not immediately clear whether an inline event is an **Incident** or a **Maintenance** (even if the render is not the same), as only the event status (Scheduled, Resolved, Investigating, etc.) is displayed. 

This change adds a visible event type flag to inline event cards, allowing users to quickly identify the nature of the event at a glance.

<img width="812" height="451" alt="image" src="https://github.com/user-attachments/assets/b50b8d0e-287c-46a2-bb16-a7a9633ee2fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added localized “Incident” labels above incident statuses.
  * Added uppercase “Maintenance” labels above maintenance statuses and titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->