### PR TITLE
docs: fix versioned internal doc links

### DIFF
--- a/src/routes/(docs)/docs/content/v3/apikeys.md
+++ b/src/routes/(docs)/docs/content/v3/apikeys.md
@@ -3,7 +3,7 @@ title: API Keys | Kener
 description: Learn how to set up and work with API keys in kener.
 ---
 
-API keys can be used to call the [APIs of kener](/docs/kener-apis). You can create multiple API keys and use them to call the APIs.
+API keys can be used to call the [APIs of kener](/docs/v3/kener-apis). You can create multiple API keys and use them to call the APIs.
 
 API keys once generated cannot be viewed again so please keep them safe and secure.
 

--- a/src/routes/(docs)/docs/content/v3/changelogs.md
+++ b/src/routes/(docs)/docs/content/v3/changelogs.md
@@ -47,7 +47,7 @@ Here are the changelogs for Kener. Changelogs are only published when there are 
 - Syntax highlighting and error checking for monitor evaluation functions
 - Added support for custom Discord and Slack body templates in triggers
 - Improved variable templating for all notification types
-- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/rbac)
+- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/v3/rbac)
 - Self-service profile management for all users
 - User activation/deactivation controls for admins
 - Added dedicated Badges management page in the admin dashboard

--- a/src/routes/(docs)/docs/content/v3/changelogs.md
+++ b/src/routes/(docs)/docs/content/v3/changelogs.md
@@ -47,7 +47,7 @@ Here are the changelogs for Kener. Changelogs are only published when there are 
 - Syntax highlighting and error checking for monitor evaluation functions
 - Added support for custom Discord and Slack body templates in triggers
 - Improved variable templating for all notification types
-- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/v3/rbac)
+- Added comprehensive user management with 3 roles: admin, editor, and member. Read more in the [access control documentation](/docs/v3/rbac).
 - Self-service profile management for all users
 - User activation/deactivation controls for admins
 - Added dedicated Badges management page in the admin dashboard

--- a/src/routes/(docs)/docs/content/v3/concepts.md
+++ b/src/routes/(docs)/docs/content/v3/concepts.md
@@ -41,7 +41,7 @@ You can set multiple triggers of the same type.
 
 Email Trigger is used to send an email when something goes wrong. It can be configured to send an email to different email addresses.
 
-Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/v3/environment-vars).
+Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more in the [environment variables documentation](/docs/v3/environment-vars).
 
 ### Slack Trigger {#slack-trigger}
 
@@ -103,7 +103,7 @@ Incidents are the ones that are created when something goes wrong. They can be c
 
 There can be two types of incidents - `DOWN` and `DEGRADED`. Incident can have a title, description, severity and status. Status can be `INVESTIGATING`, `IDENTIFIED`, `MONITORING` and `RESOLVED`.
 
-To learn more about incidents, click [here](/docs/v3/incident-management).
+Learn more in the [incident management documentation](/docs/v3/incident-management).
 
 ### Incident Updates
 

--- a/src/routes/(docs)/docs/content/v3/concepts.md
+++ b/src/routes/(docs)/docs/content/v3/concepts.md
@@ -41,7 +41,7 @@ You can set multiple triggers of the same type.
 
 Email Trigger is used to send an email when something goes wrong. It can be configured to send an email to different email addresses.
 
-Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/environment-vars).
+Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/v3/environment-vars).
 
 ### Slack Trigger {#slack-trigger}
 
@@ -103,7 +103,7 @@ Incidents are the ones that are created when something goes wrong. They can be c
 
 There can be two types of incidents - `DOWN` and `DEGRADED`. Incident can have a title, description, severity and status. Status can be `INVESTIGATING`, `IDENTIFIED`, `MONITORING` and `RESOLVED`.
 
-To learn more about incidents, click [here](/docs/incident-management).
+To learn more about incidents, click [here](/docs/v3/incident-management).
 
 ### Incident Updates
 

