### PR TITLE
fix: reference .env-min.example in setup instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Thank you for considering contributing to our project! Here are some guidelines 
    ```
 2. Create a `.env` file in the root of the project and add the following:
    ```bash
-   cp .env.example .env
+   cp .env-min.example .env
    ```
 2. Start the development server:
    ```bash

--- a/src/routes/(docs)/docs/content/v3/quick-start.md
+++ b/src/routes/(docs)/docs/content/v3/quick-start.md
@@ -29,7 +29,7 @@ npm install
 Kener needs some environment variables to be set to run properly. [Here](/docs/environment-vars) are the list of environment variables that you need to set.
 
 ```bash
-cp .env.example .env
+cp .env-min.example .env
 ```
 
 ## Start Kener {#start-kener}


### PR DESCRIPTION
## What does this PR do?

Fixes two broken setup instructions that reference a non-existent `.env.example` file:

- `.github/CONTRIBUTING.md` (Development section): `cp .env.example .env` -> `cp .env-min.example .env`
- `src/routes/(docs)/docs/content/v3/quick-start.md` (Set up Environment Variables): `cp .env.example .env` -> `cp .env-min.example .env`

The repository only tracks `.env-min.example` (with `KENER_SECRET_KEY`, `REDIS_URL`, `ORIGIN`). The v4 deployment docs already reference `.env-min.example` correctly (`mv .env-min.example .env`), so this change aligns the contributing guide and v3 quick start with the existing env-example file.

## How was this tested?

Static verification only: confirmed via `git ls-files` that `.env.example` does not exist and `.env-min.example` is the tracked example file. No runtime testing performed (documentation-only change).

## Checklist

- [ ] Documentation only (2 line changes, no source/config/test changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and quick-start setup instructions to use `.env-min.example` when creating the local `.env` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->