### PR TITLE
Fix: show Alert Logs timestamps in the selected timezone

### DIFF
--- a/src/lib/stores/datetime.test.ts
+++ b/src/lib/stores/datetime.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatDateTz } from "./datetime";
+
+// Alert Logs persist created_at / updated_at as SQLite UTC datetimes without a
+// timezone suffix ("YYYY-MM-DD HH:mm:ss"). formatDateTz must treat those as UTC
+// and convert into the selected timezone — the same contract Monitoring Data
+// already has via Unix timestamps. See https://github.com/rajnandan1/kener/issues/813
+const ALERT_TRIGGERED_UTC = "2026-08-20 04:02:00";
+
+describe("formatDateTz", () => {
+  it("treats offset-less DB datetimes as UTC and converts to the selected timezone", () => {
+    expect(formatDateTz(ALERT_TRIGGERED_UTC, "yyyy-MM-dd HH:mm:ss", "UTC")).toBe("2026-08-20 04:02:00");
+    expect(formatDateTz(ALERT_TRIGGERED_UTC, "yyyy-MM-dd HH:mm:ss", "Asia/Shanghai")).toBe("2026-08-20 12:02:00");
+  });
+
+  it("keeps ISO timestamps with a Z suffix as the same UTC instant", () => {
+    expect(formatDateTz("2026-08-20T04:02:00.000Z", "yyyy-MM-dd HH:mm:ss", "Asia/Shanghai")).toBe(
+      "2026-08-20 12:02:00",
+    );
+  });
+
+  it("converts Unix seconds the same way Monitoring Data does", () => {
+    const unixSeconds = Date.parse("2026-08-20T04:02:00.000Z") / 1000;
+    expect(formatDateTz(unixSeconds, "yyyy-MM-dd HH:mm:ss", "Asia/Shanghai")).toBe("2026-08-20 12:02:00");
+  });
+});

--- a/src/routes/(manage)/manage/app/alerts/logs/[alert_config_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/alerts/logs/[alert_config_id]/+page.svelte
@@ -15,8 +15,8 @@
   import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
   import BellOffIcon from "@lucide/svelte/icons/bell-off";
   import TrashIcon from "@lucide/svelte/icons/trash";
-  import { format } from "date-fns";
   import { toast } from "svelte-sonner";
+  import { formatDate } from "$lib/stores/datetime";
   import type { MonitorAlertConfigWithTriggers, MonitorAlertV2WithConfig } from "$lib/server/types/db";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -150,16 +150,6 @@
     }
   }
 
-  // Format date
-  function formatDate(dateStr: string | Date): string {
-    try {
-      const date = typeof dateStr === "string" ? new Date(dateStr) : dateStr;
-      return format(date, "yyyy-MM-dd HH:mm:ss");
-    } catch {
-      return String(dateStr);
-    }
-  }
-
   // Handle filter change
   function handleStatusChange(value: string | undefined) {
     if (value) {
@@ -278,8 +268,12 @@
                   <span class="text-muted-foreground text-sm">—</span>
                 {/if}
               </Table.Cell>
-              <Table.Cell class="text-muted-foreground text-sm">{formatDate(alert.created_at)}</Table.Cell>
-              <Table.Cell class="text-muted-foreground text-sm">{formatDate(alert.updated_at)}</Table.Cell>
+              <Table.Cell class="text-muted-foreground text-sm"
+                >{$formatDate(alert.created_at, "yyyy-MM-dd HH:mm:ss")}</Table.Cell
+              >
+              <Table.Cell class="text-muted-foreground text-sm"
+                >{$formatDate(alert.updated_at, "yyyy-MM-dd HH:mm:ss")}</Table.Cell
+              >
               <Table.Cell class="text-right">
                 <Button variant="destructive" size="sm" class="text-xs" onclick={() => openDeleteDialog(alert)}>
                   <TrashIcon class="size-3" /> Delete


### PR DESCRIPTION
Fixes #813

Alert Logs UTC strings were parsed as local time. Reuse formatDate like Incidents. Adds datetime tests. Server tests 105 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized alert log timestamps to display consistently in the selected timezone.
  * Correctly handles UTC timestamps and Unix timestamps when displaying alert creation and update dates.

* **Tests**
  * Added coverage for timezone conversion across supported timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->