### PR TITLE
Feat/page logo api

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -21,7 +21,11 @@ jobs:
     name: Build and push nightly Docker images
     strategy:
       matrix:
-        variant: [debian, alpine]
+        include:
+          - variant: debian
+            platforms: linux/amd64,linux/arm64
+          - variant: alpine
+            platforms: linux/amd64
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +83,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VARIANT=${{ matrix.variant }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -18,7 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [debian, alpine]
+        include:
+          - variant: debian
+            platforms: linux/amd64,linux/arm64
+          - variant: alpine
+            platforms: linux/amd64
     concurrency:
       group: main-docker-${{ github.ref }}-${{ matrix.variant }}
       cancel-in-progress: true
@@ -80,7 +84,7 @@ jobs:
           build-args: |
             VARIANT=${{ matrix.variant }}
             WITH_DOCS=true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,19 @@ jobs:
     name: Build and push release Docker images
     strategy:
       matrix:
-        variant: [debian, alpine]
-        base_path: ["", "/status"]
+        include:
+          - variant: debian
+            platforms: linux/amd64,linux/arm64
+            base_path: ""
+          - variant: debian
+            platforms: linux/amd64,linux/arm64
+            base_path: /status
+          - variant: alpine
+            platforms: linux/amd64
+            base_path: ""
+          - variant: alpine
+            platforms: linux/amd64
+            base_path: /status
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,7 +145,7 @@ jobs:
             VARIANT=${{ matrix.variant }}
             WITH_DOCS=${{ steps.vars.outputs.with_docs }}
             KENER_BASE_PATH=${{ matrix.base_path }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/src/lib/server/db/dbimpl.ts
+++ b/src/lib/server/db/dbimpl.ts
@@ -226,6 +226,7 @@ class DbImpl {
   getPageByPath!: PagesRepository["getPageByPath"];
   getAllPages!: PagesRepository["getAllPages"];
   updatePage!: PagesRepository["updatePage"];
+  replacePageLogo!: PagesRepository["replacePageLogo"];
   deletePage!: PagesRepository["deletePage"];
 
   // ============ Page Monitors ============
@@ -602,6 +603,7 @@ class DbImpl {
     this.getPageByPath = this.pages.getPageByPath.bind(this.pages);
     this.getAllPages = this.pages.getAllPages.bind(this.pages);
     this.updatePage = this.pages.updatePage.bind(this.pages);
+    this.replacePageLogo = this.pages.replacePageLogo.bind(this.pages);
     this.deletePage = this.pages.deletePage.bind(this.pages);
     this.addMonitorToPage = this.pages.addMonitorToPage.bind(this.pages);
     this.removeMonitorFromPage = this.pages.removeMonitorFromPage.bind(this.pages);

--- a/src/lib/server/db/repositories/pages.ts
+++ b/src/lib/server/db/repositories/pages.ts
@@ -1,6 +1,6 @@
 import { BaseRepository } from "./base.js";
 import { GetDbType } from "../../tool.js";
-import type { PageRecord, PageRecordInsert, PageMonitorRecord, PageMonitorRecordInsert } from "../../types/db.js";
+import type { ImageRecordInsert, PageRecord, PageRecordInsert, PageMonitorRecord, PageMonitorRecordInsert } from "../../types/db.js";
 
 /**
  * Repository for pages and page monitors operations
@@ -52,6 +52,22 @@ export class PagesRepository extends BaseRepository {
         ...data,
         updated_at: this.knex.fn.now(),
       });
+  }
+
+  async replacePageLogo(id: number, image: ImageRecordInsert): Promise<boolean> {
+    return await this.knex.transaction(async (trx) => {
+      await trx("images").insert(image);
+      const updated = await trx("pages")
+        .where("id", id)
+        .update({ page_logo: `/assets/images/${image.id}`, updated_at: trx.fn.now() });
+
+      if (updated === 0) {
+        await trx("images").where("id", image.id).del();
+        return false;
+      }
+
+      return true;
+    });
   }
 
   async deletePage(id: number): Promise<number> {

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -560,6 +560,16 @@ export interface UpdatePageResponse {
   page: PageResponse;
 }
 
+export interface UploadPageLogoRequest {
+  base64: string;
+  mime_type: string;
+  file_name?: string;
+}
+
+export interface UploadPageLogoResponse {
+  page_logo: string;
+}
+
 export interface DeletePageResponse {
   message: string;
 }

--- a/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
+++ b/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
@@ -36,6 +36,8 @@ export const POST: RequestHandler = async ({ locals, request }) => {
   }
 
   let image: Awaited<ReturnType<typeof uploadImage>>;
+  let saving = false;
+  let persisted = false;
   try {
     image = await uploadImage({
       base64: data.base64,
@@ -44,22 +46,25 @@ export const POST: RequestHandler = async ({ locals, request }) => {
       maxWidth: 256,
       maxHeight: 256,
       prefix: "page_logo_",
+      saveImage: async (imageRecord) => {
+        saving = true;
+        persisted = await db.replacePageLogo(page.id, imageRecord);
+      },
     });
   } catch (error) {
     return json(
-      { error: { code: "BAD_REQUEST", message: error instanceof Error ? error.message : "Failed to upload page logo" } },
-      { status: 400 },
+      {
+        error: {
+          code: saving ? "INTERNAL_SERVER_ERROR" : "BAD_REQUEST",
+          message: saving ? "Failed to save page logo" : error instanceof Error ? error.message : "Failed to upload page logo",
+        },
+      },
+      { status: saving ? 500 : 400 },
     );
   }
 
-  try {
-    if ((await db.updatePage(page.id, { page_logo: image.url })) === 0) {
-      await db.deleteImage(image.id).catch(() => undefined);
-      return json({ error: { code: "NOT_FOUND", message: "Page not found" } }, { status: 404 });
-    }
-  } catch {
-    await db.deleteImage(image.id).catch(() => undefined);
-    return json({ error: { code: "INTERNAL_SERVER_ERROR", message: "Failed to save page logo" } }, { status: 500 });
+  if (!persisted) {
+    return json({ error: { code: "NOT_FOUND", message: "Page not found" } }, { status: 404 });
   }
 
   const response: UploadPageLogoResponse = { page_logo: image.url };

--- a/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
+++ b/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
@@ -1,0 +1,42 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import db from "$lib/server/db/db";
+import type { UploadPageLogoRequest, UploadPageLogoResponse } from "$lib/types/api";
+import { uploadImage } from "../../../../../../(manage)/manage/api/+server";
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  const page = locals.page;
+
+  if (!page) {
+    return json({ error: { code: "NOT_FOUND", message: "Page not found" } }, { status: 404 });
+  }
+
+  let body: Partial<UploadPageLogoRequest>;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, { status: 400 });
+  }
+
+  if (typeof body.base64 !== "string" || typeof body.mime_type !== "string") {
+    return json({ error: { code: "BAD_REQUEST", message: "base64 and mime_type are required strings" } }, { status: 400 });
+  }
+
+  try {
+    const image = await uploadImage({
+      base64: body.base64,
+      mimeType: body.mime_type,
+      fileName: typeof body.file_name === "string" ? body.file_name : undefined,
+      maxWidth: 256,
+      maxHeight: 256,
+      prefix: "page_logo_",
+    });
+    await db.updatePage(page.id, { page_logo: image.url });
+    const response: UploadPageLogoResponse = { page_logo: image.url };
+    return json(response);
+  } catch (error) {
+    return json(
+      { error: { code: "BAD_REQUEST", message: error instanceof Error ? error.message : "Failed to upload page logo" } },
+      { status: 400 },
+    );
+  }
+};

--- a/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
+++ b/src/routes/(api)/api/v4/pages/[page_path]/logo/+server.ts
@@ -1,4 +1,5 @@
-import { json, type RequestHandler } from "@sveltejs/kit";
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "@sveltejs/kit";
 import db from "$lib/server/db/db";
 import type { UploadPageLogoRequest, UploadPageLogoResponse } from "$lib/types/api";
 import { uploadImage } from "../../../../../../(manage)/manage/api/+server";
@@ -10,33 +11,57 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     return json({ error: { code: "NOT_FOUND", message: "Page not found" } }, { status: 404 });
   }
 
-  let body: Partial<UploadPageLogoRequest>;
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return json({ error: { code: "BAD_REQUEST", message: "Invalid JSON body" } }, { status: 400 });
   }
 
-  if (typeof body.base64 !== "string" || typeof body.mime_type !== "string") {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return json({ error: { code: "BAD_REQUEST", message: "Request body must be an object" } }, { status: 400 });
+  }
+
+  const data = body as Partial<UploadPageLogoRequest>;
+  if (Object.keys(data).some((key) => !["base64", "mime_type", "file_name"].includes(key))) {
+    return json({ error: { code: "BAD_REQUEST", message: "Unexpected request field" } }, { status: 400 });
+  }
+
+  if (typeof data.base64 !== "string" || typeof data.mime_type !== "string") {
     return json({ error: { code: "BAD_REQUEST", message: "base64 and mime_type are required strings" } }, { status: 400 });
   }
 
+  if (data.file_name !== undefined && typeof data.file_name !== "string") {
+    return json({ error: { code: "BAD_REQUEST", message: "file_name must be a string" } }, { status: 400 });
+  }
+
+  let image: Awaited<ReturnType<typeof uploadImage>>;
   try {
-    const image = await uploadImage({
-      base64: body.base64,
-      mimeType: body.mime_type,
-      fileName: typeof body.file_name === "string" ? body.file_name : undefined,
+    image = await uploadImage({
+      base64: data.base64,
+      mimeType: data.mime_type,
+      fileName: data.file_name,
       maxWidth: 256,
       maxHeight: 256,
       prefix: "page_logo_",
     });
-    await db.updatePage(page.id, { page_logo: image.url });
-    const response: UploadPageLogoResponse = { page_logo: image.url };
-    return json(response);
   } catch (error) {
     return json(
       { error: { code: "BAD_REQUEST", message: error instanceof Error ? error.message : "Failed to upload page logo" } },
       { status: 400 },
     );
   }
+
+  try {
+    if ((await db.updatePage(page.id, { page_logo: image.url })) === 0) {
+      await db.deleteImage(image.id).catch(() => undefined);
+      return json({ error: { code: "NOT_FOUND", message: "Page not found" } }, { status: 404 });
+    }
+  } catch {
+    await db.deleteImage(image.id).catch(() => undefined);
+    return json({ error: { code: "INTERNAL_SERVER_ERROR", message: "Failed to save page logo" } }, { status: 500 });
+  }
+
+  const response: UploadPageLogoResponse = { page_logo: image.url };
+  return json(response);
 };

--- a/src/routes/(docs)/docs/content/v3/apikeys.md
+++ b/src/routes/(docs)/docs/content/v3/apikeys.md
@@ -3,7 +3,7 @@ title: API Keys | Kener
 description: Learn how to set up and work with API keys in kener.
 ---
 
-API keys can be used to call the [APIs of kener](/docs/kener-apis). You can create multiple API keys and use them to call the APIs.
+API keys can be used to call the [APIs of kener](/docs/v3/kener-apis). You can create multiple API keys and use them to call the APIs.
 
 API keys once generated cannot be viewed again so please keep them safe and secure.
 

--- a/src/routes/(docs)/docs/content/v3/changelogs.md
+++ b/src/routes/(docs)/docs/content/v3/changelogs.md
@@ -47,7 +47,7 @@ Here are the changelogs for Kener. Changelogs are only published when there are 
 - Syntax highlighting and error checking for monitor evaluation functions
 - Added support for custom Discord and Slack body templates in triggers
 - Improved variable templating for all notification types
-- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/rbac)
+- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/v3/rbac)
 - Self-service profile management for all users
 - User activation/deactivation controls for admins
 - Added dedicated Badges management page in the admin dashboard

--- a/src/routes/(docs)/docs/content/v3/changelogs.md
+++ b/src/routes/(docs)/docs/content/v3/changelogs.md
@@ -47,7 +47,7 @@ Here are the changelogs for Kener. Changelogs are only published when there are 
 - Syntax highlighting and error checking for monitor evaluation functions
 - Added support for custom Discord and Slack body templates in triggers
 - Improved variable templating for all notification types
-- Added comprehensive user management with 3 roles: admin, editor, and member. Read more [here](/docs/v3/rbac)
+- Added comprehensive user management with 3 roles: admin, editor, and member. Read more in the [access control documentation](/docs/v3/rbac).
 - Self-service profile management for all users
 - User activation/deactivation controls for admins
 - Added dedicated Badges management page in the admin dashboard

--- a/src/routes/(docs)/docs/content/v3/concepts.md
+++ b/src/routes/(docs)/docs/content/v3/concepts.md
@@ -41,7 +41,7 @@ You can set multiple triggers of the same type.
 
 Email Trigger is used to send an email when something goes wrong. It can be configured to send an email to different email addresses.
 
-Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/v3/environment-vars).
+Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more in the [environment variables documentation](/docs/v3/environment-vars).
 
 ### Slack Trigger {#slack-trigger}
 
@@ -103,7 +103,7 @@ Incidents are the ones that are created when something goes wrong. They can be c
 
 There can be two types of incidents - `DOWN` and `DEGRADED`. Incident can have a title, description, severity and status. Status can be `INVESTIGATING`, `IDENTIFIED`, `MONITORING` and `RESOLVED`.
 
-To learn more about incidents, click [here](/docs/v3/incident-management).
+Learn more in the [incident management documentation](/docs/v3/incident-management).
 
 ### Incident Updates
 

--- a/src/routes/(docs)/docs/content/v3/concepts.md
+++ b/src/routes/(docs)/docs/content/v3/concepts.md
@@ -41,7 +41,7 @@ You can set multiple triggers of the same type.
 
 Email Trigger is used to send an email when something goes wrong. It can be configured to send an email to different email addresses.
 
-Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/environment-vars).
+Kener uses [resend.com](https://resend.com) to send emails. Please make sure to sign up in [resend.com](https://resend.com) and get the API key. You will need to set the API key in the environment variable `RESEND_API_KEY`. Learn more about environment variables [here](/docs/v3/environment-vars).
 
 ### Slack Trigger {#slack-trigger}
 
@@ -103,7 +103,7 @@ Incidents are the ones that are created when something goes wrong. They can be c
 
 There can be two types of incidents - `DOWN` and `DEGRADED`. Incident can have a title, description, severity and status. Status can be `INVESTIGATING`, `IDENTIFIED`, `MONITORING` and `RESOLVED`.
 
-To learn more about incidents, click [here](/docs/incident-management).
+To learn more about incidents, click [here](/docs/v3/incident-management).
 
 ### Incident Updates
 

--- a/src/routes/(docs)/docs/content/v3/customize-site.md
+++ b/src/routes/(docs)/docs/content/v3/customize-site.md
@@ -143,9 +143,7 @@ Repository name of the github repository. If the repository is `https://github.c
 
 `incidentSince` is in hours. It means if an issue is created before X hours then kener would not honor it. What it means is that kener would not show it active incident pages nor it will update the uptime. Default is 30\*24 hours = 720 hours.
 
-To read how to set up github for kener [click here](/docs/gh-setup)
-
-To see how to create an issue [click here](/docs/incident-management)
+To see how to create an issue [click here](/docs/v3/incident-management)
 
 ---
 

--- a/src/routes/(docs)/docs/content/v3/customize-site.md
+++ b/src/routes/(docs)/docs/content/v3/customize-site.md
@@ -143,7 +143,7 @@ Repository name of the github repository. If the repository is `https://github.c
 
 `incidentSince` is in hours. It means if an issue is created before X hours then kener would not honor it. What it means is that kener would not show it active incident pages nor it will update the uptime. Default is 30\*24 hours = 720 hours.
 
-To see how to create an issue [click here](/docs/v3/incident-management)
+See the [incident management documentation](/docs/v3/incident-management) to create an issue.
 
 ---
 

--- a/src/routes/(docs)/docs/content/v3/deployment.md
+++ b/src/routes/(docs)/docs/content/v3/deployment.md
@@ -58,7 +58,7 @@ Make sure `./database` and `./uploads` directories are present in the root direc
 
 ### Examples {#docker-examples}
 
-This example is for sqlite. You can also use postgres. Read more about it [here](/docs/v3/environment-vars#database-url)
+This example is for sqlite. You can also use postgres. See [database configuration](/docs/v3/environment-vars#database-url).
 
 #### sqlite
 
@@ -133,7 +133,7 @@ docker run \
 
 #### Base path
 
-By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/v3/environment-vars/#kener-base-path).
+By default kener runs on `/` but you can change it to `/status` or any other path. See [base path configuration](/docs/v3/environment-vars/#kener-base-path).
 
 <div class="note info">
 

--- a/src/routes/(docs)/docs/content/v3/deployment.md
+++ b/src/routes/(docs)/docs/content/v3/deployment.md
@@ -13,7 +13,7 @@ Make sure you have the following installed:
 - [npm](https://www.npmjs.com/get-npm)
 - [Sqlite3](https://www.sqlite.org/download.html)
 - Make sure `./database` directory is present in the root directory
-- [Set up Environment Variables](/docs/environment-vars). You can use a `.env` file or pass them as arguments. Be sure to add `NODE_ENV=production` for production deployment
+- [Set up Environment Variables](/docs/v3/environment-vars). You can use a `.env` file or pass them as arguments. Be sure to add `NODE_ENV=production` for production deployment
 
 ## NPM {#npm}
 
@@ -52,13 +52,13 @@ ghcr.io/rajnandan1/kener:latest
 
 ### Environment Variables {#docker-env-vars}
 
-[Environment variables](/docs/environment-vars) can be passed with `-e` An example `docker run` command:
+[Environment variables](/docs/v3/environment-vars) can be passed with `-e` An example `docker run` command:
 
 Make sure `./database` and `./uploads` directories are present in the root directory.
 
 ### Examples {#docker-examples}
 
-This example is for sqlite. You can also use postgres. Read more about it [here](/docs/environment-vars#database-url)
+This example is for sqlite. You can also use postgres. Read more about it [here](/docs/v3/environment-vars#database-url)
 
 #### sqlite
 
@@ -133,7 +133,7 @@ docker run \
 
 #### Base path
 
-By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/environment-vars/#kener-base-path).
+By default kener runs on `/` but you can change it to `/status` or any other path. Read more about it [here](/docs/v3/environment-vars/#kener-base-path).
 
 <div class="note info">
 

--- a/src/routes/(docs)/docs/content/v3/environment-vars.md
+++ b/src/routes/(docs)/docs/content/v3/environment-vars.md
@@ -75,7 +75,7 @@ export RESEND_SENDER_EMAIL=Some Name <email@domain.com>
 
 ## DATABASE_URL {#database-url}
 
-Kener uses a database to store its data. By default, Kener uses sqlite. You can change the database by setting the `DATABASE_URL` environment variable. The connection string has to start with `sqlite`, `postgresql`, or `mysql`. Read more about [database configuration](/docs/database).
+Kener uses a database to store its data. By default, Kener uses sqlite. You can change the database by setting the `DATABASE_URL` environment variable. The connection string has to start with `sqlite`, `postgresql`, or `mysql`. Read more about [database configuration](/docs/v3/database).
 
 ```bash
 export DATABASE_URL=sqlite://./database/awesomeKener.db

--- a/src/routes/(docs)/docs/content/v3/home-page.md
+++ b/src/routes/(docs)/docs/content/v3/home-page.md
@@ -49,7 +49,7 @@ The URL to redirect to when the link is clicked.
 
 ## Internationalization {#internationalization}
 
-Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/i18n).
+Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/v3/i18n).
 
 - Adding more than one locales will enable a dropdown in the navbar to select the language.
 - Selected languages are stored in cookies and will be used when the user visits the site again.

--- a/src/routes/(docs)/docs/content/v3/home-page.md
+++ b/src/routes/(docs)/docs/content/v3/home-page.md
@@ -49,7 +49,7 @@ The URL to redirect to when the link is clicked.
 
 ## Internationalization {#internationalization}
 
-Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the steps [here](/docs/v3/i18n).
+Add multiple languages to your status page. You can add a new language and add translations for all the text that is shown on the status page by following the [internationalization instructions](/docs/v3/i18n).
 
 - Adding more than one locales will enable a dropdown in the navbar to select the language.
 - Selected languages are stored in cookies and will be used when the user visits the site again.

--- a/src/routes/(docs)/docs/content/v3/how-it-works.md
+++ b/src/routes/(docs)/docs/content/v3/how-it-works.md
@@ -25,11 +25,11 @@ Kener has two parts.
 
 ## Site.yaml
 
-This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/v3/site)
+This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read the [Site.yaml documentation](/docs/v3/site).
 
 ## Monitors.yaml
 
-This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/v3/monitors)
+This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read the [Monitors.yaml documentation](/docs/v3/monitors).
 
 ## Data
 

--- a/src/routes/(docs)/docs/content/v3/how-it-works.md
+++ b/src/routes/(docs)/docs/content/v3/how-it-works.md
@@ -25,11 +25,11 @@ Kener has two parts.
 
 ## Site.yaml
 
-This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/customize-site)
+This is the configuration file for your site. This is where you define the name of your site, the look and feel of your site etc. Read more about it [here](/docs/v3/site)
 
 ## Monitors.yaml
 
-This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/monitors)
+This is the configuration file for your monitors. This is where you define the monitors you want to show on your site. Read more about it [here](/docs/v3/monitors)
 
 ## Data
 

--- a/src/routes/(docs)/docs/content/v3/monitor-examples.md
+++ b/src/routes/(docs)/docs/content/v3/monitor-examples.md
@@ -206,7 +206,7 @@ The below monitor will show DEGRADED if 3 or more degraded status in a day and D
 
 ## Monitor with Alerts
 
-Make sure you have set up triggers in `server.yaml`. Read more about [alerts](/docs/alerting).
+Make sure you have set up triggers in `server.yaml`. Read more about [alerts](/docs/v3/triggers).
 
 The below example will trigger an alert if the monitor is DOWN for 10 consecutive times. It will also create an incident in GitHub and send alerts to Webhook, Discord and Slack. It will also trigger an alert if the monitor is DEGRADED for 5 consecutive times. It will not create an incident in GitHub and send alerts to Webhook, Discord and Slack.
 

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -91,25 +91,25 @@ The include degraded is used to include the degraded checks in the total bad che
 
 ### API Monitor {#api-monitor}
 
-To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/monitors-api).
+To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/v3/monitors-api).
 
 ### DNS Monitor {#dns-monitor}
 
-To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/monitors-dns).
+To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/v3/monitors-dns).
 
 ### PING Monitor {#ping-monitor}
 
-To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/monitors-ping).
+To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/v3/monitors-ping).
 
 ### GAMEDIG Monitor {#gamedig-monitor}
 
-To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/monitors-gamedig).
+To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/v3/monitors-gamedig).
 
 ---
 
 ## Triggers {#triggers}
 
-To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/triggers).
+To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/v3/triggers).
 
 - Click on the 🔔 icon on the top right corner of the monitor.
 - Add details for either DOWN or DEGRADED.

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -91,25 +91,25 @@ The include degraded is used to include the degraded checks in the total bad che
 
 ### API Monitor {#api-monitor}
 
-To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. You can read more about API monitoring [here](/docs/v3/monitors-api).
+To monitor an API, you need to provide the URL of the API and the expected status code. If the status code is not received, the monitor will be marked as down. Read the [API monitoring documentation](/docs/v3/monitors-api).
 
 ### DNS Monitor {#dns-monitor}
 
-To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. You can read more about DNS monitoring [here](/docs/v3/monitors-dns).
+To monitor the DNS records, you need to provide the domain name and the record type. If the record is not found, the monitor will be marked as down. Read the [DNS monitoring documentation](/docs/v3/monitors-dns).
 
 ### PING Monitor {#ping-monitor}
 
-To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. You can read more about PING monitoring [here](/docs/v3/monitors-ping).
+To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. Read the [PING monitoring documentation](/docs/v3/monitors-ping).
 
 ### GAMEDIG Monitor {#gamedig-monitor}
 
-To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. You can read more about GAMEDIG monitoring [here](/docs/v3/monitors-gamedig).
+To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. Read the [GAMEDIG monitoring documentation](/docs/v3/monitors-gamedig).
 
 ---
 
 ## Triggers {#triggers}
 
-To add a trigger to a monitor make sure you have created a trigger. You can read more about triggers [here](/docs/v3/triggers).
+To add a trigger to a monitor make sure you have created a trigger. Read the [trigger documentation](/docs/v3/triggers).
 
 - Click on the 🔔 icon on the top right corner of the monitor.
 - Add details for either DOWN or DEGRADED.

--- a/src/routes/(docs)/docs/content/v3/monitors.md
+++ b/src/routes/(docs)/docs/content/v3/monitors.md
@@ -99,11 +99,11 @@ To monitor the DNS records, you need to provide the domain name and the record t
 
 ### PING Monitor {#ping-monitor}
 
-To monitor the ping, you need to provide the IP address or the domain name. If the ping is not successful, the monitor will be marked as down. Read the [PING monitoring documentation](/docs/v3/monitors-ping).
+For a PING monitor, provide the IP address or domain name. If the ping is not successful, the monitor will be marked as down. Read the [PING monitoring documentation](/docs/v3/monitors-ping).
 
 ### GAMEDIG Monitor {#gamedig-monitor}
 
-To monitor game/service, you need to provide the game or service to monitor, the IP address or the domain name and the port. If the query is not successful, the monitor will be marked as down. Read the [GAMEDIG monitoring documentation](/docs/v3/monitors-gamedig).
+To monitor a game or service, provide the game or service, the IP address or domain name, and the port. If the query is not successful, the monitor will be marked as down. Read the [GAMEDIG monitoring documentation](/docs/v3/monitors-gamedig).
 
 ---
 

--- a/src/routes/(docs)/docs/content/v3/quick-start.md
+++ b/src/routes/(docs)/docs/content/v3/quick-start.md
@@ -26,7 +26,7 @@ npm install
 
 ## Set up Environment Variables {#set-up-environment-variables}
 
-Kener needs some environment variables to be set to run properly. [Here](/docs/environment-vars) are the list of environment variables that you need to set.
+Kener needs some environment variables to be set to run properly. [Here](/docs/v3/environment-vars) are the list of environment variables that you need to set.
 
 ```bash
 cp .env.example .env
@@ -72,9 +72,9 @@ You can watch the video tutorial on how to get started with Kener
 
 Learn how to configure kener by going through one of the topics
 
-- [Monitors](/docs/monitors): Learn how to set up and work with monitors in kener.
-- [Triggers](/docs/triggers): Learn how to set up and work with triggers in kener.
-- [Environment Variables](/docs/environment-vars): Learn how to set up and work with environment variables in kener.
-- [API](/docs/kener-apis): Learn how to use the API in kener.
-- [Databases](/docs/database): Learn how to set up and work with databases in kener.
-- [Theme](/docs/theme): Learn how to set up and work with theme in kener.
+- [Monitors](/docs/v3/monitors): Learn how to set up and work with monitors in kener.
+- [Triggers](/docs/v3/triggers): Learn how to set up and work with triggers in kener.
+- [Environment Variables](/docs/v3/environment-vars): Learn how to set up and work with environment variables in kener.
+- [API](/docs/v3/kener-apis): Learn how to use the API in kener.
+- [Databases](/docs/v3/database): Learn how to set up and work with databases in kener.
+- [Theme](/docs/v3/theme): Learn how to set up and work with theme in kener.

--- a/src/routes/(docs)/docs/content/v3/quick-start.md
+++ b/src/routes/(docs)/docs/content/v3/quick-start.md
@@ -26,7 +26,7 @@ npm install
 
 ## Set up Environment Variables {#set-up-environment-variables}
 
-Kener needs some environment variables to be set to run properly. [Here](/docs/v3/environment-vars) are the list of environment variables that you need to set.
+Kener needs some environment variables to be set to run properly. See the [environment variables documentation](/docs/v3/environment-vars).
 
 ```bash
 cp .env.example .env

--- a/src/routes/(docs)/docs/content/v4/alerting/alert-configurations.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/alert-configurations.md
@@ -62,6 +62,6 @@ Higher thresholds reduce noise; lower thresholds detect faster.
 
 ## Related pages {#related-pages}
 
-- [Triggers](/docs/alerting/triggers)
-- [Templates](/docs/alerting/templates)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Templates](/docs/v4/alerting/templates)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/overview.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/overview.md
@@ -39,7 +39,7 @@ Current runtime supports:
 
 Trigger templates render with alert and site variables (for example `{{alert_name}}`, `{{alert_status}}`, `{{site_name}}`, `{{site_url}}`).
 
-Use [Templates](/docs/alerting/templates) for the canonical variable list.
+Use [Templates](/docs/v4/alerting/templates) for the canonical variable list.
 
 ## Secret interpolation {#secret-interpolation}
 
@@ -53,7 +53,7 @@ Authorization: Bearer $API_TOKEN
 
 ## Next steps {#next-steps}
 
-- [Alert Configurations](/docs/alerting/alert-configurations)
-- [Triggers](/docs/alerting/triggers)
-- [Templates](/docs/alerting/templates)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Alert Configurations](/docs/v4/alerting/alert-configurations)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Templates](/docs/v4/alerting/templates)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -78,5 +78,5 @@ Authorization: Bearer $API_TOKEN
 
 ## Related pages {#related-pages}
 
-- [Triggers](/docs/alerting/triggers)
-- [Webhook Examples](/docs/alerting/webhook-examples)
+- [Triggers](/docs/v4/alerting/triggers)
+- [Webhook Examples](/docs/v4/alerting/webhook-examples)

--- a/src/routes/(docs)/docs/content/v4/alerting/triggers.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/triggers.md
@@ -28,7 +28,7 @@ Runtime currently supports:
 
 ## Template variables {#template-variables}
 
-Trigger bodies/subjects can use Mustache variables. Use the canonical list in [Templates](/docs/alerting/templates).
+Trigger bodies/subjects can use Mustache variables. Use the canonical list in [Templates](/docs/v4/alerting/templates).
 
 ## Secret handling {#secret-handling}
 

--- a/src/routes/(docs)/docs/content/v4/api-reference.md
+++ b/src/routes/(docs)/docs/content/v4/api-reference.md
@@ -123,4 +123,4 @@ Receive real-time notifications for events:
 }
 ```
 
-See [Authentication](/docs/api-reference/authentication) for detailed auth docs, or [Monitors API](/docs/api-reference/monitors) for monitor endpoints.
+See the [OpenAPI reference](/docs/spec/v4/) for authentication and monitor endpoints.

--- a/src/routes/(docs)/docs/content/v4/architecture.md
+++ b/src/routes/(docs)/docs/content/v4/architecture.md
@@ -199,7 +199,7 @@ This ensures in-flight jobs complete and no data is lost during deployments or r
 
 ## Next Steps {#next-steps}
 
-- [Environment Variables](/docs/setup/environment-variables) — required and optional configuration
-- [Database Setup](/docs/setup/database-setup) — choosing and configuring your database
-- [Redis Setup](/docs/setup/redis-setup) — configuring Redis for BullMQ queues
-- [Monitors](/docs/monitors/overview) — understanding monitor types and configuration
+- [Environment Variables](/docs/v4/setup/environment-variables) — required and optional configuration
+- [Database Setup](/docs/v4/setup/database-setup) — choosing and configuring your database
+- [Redis Setup](/docs/v4/setup/redis-setup) — configuring Redis for BullMQ queues
+- [Monitors](/docs/v4/monitors/overview) — understanding monitor types and configuration

--- a/src/routes/(docs)/docs/content/v4/configuration.md
+++ b/src/routes/(docs)/docs/content/v4/configuration.md
@@ -192,7 +192,7 @@ status.yourdomain.com {
 }
 ```
 
-📖 **For complete configuration including SSL, subpaths, load balancing, and troubleshooting**, see the [Reverse Proxy Setup Guide](/docs/advanced-topics/reverse-proxy).
+📖 **For complete configuration including SSL, subpaths, load balancing, and troubleshooting**, see the [Reverse Proxy Setup Guide](/docs/v4/guides/reverse-proxy).
 
 ## Next Steps
 

--- a/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
+++ b/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
@@ -20,7 +20,7 @@ Kener is built and maintained by [Rajnandan1](https://www.rajnandan.com). It is 
 4. Discussions - [discuss](https://github.com/rajnandan1/kener/discussions)
 5. Roadmap - [view](https://github.com/users/rajnandan1/projects/4)
 6. Discord - [join](https://discord.gg/uSTpnuK9XR)
-7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/CONTRIBUTING.md)
+7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/.github/CONTRIBUTING.md)
 
 ## One Click Deployment {#one-click-deployment}
 

--- a/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
+++ b/src/routes/(docs)/docs/content/v4/getting-started/introduction.md
@@ -20,7 +20,7 @@ Kener is built and maintained by [Rajnandan1](https://www.rajnandan.com). It is 
 4. Discussions - [discuss](https://github.com/rajnandan1/kener/discussions)
 5. Roadmap - [view](https://github.com/users/rajnandan1/projects/4)
 6. Discord - [join](https://discord.gg/uSTpnuK9XR)
-7. Contribution - [contribute](/docs/v4/getting-started/contributing)
+7. Contribution - [contribute](https://github.com/rajnandan1/kener/blob/main/CONTRIBUTING.md)
 
 ## One Click Deployment {#one-click-deployment}
 

--- a/src/routes/(docs)/docs/content/v4/guides/reverse-proxy.md
+++ b/src/routes/(docs)/docs/content/v4/guides/reverse-proxy.md
@@ -764,7 +764,7 @@ ab -n 1000 -c 10 https://status.example.com/
 
 ## Next Steps {#next-steps}
 
-- [Environment Variables](/docs/setup/environment-variables) - Configure KENER_BASE_PATH and other variables
-- [Database Setup](/docs/setup/database-setup) - Set up PostgreSQL/MySQL for production
-- [Email Setup](/docs/setup/email-setup) - Configure email notifications
-- [Docker Deployment](/docs/deployment/docker) - Deploy with Docker/Docker Compose
+- [Environment Variables](/docs/v4/setup/environment-variables) - Configure KENER_BASE_PATH and other variables
+- [Database Setup](/docs/v4/setup/database-setup) - Set up PostgreSQL/MySQL for production
+- [Email Setup](/docs/v4/setup/email-setup) - Configure email notifications
+- [Deployment](/docs/v4/setup/deployment) - Deploy with Docker/Docker Compose

--- a/src/routes/(docs)/docs/content/v4/incidents/creating-managing.md
+++ b/src/routes/(docs)/docs/content/v4/incidents/creating-managing.md
@@ -205,7 +205,7 @@ INVESTIGATING → IDENTIFIED → MONITORING → INVESTIGATING → IDENTIFIED →
 
 - Add updates regularly (every 15-30 minutes for critical issues)
 - Include substantive information
-- See [Incident Updates](/docs/incidents/updates)
+- See [Incident Updates](/docs/v4/incidents/updates)
 
 ## Filtering and Organization {#filtering-organization}
 
@@ -248,6 +248,6 @@ To delete an incident:
 
 ## Next Steps {#next-steps}
 
-- [Incident Updates](/docs/incidents/updates) - Learn how to add updates and change incident state
-- [Incident Impact on Monitoring](/docs/incidents/impact-on-monitoring) - Understand how incidents affect monitor status
-- [Auto-Generated Incidents](/docs/incidents/auto-generated) - Configure alerts to create incidents automatically
+- [Incident Updates](/docs/v4/incidents/updates) - Learn how to add updates and change incident state
+- [Incident Impact on Monitoring](/docs/v4/incidents/impact-on-monitoring) - Understand how incidents affect monitor status
+- [Auto-Generated Incidents](/docs/v4/incidents/auto-generated) - Configure alerts to create incidents automatically

--- a/src/routes/(docs)/docs/content/v4/installation.md
+++ b/src/routes/(docs)/docs/content/v4/installation.md
@@ -146,6 +146,6 @@ Verify your `DATABASE_URL` is correct and the database server is running.
 
 ## Next Steps
 
-- Configure your [environment variables](/docs/configuration)
-- Set up your first [monitor](/docs/monitors)
-- Customize your [status page](/docs/configuration)
+- Configure your [environment variables](/docs/v4/setup/environment-variables)
+- Set up your first [monitor](/docs/v4/monitors)
+- Customize your [status page](/docs/v4/setup/site-configuration)

--- a/src/routes/(docs)/docs/content/v4/monitors/grace-period.md
+++ b/src/routes/(docs)/docs/content/v4/monitors/grace-period.md
@@ -46,7 +46,7 @@ PATCH /api/v4/monitors/{monitor_tag}
 { "confirmation_threshold": 5 }
 ```
 
-It is validated as an integer between `1` and `60`. See the [API Reference](/docs/v4/api-reference).
+It is validated as an integer between `1` and `60`. See the [API Reference](/docs/spec/v4/).
 
 ## What gets damped {#scope}
 

--- a/src/routes/(docs)/docs/content/v4/sharing.md
+++ b/src/routes/(docs)/docs/content/v4/sharing.md
@@ -108,4 +108,4 @@ On a monitor page, the share buttons in the top action bar are shown only when a
 
 - [Monitors Overview](/docs/v4/monitors/overview)
 - [Pages](/docs/v4/pages)
-- [Configuration](/docs/v4/configuration)
+- [Configuration](/docs/v4/setup/site-configuration)

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -129,7 +129,7 @@ import {
 } from "$lib/server/controllers/userController.js";
 import type { SiteDataForNotification } from "$lib/server/notification/types";
 import { alertToVariables, siteDataToVariables } from "$lib/server/notification/notification_utils";
-import type { TriggerMeta } from "$lib/server/types/db.js";
+import type { ImageRecordInsert, TriggerMeta } from "$lib/server/types/db.js";
 import sendWebhook from "$lib/server/notification/webhook_notification.js";
 import sendEmail from "$lib/server/notification/email_notification.js";
 import sendDiscord from "$lib/server/notification/discord_notification.js";
@@ -695,7 +695,7 @@ async function storeSiteData(data: { [x: string]: any }) {
   return { success: true };
 }
 
-interface ImageUploadData {
+export interface ImageUploadData {
   base64: string; // base64 encoded image data (without data URI prefix)
   mimeType: string;
   fileName?: string;
@@ -703,6 +703,7 @@ interface ImageUploadData {
   maxHeight?: number;
   forceDimensions?: boolean;
   prefix?: string; // prefix for the ID (e.g., "logo_", "favicon_")
+  saveImage?: (image: ImageRecordInsert) => Promise<void>;
 }
 
 export async function uploadImage(data: ImageUploadData): Promise<{ id: string; url: string }> {
@@ -847,7 +848,7 @@ export async function uploadImage(data: ImageUploadData): Promise<{ id: string; 
   const processedBase64 = processedBuffer.toString("base64");
 
   // Store in database
-  await db.insertImage({
+  const imageRecord: ImageRecordInsert = {
     id,
     data: processedBase64,
     mime_type: finalMimeType,
@@ -855,7 +856,8 @@ export async function uploadImage(data: ImageUploadData): Promise<{ id: string; 
     width: width || null,
     height: height || null,
     size: processedBuffer.length,
-  });
+  };
+  await (data.saveImage ?? db.insertImage)(imageRecord);
 
   return {
     id,

--- a/src/routes/(manage)/manage/api/+server.ts
+++ b/src/routes/(manage)/manage/api/+server.ts
@@ -705,7 +705,7 @@ interface ImageUploadData {
   prefix?: string; // prefix for the ID (e.g., "logo_", "favicon_")
 }
 
-async function uploadImage(data: ImageUploadData): Promise<{ id: string; url: string }> {
+export async function uploadImage(data: ImageUploadData): Promise<{ id: string; url: string }> {
   const {
     base64,
     mimeType,

--- a/static/api-references/v4.json
+++ b/static/api-references/v4.json
@@ -1002,6 +1002,71 @@
         "description": "The home page (addressed as `~home`) cannot be deleted and returns `400`."
       }
     },
+    "/api/v4/pages/{page_path}/logo": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/PagePath"
+        }
+      ],
+      "post": {
+        "tags": ["Pages"],
+        "operationId": "uploadPageLogo",
+        "summary": "Upload page logo",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["base64", "mime_type"],
+                "properties": {
+                  "base64": {
+                    "type": "string",
+                    "description": "Base64-encoded image data without a data URI prefix"
+                  },
+                  "mime_type": {
+                    "type": "string",
+                    "enum": ["image/png", "image/jpeg", "image/jpg", "image/webp", "image/heic", "image/heif"]
+                  },
+                  "file_name": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Page logo uploaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["page_logo"],
+                  "properties": {
+                    "page_logo": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "description": "Images are resized to fit within 256x256 pixels."
+      }
+    },
     "/api/v4/site": {
       "get": {
         "tags": ["Site"],


### PR DESCRIPTION
## Summary

Added `POST /api/v4/pages/:page_path/logo` to upload page logos using API keys.

- Accepts base64 image data, MIME type, and optional filename
- Reuses existing image validation, resizing, and storage
- Returns the uploaded `page_logo` URL
- Added request/response types and OpenAPI documentation

## Testing

- Validated the OpenAPI specification
- Ran `npm run check`

Closes #798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for uploading page logos with base64 image data, MIME type, and optional file name.
  * Logos are resized to fit within 256×256 pixels and return the stored logo path.
  * Added validation and clear errors for invalid pages, malformed requests, unsupported fields, and upload failures.

* **Documentation**
  * Documented the page logo upload endpoint and request and response formats.
  * Corrected and versioned links throughout the v3 and v4 documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->