### PR TITLE
Fix: look up users by email case-insensitively

### DIFF
--- a/src/lib/server/controllers/userController.ts
+++ b/src/lib/server/controllers/userController.ts
@@ -121,7 +121,7 @@ export const GetUserByIDDashboard = async (userID: number): Promise<UserRecordDa
 
 //getUserByEmail
 export const GetUserByEmail = async (email: string): Promise<UserRecordPublic | undefined> => {
-  return await db.getUserByEmail(email);
+  return await db.getUserByEmail(normalizeEmail(email));
 };
 
 export const UpdateUserData = async (data: UserUpdateInput): Promise<number> => {

--- a/src/lib/server/db/repositories/users.test.ts
+++ b/src/lib/server/db/repositories/users.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import knex, { type Knex } from "knex";
+import { UsersRepository } from "./users";
+
+describe("UsersRepository.getUserByEmail", () => {
+  let db: Knex;
+  let repo: UsersRepository;
+
+  beforeAll(async () => {
+    db = knex({
+      client: "better-sqlite3",
+      connection: { filename: ":memory:" },
+      useNullAsDefault: true,
+    });
+
+    await db.schema.createTable("users", (table) => {
+      table.increments("id").primary();
+      table.string("email", 255).notNullable().unique();
+      table.string("name", 255).notNullable();
+      table.string("password_hash", 255).notNullable();
+      table.integer("is_active").defaultTo(1);
+      table.integer("is_verified").defaultTo(0);
+      table.string("is_owner").defaultTo("NO");
+      table.timestamp("created_at").defaultTo(db.fn.now());
+      table.timestamp("updated_at").defaultTo(db.fn.now());
+    });
+    await db.schema.createTable("roles", (table) => {
+      table.string("id").primary();
+      table.string("status").notNullable();
+    });
+    await db.schema.createTable("users_roles", (table) => {
+      table.string("roles_id").notNullable();
+      table.integer("users_id").notNullable();
+    });
+    await db("roles").insert({ id: "admin", status: "ACTIVE" });
+
+    repo = new UsersRepository(db);
+
+    // Signup stores emails lowercased. This is the address from issue #815.
+    const inserted = await db("users").insert({
+      email: "timothy.pace@yours.me.com",
+      name: "Timothy Pace",
+      password_hash: "hash",
+    });
+    await db("users_roles").insert({ roles_id: "admin", users_id: inserted[0] });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it("does not match mixed-case input with a case-sensitive exact compare", async () => {
+    const row = await db("users").where("email", "Timothy.Pace@yours.me.com").first();
+    expect(row).toBeUndefined();
+  });
+
+  it("finds a user when the lookup email differs only by case", async () => {
+    const user = await repo.getUserByEmail("Timothy.Pace@yours.me.com");
+    expect(user).toBeDefined();
+    expect(user?.email).toBe("timothy.pace@yours.me.com");
+    expect(user?.role_ids).toEqual(["admin"]);
+  });
+
+  it("finds a user with an already-normalized email", async () => {
+    const user = await repo.getUserByEmail("timothy.pace@yours.me.com");
+    expect(user?.email).toBe("timothy.pace@yours.me.com");
+  });
+
+  it("trims surrounding whitespace before lookup", async () => {
+    const user = await repo.getUserByEmail("  Timothy.Pace@yours.me.com  ");
+    expect(user?.email).toBe("timothy.pace@yours.me.com");
+  });
+
+  it("returns undefined for a missing address", async () => {
+    const user = await repo.getUserByEmail("nobody@example.com");
+    expect(user).toBeUndefined();
+  });
+
+  it("does not treat email length as a constraint for valid addresses", async () => {
+    const longLocal = `${"a".repeat(64)}@example.com`;
+    await db("users").insert({
+      email: longLocal,
+      name: "Long Email",
+      password_hash: "hash",
+    });
+    const user = await repo.getUserByEmail(longLocal.toUpperCase());
+    expect(user?.email).toBe(longLocal);
+  });
+});

--- a/src/lib/server/db/repositories/users.ts
+++ b/src/lib/server/db/repositories/users.ts
@@ -54,9 +54,11 @@ export class UsersRepository extends BaseRepository {
   }
 
   async getUserByEmail(email: string): Promise<UserRecordPublic | undefined> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) return undefined;
     const row = await this.knex("users")
       .select(...this.userColumns)
-      .where("email", email)
+      .whereRaw("LOWER(email) = ?", [normalizedEmail]) // portable across sqlite, postgres, mysql
       .first();
     if (!row) return undefined;
     return await this.enrichWithRoleIds(row);

--- a/src/routes/(account)/account/signin/+page.server.ts
+++ b/src/routes/(account)/account/signin/+page.server.ts
@@ -98,26 +98,26 @@ export const actions: Actions = {
 
     try {
       await CreateFirstUser({ email, name, password });
-      const userDB = await GetUserByEmail(email);
-
-      if (!userDB) {
-        return fail(500, { error: "Failed to create user", values: { name, email } });
-      }
-
-      const token = await GenerateToken(userDB);
-      const cookieConfig = CookieConfig();
-      cookies.set(cookieConfig.name, token, {
-        path: cookieConfig.path,
-        maxAge: cookieConfig.maxAge,
-        httpOnly: cookieConfig.httpOnly,
-        secure: cookieConfig.secure,
-        sameSite: cookieConfig.sameSite,
-      });
-
-      throw redirect(302, serverResolve("/manage/app/site-configurations"));
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : "An error occurred during signup";
       return fail(400, { error: errorMessage, values: { name, email } });
     }
+
+    const userDB = await GetUserByEmail(email);
+    if (!userDB) {
+      return fail(500, { error: "Failed to create user", values: { name, email } });
+    }
+
+    const token = await GenerateToken(userDB);
+    const cookieConfig = CookieConfig();
+    cookies.set(cookieConfig.name, token, {
+      path: cookieConfig.path,
+      maxAge: cookieConfig.maxAge,
+      httpOnly: cookieConfig.httpOnly,
+      secure: cookieConfig.secure,
+      sameSite: cookieConfig.sameSite,
+    });
+
+    throw redirect(302, serverResolve("/manage/app/site-configurations"));
   },
 };


### PR DESCRIPTION
Fixes #815

Admin signup lowercases emails before insert, then immediately looks them up with the original mixed-case value. SQLite and PostgreSQL treat `=` as case-sensitive, so addresses like `Timothy.Pace@yours.me.com` failed with "Failed to create user" even though the row was written. `test@example.com` worked because it was already lowercase, not because it was shorter.

This PR:
- Looks up users with `LOWER(email) = ?`
- Normalizes the email in `GetUserByEmail`
- Stops swallowing SvelteKit `redirect()` after first-user creation (it was inside the same try/catch as the insert)

Server tests: 108 passed (including a regression for the reporter's email).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email addresses are now matched consistently regardless of capitalization or accidental spaces during account lookup.
  * Empty email searches no longer trigger unnecessary database lookups.
  * Valid long email addresses are supported during sign-in and account registration.
  * Account registration errors are handled more accurately, allowing unexpected failures to be surfaced instead of being reported as validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->