### PR TITLE
Fix: prefix KENER_BASE_PATH on favicon href

### DIFF
--- a/src/lib/server/controllers/layoutController.ts
+++ b/src/lib/server/controllers/layoutController.ts
@@ -11,6 +11,7 @@ import {
   IsEmailSetup,
 } from "./controller.js";
 import type { EventDisplaySettings, GlobalPageVisibilitySettings, SiteDateTimeFormat } from "$lib/types/site.js";
+import serverResolve from "../resolver.js";
 
 export interface LayoutServerData {
   isMobile: boolean;
@@ -165,7 +166,10 @@ export async function GetLayoutServerData(cookies: Cookies, request: Request): P
     siteName: siteData.siteName || "Kener",
     siteUrl: siteData.siteURL || "",
     logo: siteData.logo,
-    favicon: siteData.favicon,
+    // Browsers fetch <link rel="icon"> from the SSR HTML before hydration.
+    // SvelteKit's resolve() uses a relative base on the app-root page, so
+    // prefix KENER_BASE_PATH here instead of in the layout.
+    favicon: siteData.favicon ? serverResolve(siteData.favicon) : siteData.favicon,
     footerHTML: siteData.footerHTML || "",
     isSubsEnabled,
     languageSetting,

--- a/src/lib/server/resolver.test.ts
+++ b/src/lib/server/resolver.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import serverResolve from "./resolver.js";
+
+describe("serverResolve", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefixes KENER_BASE_PATH onto uploaded favicon asset paths", () => {
+    vi.stubEnv("KENER_BASE_PATH", "/status");
+    expect(serverResolve("/assets/images/abc123.png")).toBe("/status/assets/images/abc123.png");
+  });
+
+  it("prefixes KENER_BASE_PATH onto the default favicon path", () => {
+    vi.stubEnv("KENER_BASE_PATH", "/status");
+    expect(serverResolve("/logo96.png")).toBe("/status/logo96.png");
+  });
+
+  it("returns the path unchanged when KENER_BASE_PATH is unset", () => {
+    vi.stubEnv("KENER_BASE_PATH", "");
+    expect(serverResolve("/assets/images/abc123.png")).toBe("/assets/images/abc123.png");
+  });
+
+  it("leaves absolute URLs unchanged", () => {
+    vi.stubEnv("KENER_BASE_PATH", "/status");
+    expect(serverResolve("https://cdn.example.com/icon.png")).toBe("https://cdn.example.com/icon.png");
+  });
+
+  it("collapses a trailing slash on KENER_BASE_PATH", () => {
+    vi.stubEnv("KENER_BASE_PATH", "/status/");
+    expect(serverResolve("/assets/images/abc123.png")).toBe("/status/assets/images/abc123.png");
+  });
+});

--- a/src/routes/(account)/+layout.svelte
+++ b/src/routes/(account)/+layout.svelte
@@ -10,15 +10,12 @@
   import KenerNav from "$lib/components/KenerNav.svelte";
 </script>
 
-<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
+<ModeWatcher defaultMode={data.defaultSiteTheme as "light" | "dark" | "system"} />
 <Toaster />
 
 <svelte:head>
   <meta name="robots" content="noindex, nofollow" />
-  <link
-    rel="icon"
-    href={data.favicon ? clientResolver(resolve, data.favicon) : data.favicon}
-  />
+  <link rel="icon" href={data.favicon} />
   {#if data.font?.cssSrc}
     <link rel="stylesheet" href={data.font.cssSrc} />
   {/if}

--- a/src/routes/(embed)/+layout.svelte
+++ b/src/routes/(embed)/+layout.svelte
@@ -3,23 +3,18 @@
   import "../kener.css";
   import "../embed.css";
   import { ModeWatcher } from "mode-watcher";
-  import { resolve } from "$app/paths";
-  import clientResolver from "$lib/client/resolver.js";
   import { Toaster } from "$lib/components/ui/sonner/index.js";
 
   let { children, data } = $props();
 </script>
 
-<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
+<ModeWatcher defaultMode={data.defaultSiteTheme as "light" | "dark" | "system"} />
 <Toaster />
 
 <svelte:head>
   <meta name="robots" content="noindex, nofollow" />
   <title>Kener Status</title>
-  <link
-    rel="icon"
-    href={data.favicon ? clientResolver(resolve, data.favicon) : data.favicon}
-  />
+  <link rel="icon" href={data.favicon} />
   {#if data.font?.cssSrc}
     <link rel="stylesheet" href={data.font.cssSrc} />
   {/if}

--- a/src/routes/(kener)/+layout.svelte
+++ b/src/routes/(kener)/+layout.svelte
@@ -20,15 +20,12 @@
   });
 </script>
 
-<ModeWatcher defaultMode={data.defaultSiteTheme as 'light' | 'dark' | 'system'} />
+<ModeWatcher defaultMode={data.defaultSiteTheme as "light" | "dark" | "system"} />
 
 <Toaster />
 
 <svelte:head>
-  <link
-    rel="icon"
-    href={data.favicon ? clientResolver(resolve, data.favicon) : data.favicon}
-  />
+  <link rel="icon" href={data.favicon} />
   <link rel="alternate" type="application/rss+xml" title="RSS feed" href={rssHref} />
   {#if data.font?.cssSrc}
     <link rel="stylesheet" href={data.font.cssSrc} />


### PR DESCRIPTION
Fixes #781

Favicon paths were stored as /assets/images/{id}. Layouts used client-side resolve(), which is empty on the app-root page before hydration, so browsers requested oururl.com/assets/... instead of oururl.com/status/assets/... when KENER_BASE_PATH is set.

Prefix on the server with serverResolve() and use data.favicon directly in status, account, and embed layouts. Adds resolver.test.ts (5 cases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed favicon links so they load correctly when the application is hosted under a configured base path.
  * Preserved absolute favicon URLs and behavior when no base path is configured.
  * Updated account, embedded, and main layouts to consistently use the resolved favicon URL.

* **Tests**
  * Added coverage for favicon URL resolution across supported path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->