--- a/src/routes/(docs)/docs/content/v3/customize-site.md
+++ b/src/routes/(docs)/docs/content/v3/customize-site.md
@@ -143,9 +143,7 @@ Repository name of the github repository. If the repository is `https://github.c
 
 `incidentSince` is in hours. It means if an issue is created before X hours then kener would not honor it. What it means is that kener would not show it active incident pages nor it will update the uptime. Default is 30\*24 hours = 720 hours.
 
-To read how to set up github for kener [click here](/docs/gh-setup)
-
-To see how to create an issue [click here](/docs/incident-management)
+To see how to create an issue [click here](/docs/v3/incident-management)
 
 ---
 

--- a/src/routes/(docs)/docs/content/v3/customize-site.md
+++ b/src/routes/(docs)/docs/content/v3/customize-site.md
@@ -143,7 +143,7 @@ Repository name of the github repository. If the repository is `https://github.c
 
 `incidentSince` is in hours. It means if an issue is created before X hours then kener would not honor it. What it means is that kener would not show it active incident pages nor it will update the uptime. Default is 30\*24 hours = 720 hours.
 
-To see how to create an issue [click here](/docs/v3/incident-management)
+See the [incident management documentation](/docs/v3/incident-management) to create an issue.
 
 ---
 

--- a/src/routes/(docs)/docs/content/v3/deployment.md
+++ b/src/routes/(docs)/docs/content/v3/deployment.md
@@ -58,7 +58,7 @@ Make sure `./database` and `./uploads` directories are present in the root direc
 
 ### Examples {#docker-examples}
 
-This example is for sqlite. You can also use postgres. Read more about it [here](/docs/v3/environment-vars#database-url)
+This example is for sqlite. You can also use postgres. See [database configuration](/docs/v3/environment-vars#database-url).
 
 #### sqlite
 
@@ -133,7 +133,7 @@ docker run \
 
 #### Base path
 
-By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/v3/environment-vars/#kener-base-path).
+By default kener runs on `/` but you can change it to `/status` or any other path. See [base path configuration](/docs/v3/environment-vars/#kener-base-path).
 
 <div class="note info">
 

--- a/src/routes/(docs)/docs/content/v3/deployment.md
+++ b/src/routes/(docs)/docs/content/v3/deployment.md
@@ -13,7 +13,7 @@ Make sure you have the following installed:
 - [npm](https://www.npmjs.com/get-npm)
 - [Sqlite3](https://www.sqlite.org/download.html)
 - Make sure `./database` directory is present in the root directory
-- [Set up Environment Variables](/docs/environment-vars). You can use a `.env` file or pass them as arguments. Be sure to add `NODE_ENV=production` for production deployment
+- [Set up Environment Variables](/docs/v3/environment-vars). You can use a `.env` file or pass them as arguments. Be sure to add `NODE_ENV=production` for production deployment
 
 ## NPM {#npm}
 
@@ -52,13 +52,13 @@ ghcr.io/rajnandan1/kener:latest
 
 ### Environment Variables {#docker-env-vars}
 
-[Environment variables](/docs/environment-vars) can be passed with `-e` An example `docker run` command:
+[Environment variables](/docs/v3/environment-vars) can be passed with `-e` An example `docker run` command:
 
 Make sure `./database` and `./uploads` directories are present in the root directory.
 
 ### Examples {#docker-examples}
 
-This example is for sqlite. You can also use postgres. Read more about it [here](/docs/environment-vars#database-url)
+This example is for sqlite. You can also use postgres. Read more about it [here](/docs/v3/environment-vars#database-url)
 
 #### sqlite
 
@@ -133,7 +133,7 @@ docker run \
 
 #### Base path
 
-By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/environment-vars/#kener-base-path).
+By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/v3/environment-vars/#kener-base-path).
 
 <div class="note info">
 

--- a/src/routes/(docs)/docs/content/v3/environment-vars.md
+++ b/src/routes/(docs)/docs/content/v3/environment-vars.md
@@ -75,7 +75,7 @@ export RESEND_SENDER_EMAIL=Some Name <email@domain.com>
 
 ## DATABASE_URL {#database-url}
 
-Kener uses a database to store its data. By default, Kener uses sqlite. You can change the database by setting the `DATABASE_URL` environment variable. The connection string has to start with `sqlite`, `postgresql`, or `mysql`. Read more about [database configuration](/docs/database).
+Kener uses a database to store its data. By default, Kener uses sqlite. You can change the database by setting the `DATABASE_URL` environment variable. The connection string has to start with `sqlite`, `postgresql`, or `mysql`. Read more about [database configuration](/docs/v3/database).
 
 ```bash
 export DATABASE_URL=sqlite://./database/awesomeKener.db

--- a/src/routes/(docs)/docs/content/v3/home-page.md
+++ b/src/routes/(docs)/docs/content/v3/home-page.md
@@ -49,7 +49,7 @@ The URL to redirect to when the link is clicked.
 
 ## Internationalization {#internationalization}
 
-Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/i18n).
+Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/v3/i18n).
 
 - Adding more than one locales will enable a dropdown in the navbar to select the language.
 - Selected languages are stored in cookies and will be used when the user visits the site again.

--- a/src/routes/(docs)/docs/content/v3/home-page.md
+++ b/src/routes/(docs)/docs/content/v3/home-page.md
@@ -49,7 +49,7 @@ The URL to redirect to when the link is clicked.
 
 ## Internationalization {#internationalization}
 
-Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/v3/i18n).
+Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the [internationalization instructions](/docs/v3/i18n).
 
 - Adding more than one locales will enable a dropdown in the navbar to select the language.
 - Selected languages are stored in cookies and will be used when the user visits the site again.

--- a/src/routes/(docs)/docs/content/v3/how-it-works.md
+++ b/src/routes/(docs)/docs/content/v3/how-it-works.md
@@ -25,11 +25,11 @@ Kener has two parts.
 
 ## Site.yaml
 
-This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/v3/site)
+This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read the [Site.yaml documentation](/docs/v3/site).
 
 ## Monitors.yaml
 
-This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/v3/monitors)
+This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read the [Monitors.yaml documentation](/docs/v3/monitors).
 
 ## Data
 

--- a/src/routes/(docs)/docs/content/v3/how-it-works.md
+++ b/src/routes/(docs)/docs/content/v3/how-it-works.md
@@ -25,11 +25,11 @@ Kener has two parts.
 
 ## Site.yaml
 
-This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/customize-site)
+This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/v3/site)
 
 ## Monitors.yaml
 
-This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/monitors)
+This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/v3/monitors)
 
 ## Data
 

--- a/src/routes/(docs)/docs/content/v3/monitor-examples.md
+++ b/src/routes/(docs)/docs/content/v3/monitor-examples.md
@@ -206,7 +206,7 @@ The below monitor will show DEGRADED if 3 or more degraded status in a day and D
 
 ## Monitor with Alerts
 
-Make sure you have set up triggers in `server.yaml`. Read more about [alerts](/docs/alerting).
+Make sure you have set up triggers in `server.yaml`. Read more about [alerts](/docs/v3/triggers).
 
 The below example will trigger an alert if the monitor is DOWN for 10 consecutive times. It will also create an incident in GitHub and send alerts to Webhook, Discord and Slack. It will also trigger an alert if the monitor is DEGRADED for 5 consecutive times. It will not create an incident in GitHub and send alerts to Webhook, Discord and Slack.
 

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -91,25 +91,25 @@ The include degraded is used to include the degraded checks in the total bad che
 
 ### API Monitor {#api-monitor}
 
-To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/monitors-api).
+To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/v3/monitors-api).
 
 ### DNS Monitor {#dns-monitor}
 
-To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/monitors-dns).
+To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/v3/monitors-dns).
 
 ### PING Monitor {#ping-monitor}
 
-To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/monitors-ping).
+To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/v3/monitors-ping).
 
 ### GAMEDIG Monitor {#gamedig-monitor}
 
-To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/monitors-gamedig).
+To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/v3/monitors-gamedig).
 
 ---
 
 ## Triggers {#triggers}
 
-To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/triggers).
+To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/v3/triggers).
 
 - Click on the 🔔 icon on the top right corner of the monitor.
 - Add details for either DOWN or DEGRADED.

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -91,25 +91,25 @@ The include degraded is used to include the degraded checks in the total bad che
 
 ### API Monitor {#api-monitor}
 
-To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/v3/monitors-api).
+To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. Read the [API monitoring documentation](/docs/v3/monitors-api).
 
 ### DNS Monitor {#dns-monitor}
 
-To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/v3/monitors-dns).
+To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. Read the [DNS monitoring documentation](/docs/v3/monitors-dns).
 
 ### PING Monitor {#ping-monitor}
 
-To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/v3/monitors-ping).
+To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. Read the [PING monitoring documentation](/docs/v3/monitors-ping).
 
 ### GAMEDIG Monitor {#gamedig-monitor}
 
-To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/v3/monitors-gamedig).
+To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. Read the [GAMEDIG monitoring documentation](/docs/v3/monitors-gamedig).
 
 ---
 
 ## Triggers {#triggers}
 
-To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/v3/triggers).
+To add a trigger to a monitor make sure you have created a trigger. Read the [trigger documentation](/docs/v3/triggers).
 
 - Click on the 🔔 icon on the top right corner of the monitor.
 - Add details for either DOWN or DEGRADED.

--- a/src/routes/(docs)/docs/content/v3/quick-start.md
+++ b/src/routes/(docs)/docs/content/v3/quick-start.md
@@ -26,7 +26,7 @@ npm install
 
 ## Set up Environment Variables {#set-up-environment-variables}
 
-Kener needs some environment variables to be set to run properly. [Here](/docs/environment-vars) are the list of environment variables that you need to set.
+Kener needs some environment variables to be set to run properly. [Here](/docs/v3/environment-vars) are the list of environment variables that you need to set.
 
 ```bash
 cp .env.example .env
@@ -72,9 +72,9 @@ You can watch the video tutorial on how to get started with Kener
 
 Learn how to configure kener by going through one of the topics
 
-- [Monitors](/docs/monitors): Learn how to set up and work with monitors in kener.
-- [Triggers](/docs/triggers): Learn how to set up and work with triggers in kener.
-- [Environment Variables](/docs/environment-vars): Learn how to set up and work with environment variables in kener.
-- [API](/docs/kener-apis): Learn how to use the API in kener.
-- [Databases](/docs/database): Learn how to set up and work with databases in kener.
-- [Theme](/docs/theme): Learn how to set up and work with theme in kener.
+- [Monitors](/docs/v3/monitors): Learn how to set up and work with monitors in kener.
+- [Triggers](/docs/v3/triggers): Learn how to set up and work with triggers in kener.
+- [Environment Variables](/docs/v3/environment-vars): Learn how to set up and work with environment variables in kener.
+- [API](/docs/v3/kener-apis): Learn how to use the API in kener.
+- [Databases](/docs/v3/database): Learn how to set up and work with databases in kener.
+- [Theme](/docs/v3/theme): Learn how to set up and work with theme in kener.

--- a/src/routes/(docs)/docs/content/v3/quick-start.md
+++ b/src/routes/(docs)/docs/content/v3/quick-start.md
@@ -26,7 +26,7 @@ npm install
 
 ## Set up Environment Variables {#set-up-environment-variables}
 
-Kener needs some environment variables to be set to run properly. [Here](/docs/v3/environment-vars) are the list of environment variables that you need to set.
+Kener needs some environment variables to be set to run properly. See the [environment variables documentation](/docs/v3/environment-vars).
 
 ```bash
 cp .env.example .env

--- a/src/routes/(docs)/docs/content/v4/alerting/alert-configurations.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/alert-configurations.md
@@ -62,6 +62,6 @@ Higher thresholds reduce noise; lower thresholds detect faster.
 
 ## Related pages {#related-pages}
 
-- [Triggers](/docs/alerting/triggers)
-- [Templates](/docs/alerting/templates)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Templates](/docs/v4/alerting/templates)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/overview.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/overview.md
@@ -39,7 +39,7 @@ Current runtime supports:
 
 Trigger templates render with alert and site variables (for example `{{alert_name}}`, `{{alert_status}}`, `{{site_name}}`, `{{site_url}}`).
 
-Use [Templates](/docs/alerting/templates) for the canonical variable list.
+Use [Templates](/docs/v4/alerting/templates) for the canonical variable list.
 
 ## Secret interpolation {#secret-interpolation}
 
@@ -53,7 +53,7 @@ Authorization: Bearer $API_TOKEN
 
 ## Next steps {#next-steps}
 
-- [Alert Configurations](/docs/alerting/alert-configurations)
-- [Triggers](/docs/alerting/triggers)
-- [Templates](/docs/alerting/templates)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Alert Configurations](/docs/v4/alerting/alert-configurations)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Templates](/docs/v4/alerting/templates)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -78,5 +78,5 @@ Authorization: Bearer $API_TOKEN
 
 ## Related pages {#related-pages}
 
-- [Triggers](/docs/alerting/triggers)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/triggers.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/triggers.md
@@ -28,7 +28,7 @@ Runtime currently supports:
 
 ## Template variables {#template-variables}
 
-Trigger bodies/subjects can use Mustache variables. Use the canonical list in [Templates](/docs/alerting/templates).
+Trigger bodies/subjects can use Mustache variables. Use the canonical list in [Templates](/docs/v4/alerting/templates).
 
 ## Secret handling {#secret-handling}
 

--- a/src/routes/(docs)/docs/content/v4/api-reference.md
+++ b/src/routes/(docs)/docs/content/v4/api-reference.md
@@ -123,4 +123,4 @@ Receive real-time notifications for events:
 }
 ```
 
-See [Authentication](/docs/api-reference/authentication) for detailed auth docs, or [Monitors API](/docs/api-reference/monitors) for monitor endpoints.
+See the [OpenAPI reference](/docs/spec/v4/) for authentication and monitor endpoints.

--- a/src/routes/(docs)/docs/content/v4/architecture.md
+++ b/src/routes/(docs)/docs/content/v4/architecture.md
@@ -199,7 +199,7 @@ This ensures in-flight jobs complete and no data is lost during deployments or r
 
 ## Next Steps {#next-steps}
 
-- [Environment Variables](/docs/setup/environment-variables) — required and optional configuration
-- [Database Setup](/docs/setup/database-setup) — choosing and configuring your database
-- [Redis Setup](/docs/setup/redis-setup) — configuring Redis for BullMQ queues
-- [Monitors](/docs/monitors/overview) — understanding monitor types and configuration
+- [Environment Variables](/docs/v4/setup/environment-variables) — required and optional configuration
+- [Database Setup](/docs/v4/setup/database-setup) — choosing and configuring your database
+- [Redis Setup](/docs/v4/setup/redis-setup) — configuring Redis for BullMQ queues
+- [Monitors](/docs/v4/monitors/overview) — understanding monitor types and configuration

--- a/src/routes/(docs)/docs/content/v4/configuration.md
+++ b/src/routes/(docs)/docs/content/v4/configuration.md
@@ -192,7 +192,7 @@ status.yourdomain.com {
 }
 ```
 
-📖 **For complete configuration including SSL, subpaths, load balancing, and troubleshooting**, see the [Reverse Proxy Setup Guide](/docs/advanced-topics/reverse-proxy).
+📖 **For complete configuration including SSL, subpaths, load balancing, and troubleshooting**, see the [Reverse Proxy Setup Guide](/docs/v4/guides/reverse-proxy).
 
 ## Next Steps
 

--- a/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
+++ b/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
@@ -20,7 +20,7 @@ Kener is built and maintained by [Rajnandan1](https://www.rajnandan.com). It is 
 4. Discussions - [discuss](https://github.com/rajnandan1/kener/discussions)
 5. Roadmap - [view](https://github.com/users/rajnandan1/projects/4)
 6. Discord - [join](https://discord.gg/uSTpnuK9XR)
-7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/CONTRIBUTING.md)
+7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/.github/CONTRIBUTING.md)
 
 ## One Click Deployment {#one-click-deployment}
 

--- a/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
+++ b/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
@@ -20,7 +20,7 @@ Kener is built and maintained by [Rajnandan1](https://www.rajnandan.com). It is 
 4. Discussions - [discuss](https://github.com/rajnandan1/kener/discussions)
 5. Roadmap - [view](https://github.com/users/rajnandan1/projects/4)
 6. Discord - [join](https://discord.gg/uSTpnuK9XR)
-7. Contribution - [contribute](/docs/v4/getting-started/contributing)
+7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/CONTRIBUTING.md)
 
 ## One Click Deployment {#one-click-deployment}
 

--- a/src/routes/(docs)/docs/content/v4/guides/reverse-proxy.md
+++ b/src/routes/(docs)/docs/content/v4/guides/reverse-proxy.md
@@ -764,7 +764,7 @@ ab -n 1000 -c 10 https://status.example.com/
 
 ## Next Steps {#next-steps}
 
-- [Environment Variables](/docs/setup/environment-variables) - Configure KENER_BASE_PATH and other variables
-- [Database Setup](/docs/setup/database-setup) - Set up PostgreSQL/MySQL for production
-- [Email Setup](/docs/setup/email-setup) - Configure email notifications
-- [Docker Deployment](/docs/deployment/docker) - Deploy with Docker/Docker Compose
+- [Environment Variables](/docs/v4/setup/environment-variables) - Configure KENER_BASE_PATH and other variables
+- [Database Setup](/docs/v4/setup/database-setup) - Set up PostgreSQL/MySQL for production
+- [Email Setup](/docs/v4/setup/email-setup) - Configure email notifications
+- [Deployment](/docs/v4/setup/deployment) - Deploy with Docker/Docker Compose

--- a/src/routes/(docs)/docs/content/v4/incidents/creating-managing.md
+++ b/src/routes/(docs)/docs/content/v4/incidents/creating-managing.md
@@ -205,7 +205,7 @@ INVESTIGATING → IDENTIFIED → MONITORING → INVESTIGATING → IDENTIFIED →
 
 - Add updates regularly (every 15-30 minutes for critical issues)
 - Include substantive information
-- See [Incident Updates](/docs/incidents/updates)
+- See [Incident Updates](/docs/v4/incidents/updates)
 
 ## Filtering and Organization {#filtering-organization}
 
@@ -248,6 +248,6 @@ To delete an incident:
 
 ## Next Steps {#next-steps}
 
-- [Incident Updates](/docs/incidents/updates) - Learn how to add updates and change incident state
-- [Incident Impact on Monitoring](/docs/incidents/impact-on-monitoring) - Understand how incidents affect monitor status
-- [Auto-Generated Incidents](/docs/incidents/auto-generated) - Configure alerts to create incidents automatically
+- [Incident Updates](/docs/v4/incidents/updates) - Learn how to add updates and change incident state
+- [Incident Impact on Monitoring](/docs/v4/incidents/impact-on-monitoring) - Understand how incidents affect monitor status
+- [Auto-Generated Incidents](/docs/v4/incidents/auto-generated) - Configure alerts to create incidents automatically

--- a/src/routes/(docs)/docs/content/v4/installation.md
+++ b/src/routes/(docs)/docs/content/v4/installation.md
@@ -146,6 +146,6 @@ Verify your `DATABASE_URL` is correct and the database server is running.
 
 ## Next Steps
 
-- Configure your [environment variables](/docs/configuration)
-- Set up your first [monitor](/docs/monitors)
-- Customize your [status page](/docs/configuration)
+- Configure your [environment variables](/docs/v4/setup/environment-variables)
+- Set up your first [monitor](/docs/v4/monitors)
+- Customize your [status page](/docs/v4/setup/site-configuration)

--- a/src/routes/(docs)/docs/content/v4/monitors/grace-period.md
+++ b/src/routes/(docs)/docs/content/v4/monitors/grace-period.md
@@ -46,7 +46,7 @@ PATCH /api/v4/monitors/{monitor_tag}
 { "confirmation_threshold": 5 }
 ```
 
-It is validated as an integer between `1` and `60`. See the [API Reference](/docs/v4/api-reference).
+It is validated as an integer between `1` and `60`. See the [API Reference](/docs/spec/v4/).
 
 ## What gets damped {#scope}
 

--- a/src/routes/(docs)/docs/content/v4/sharing.md
+++ b/src/routes/(docs)/docs/content/v4/sharing.md
@@ -108,4 +108,4 @@ On a monitor page, the share buttons in the top action bar are shown only when a
 
 - [Monitors Overview](/docs/v4/monitors/overview)
 - [Pages](/docs/v4/pages)
-- [Configuration](/docs/v4/configuration)
+- [Configuration](/docs/v4/setup/site-configuration)


### PR DESCRIPTION
## Summary

Fixes internal docs links that were missing their version prefix and caused 404 pages.

- Updated v3 links to use `/docs/v3/...`
- Updated v4 links to use `/docs/v4/...`
- Corrected stale links to current documentation pages
- Verified versioned links resolve through `docs.json`

## Verification

- `npm run check`

Closes #808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v3 and v4 documentation links to use the correct versioned paths.
  * Improved navigation between API, monitoring, alerting, deployment, configuration, incidents, and setup guides.
  * Linked API reference content to the v4 OpenAPI specification.
  * Replaced outdated or obsolete links with current contribution, incident-management, and deployment resources.
  * Added minor spacing improvements between monitor documentation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->