### PR TITLE
fix(manage): show timestamps in browser timezone with UTC tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ CONTEXT.md
 docs/adr/
 docs/superpowers/
 .superpowers/
+# Wayfinder scratch (local only)
+scratch/

--- a/src/lib/components/LocalTime.harness.svelte
+++ b/src/lib/components/LocalTime.harness.svelte
@@ -1,0 +1,11 @@
+<!-- Test-only: LocalTime needs the Tooltip.Provider that app layouts supply. -->
+<script lang="ts">
+  import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+  import LocalTime from "./LocalTime.svelte";
+
+  let { value, format }: { value: Date | string | number; format?: string } = $props();
+</script>
+
+<Tooltip.Provider>
+  <LocalTime {value} {format} />
+</Tooltip.Provider>

--- a/src/lib/components/LocalTime.svelte
+++ b/src/lib/components/LocalTime.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+  import { format as fmt, isValid } from "date-fns";
+  import { formatInTimeZone } from "date-fns-tz";
+  import { parseDateInput } from "$lib/stores/datetime";
+
+  interface Props {
+    /** Audit column (Date, ISO or naive "YYYY-MM-DD HH:mm:ss" string) or event time (epoch seconds). */
+    value: Date | string | number;
+    /** date-fns format for the local time. */
+    format?: string;
+    class?: string;
+  }
+
+  let { value, format = "yyyy-MM-dd HH:mm:ss", class: className }: Props = $props();
+
+  const date = $derived(parseDateInput(value));
+  const local = $derived(isValid(date) ? `${fmt(date, format)} ${fmt(date, "O")}` : null);
+</script>
+
+<!-- Needs a Tooltip.Provider above it; the (manage) and (kener) layouts supply one. -->
+{#if local}
+  <Tooltip.Root>
+    <Tooltip.Trigger class={className}>{local}</Tooltip.Trigger>
+    <Tooltip.Content>
+      {formatInTimeZone(date, "UTC", "yyyy-MM-dd HH:mm:ss 'UTC'")}
+    </Tooltip.Content>
+  </Tooltip.Root>
+{:else}
+  <span class={className}>{String(value ?? "")}</span>
+{/if}

--- a/src/lib/components/LocalTime.svelte.test.ts
+++ b/src/lib/components/LocalTime.svelte.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-svelte";
+import LocalTime from "./LocalTime.harness.svelte";
+
+// Browser context is pinned to UTC (vite.config.ts), so the offset label is "GMT".
+const EPOCH = 1787198520; // 2026-08-20T04:02:00Z
+
+describe("LocalTime", () => {
+  it("renders a naive DB string as local time with the GMT offset", async () => {
+    const screen = await render(LocalTime, { value: "2026-08-20 04:02:00" });
+    await expect.element(screen.getByText("2026-08-20 04:02:00 GMT")).toBeInTheDocument();
+  });
+
+  it("accepts epoch seconds and a custom format", async () => {
+    const screen = await render(LocalTime, { value: EPOCH, format: "MMM d, yyyy HH:mm" });
+    await expect.element(screen.getByText("Aug 20, 2026 04:02 GMT")).toBeInTheDocument();
+  });
+
+  it("shows the UTC time in a tooltip on hover", async () => {
+    const screen = await render(LocalTime, { value: EPOCH });
+    await screen.getByText("2026-08-20 04:02:00 GMT").hover();
+    await expect.element(screen.getByText("2026-08-20 04:02:00 UTC")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw value instead of throwing on an unparseable input", async () => {
+    const screen = await render(LocalTime, { value: "not-a-date" });
+    await expect.element(screen.getByText("not-a-date")).toBeInTheDocument();
+  });
+});

--- a/src/lib/server/controllers/incidentController.ts
+++ b/src/lib/server/controllers/incidentController.ts
@@ -14,7 +14,9 @@ import type {
   IncidentCommentRecord,
   MonitorAlertV2Record,
   MonitorAlertConfigRecord,
+  DbTimestamp,
 } from "../types/db.js";
+import { parseDbTimestamp } from "../tool.js";
 import GC from "../../global-constants.js";
 import { getUnixTime, differenceInSeconds } from "date-fns";
 import { siteDataToVariables } from "../notification/notification_utils.js";
@@ -277,7 +279,7 @@ export const ClosureCommentAlertMarkdown = (
   let comment = "The alert has been resolved";
 
   // Calculate duration in seconds between created_at and updated_at
-  const durationInSeconds = differenceInSeconds(new Date(alert.updated_at), new Date(alert.created_at));
+  const durationInSeconds = differenceInSeconds(parseDbTimestamp(alert.updated_at), parseDbTimestamp(alert.created_at));
   const durationInMinutes = Math.round(durationInSeconds / 60);
 
   comment = comment + `, Total duration: ${durationInMinutes} minutes`;
@@ -507,8 +509,8 @@ export const ParseIncidentToAPIResp = async (
   id: number;
   start_date_time: number;
   end_date_time: number | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   title: string;
   status: string;
   state: string;

--- a/src/lib/server/controllers/userSubscriptionsController.ts
+++ b/src/lib/server/controllers/userSubscriptionsController.ts
@@ -9,6 +9,7 @@ import type {
   UserSubscriptionV2Record,
   SubscriberUserRecord,
   SubscriberMethodRecord,
+  DbTimestamp,
 } from "$lib/server/types/db.js";
 
 // ============ V2 Admin Functions ============
@@ -26,7 +27,7 @@ export async function GetSubscribersByMethod(
     subscriber_send: string;
     subscriber_type: string;
     subscriber_status: string;
-    created_at: Date;
+    created_at: DbTimestamp;
     subscription_count: number;
     event_types: SubscriptionEventType[];
   }>;
@@ -127,7 +128,7 @@ export interface AdminSubscriberRecord {
   maintenances_enabled: boolean;
   incidents_subscription_id: number | null;
   maintenances_subscription_id: number | null;
-  created_at: Date;
+  created_at: DbTimestamp;
 }
 
 /**

--- a/src/lib/server/db/repositories/incidents.ts
+++ b/src/lib/server/db/repositories/incidents.ts
@@ -11,6 +11,7 @@ import type {
   IncidentForMonitorList,
   IncidentForMonitorListWithComments,
   IncidentMonitorImpact,
+  DbTimestamp,
 } from "../../types/db.js";
 
 // Raw row type from DB query before grouping
@@ -19,8 +20,8 @@ interface IncidentRowWithMonitor {
   title: string;
   start_date_time: number;
   end_date_time: number | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   status: string;
   state: string;
   monitor_impact: string;

--- a/src/lib/server/db/repositories/subscriptionSystem.ts
+++ b/src/lib/server/db/repositories/subscriptionSystem.ts
@@ -11,6 +11,7 @@ import type {
   UserSubscriptionV2RecordInsert,
   UserSubscriptionV2Filter,
   SubscriptionEventType,
+  DbTimestamp,
 } from "../../types/db.js";
 import { GetDbType } from "../../tool.js";
 
@@ -410,7 +411,7 @@ export class SubscriptionSystemRepository extends BaseRepository {
       method_value: string;
       method_id: number;
       status: string;
-      created_at: Date;
+      created_at: DbTimestamp;
       subscription_count: number;
       event_types: SubscriptionEventType[];
     }>

--- a/src/lib/server/notification/notification_utils.ts
+++ b/src/lib/server/notification/notification_utils.ts
@@ -5,6 +5,7 @@ import type { SiteDataTransformed } from "../controllers/siteDataController.js";
 import { format } from "date-fns";
 import mdToHTML from "../..//marked.js";
 import serverResolver from "../resolver.js";
+import { parseDbTimestamp } from "../tool.js";
 
 export function alertToVariables(
   config: MonitorAlertConfigRecord,
@@ -12,7 +13,7 @@ export function alertToVariables(
   siteVars: SiteDataForNotification,
   monitorTag?: string,
 ): AlertVariableMap {
-  const createdAtDate = alert.created_at instanceof Date ? alert.created_at : new Date(alert.created_at);
+  const createdAtDate = parseDbTimestamp(alert.created_at);
   const effectiveMonitorTag = monitorTag || config.monitor_tag || "unknown";
   const alert_name = `Alert ${effectiveMonitorTag} for ${config.alert_for} ${config.alert_value} ${alert.alert_status} at ${createdAtDate.toISOString()}`;
 

--- a/src/lib/server/queues/alertingQueue.ts
+++ b/src/lib/server/queues/alertingQueue.ts
@@ -27,6 +27,7 @@ import type { IncidentInput } from "../controllers/incidentController.js";
 import { GetMonitorAlertsV2 } from "../controllers/monitorAlertConfigController.js";
 import db from "../db/db.js";
 import { getUnixTime, differenceInSeconds } from "date-fns";
+import { parseDbTimestamp } from "../tool.js";
 import GC from "../../global-constants.js";
 import { alertToVariables, siteDataToVariables } from "../notification/notification_utils.js";
 import sendEmail from "../notification/email_notification.js";
@@ -62,7 +63,7 @@ async function createNewIncident(
   monitorName: string,
   monitorTag: string,
 ): Promise<{ incident_id: number }> {
-  let startDateTime = getUnixTime(new Date(alert.created_at));
+  let startDateTime = getUnixTime(parseDbTimestamp(alert.created_at));
   let incidentInput: IncidentInput = {
     title: monitorName + " " + config.alert_for + ": " + config.alert_value,
     start_date_time: startDateTime,
@@ -103,7 +104,7 @@ async function closeIncident(
 
   let incident_id = alert.incident_id;
   const comment = ClosureCommentAlertMarkdown(alert, config, monitorName, monitorTag, GC.RESOLVED);
-  const updatedAt = getUnixTime(new Date(alert.updated_at));
+  const updatedAt = getUnixTime(parseDbTimestamp(alert.updated_at));
   // Subscriber notification comes from AddIncidentComment — do not push here too.
   await AddIncidentComment(incident_id, comment, GC.RESOLVED, updatedAt);
 }

--- a/src/lib/server/tool.test.ts
+++ b/src/lib/server/tool.test.ts
@@ -30,6 +30,7 @@ import {
   ValidateIpAddress,
   ValidateMonitorAlerts,
   ValidateURL,
+  parseDbTimestamp,
 } from "./tool";
 import type { TimestampStatusCount } from "./types/db";
 
@@ -426,5 +427,24 @@ describe("ValidateMonitorAlerts", () => {
     expect(ValidateMonitorAlerts({ DOWN: { triggers: [1] } })).toBe(false);
     expect(ValidateMonitorAlerts({ DOWN: { ...validAlert, failureThreshold: 1.5 } })).toBe(false);
     expect(ValidateMonitorAlerts({ DOWN: { ...validAlert, successThreshold: 0 } })).toBe(false);
+  });
+});
+
+describe("parseDbTimestamp", () => {
+  it("treats a naive SQLite audit-column string as UTC", () => {
+    expect(parseDbTimestamp("2026-08-20 04:02:00").toISOString()).toBe("2026-08-20T04:02:00.000Z");
+  });
+
+  it("passes Date objects through (pg/mysql drivers)", () => {
+    const d = new Date("2026-08-20T04:02:00.000Z");
+    expect(parseDbTimestamp(d)).toBe(d);
+  });
+
+  it("reads epoch milliseconds (SQLite when a Date was bound)", () => {
+    expect(parseDbTimestamp(1787198520000).toISOString()).toBe("2026-08-20T04:02:00.000Z");
+  });
+
+  it("falls back to Date parsing for ISO strings", () => {
+    expect(parseDbTimestamp("2026-08-20T04:02:00Z").toISOString()).toBe("2026-08-20T04:02:00.000Z");
   });
 });

--- a/src/lib/server/tool.ts
+++ b/src/lib/server/tool.ts
@@ -538,7 +538,20 @@ function UptimeCalculator(
   };
 }
 
+/**
+ * Parse an audit column (created_at/updated_at) into a Date regardless of driver.
+ * pg/mysql return Date; SQLite returns naive UTC text "YYYY-MM-DD HH:mm:ss",
+ * or epoch ms when a Date was bound on insert.
+ */
+function parseDbTimestamp(value: Date | string | number): Date {
+  if (value instanceof Date) return value;
+  if (typeof value === "number") return new Date(value);
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)) return new Date(value.replace(" ", "T") + "Z");
+  return new Date(value);
+}
+
 export {
+  parseDbTimestamp,
   IsValidURL,
   UptimeCalculator,
   IsValidHTTPMethod,

--- a/src/lib/server/types/db.ts
+++ b/src/lib/server/types/db.ts
@@ -2,6 +2,9 @@
 import type { Knex } from "knex";
 import type { PageMonitorLayoutStyle } from "$lib/types/api";
 
+/** Audit column as returned by the driver: Date on pg/mysql, naive UTC text on SQLite. Parse before use. */
+export type DbTimestamp = Date | string;
+
 // ============ monitoring_data table ============
 export interface MonitoringData {
   monitor_tag: string;
@@ -40,8 +43,8 @@ export interface MonitorAlert {
   alert_status: string;
   health_checks: number;
   incident_number: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MonitorAlertInsert {
@@ -58,8 +61,8 @@ export interface SiteData {
   key: string;
   value: string;
   data_type: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // ============ monitors table ============
@@ -84,8 +87,8 @@ export interface MonitorRecord {
   include_degraded_in_downtime?: string;
   is_hidden: string;
   monitor_settings_json: string | null;
-  created_at?: Date;
-  updated_at?: Date;
+  created_at?: DbTimestamp;
+  updated_at?: DbTimestamp;
 }
 export interface MonitorSharingOptions {
   showShareBadgeMonitor: boolean;
@@ -142,8 +145,8 @@ export interface MonitorRecordTyped {
   include_degraded_in_downtime?: string;
   is_hidden: string;
   monitor_settings_json: MonitorSettings | null;
-  created_at?: Date;
-  updated_at?: Date;
+  created_at?: DbTimestamp;
+  updated_at?: DbTimestamp;
   external_url?: string | null;
 }
 
@@ -177,8 +180,8 @@ export interface TriggerRecord {
   trigger_desc: string | null;
   trigger_status: string | null;
   trigger_meta: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // Template JSON types for each template type
@@ -243,8 +246,8 @@ export interface UserRecord {
   is_active: number;
   is_verified: number;
   role_ids: string[]; // Array of role IDs
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface UserRecordInsert {
@@ -265,8 +268,8 @@ export interface UserRecordPublic {
   is_verified: number;
   is_owner: string;
   role_ids: string[];
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 export interface UserRecordDashboard extends UserRecordPublic {
   has_password: boolean;
@@ -278,23 +281,23 @@ export interface RoleRecord {
   role_name: string;
   readonly: number;
   status: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface RolePermissionRecord {
   roles_id: string;
   permissions_id: string;
   status: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface UserRoleRecord {
   roles_id: string;
   users_id: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // ============ api_keys table ============
@@ -304,8 +307,8 @@ export interface ApiKeyRecord {
   hashed_key: string;
   masked_key: string;
   status: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface ApiKeyRecordInsert {
@@ -321,8 +324,8 @@ export interface IncidentRecord {
   title: string;
   start_date_time: number;
   end_date_time: number | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   status: string;
   state: string;
   incident_type: string;
@@ -342,8 +345,8 @@ export interface IncidentForMonitorList {
   title: string;
   start_date_time: number;
   end_date_time: number | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   status: string;
   state: string;
   monitors: IncidentMonitorImpact[];
@@ -369,8 +372,8 @@ export interface IncidentMonitorRecord {
   id: number;
   monitor_tag: string;
   monitor_impact: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   incident_id: number;
 }
 
@@ -387,8 +390,8 @@ export interface IncidentMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   incident_id: number;
 }
 
@@ -398,8 +401,8 @@ export interface IncidentCommentRecord {
   comment: string;
   incident_id: number;
   commented_at: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   status: string;
   state: string;
 }
@@ -433,8 +436,8 @@ export interface ImageRecord {
   width: number | null;
   height: number | null;
   size: number | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface ImageRecordInsert {
@@ -456,8 +459,8 @@ export interface PageRecord {
   page_subheader: string | null;
   page_logo: string | null;
   page_settings_json: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface PageRecordInsert {
@@ -488,8 +491,8 @@ export interface PageRecordTyped {
   page_subheader: string | null;
   page_logo: string | null;
   page_settings: PageSettingsType | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // ============ pages_monitors table ============
@@ -498,8 +501,8 @@ export interface PageMonitorRecord {
   monitor_tag: string;
   monitor_settings_json: string | null;
   position: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface PageMonitorRecordInsert {
@@ -514,8 +517,8 @@ export interface PageMonitorRecordTyped {
   monitor_tag: string;
   monitor_settings: Record<string, unknown> | null;
   position: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // ============ Page Filter ============
@@ -535,8 +538,8 @@ export interface MaintenanceRecord {
   rrule: string; // iCalendar RRULE string (e.g., FREQ=WEEKLY;BYDAY=SU or FREQ=MINUTELY;COUNT=1)
   duration_seconds: number; // Duration of each maintenance window in seconds
   status: "ACTIVE" | "INACTIVE";
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   is_global: string;
 }
 
@@ -556,8 +559,8 @@ export interface MaintenanceMonitorRecord {
   maintenance_id: number;
   monitor_tag: string;
   monitor_impact: "UP" | "DOWN" | "DEGRADED" | "MAINTENANCE";
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MaintenanceMonitorDetailRecord {
@@ -568,8 +571,8 @@ export interface MaintenanceMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MaintenanceMonitorDetailRecord {
@@ -580,8 +583,8 @@ export interface MaintenanceMonitorDetailRecord {
   monitor_name: string;
   monitor_image: string | null;
   monitor_description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MaintenanceMonitorRecordInsert {
@@ -598,8 +601,8 @@ export interface MaintenanceEventRecord {
   start_date_time: number;
   end_date_time: number;
   status: "SCHEDULED" | "READY" | "ONGOING" | "COMPLETED" | "CANCELLED";
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MaintenanceEventRecordDetailed {
@@ -608,8 +611,8 @@ export interface MaintenanceEventRecordDetailed {
   start_date_time: number;
   end_date_time: number;
   status: "SCHEDULED" | "READY" | "ONGOING" | "COMPLETED" | "CANCELLED";
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
   title: string;
   description: string | null;
 }
@@ -649,8 +652,8 @@ export interface MaintenanceEventsMonitorList {
   end_date_time: number; // Unix timestamp - when the first occurrence ends
   is_global: YesNoType; // "YES" when the maintenance affects all monitors (no per-monitor rows)
   monitors: MaintenanceMonitorImpact[];
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 // ============ monitor_alerts_config table ============
@@ -669,8 +672,8 @@ export interface MonitorAlertConfigRecord {
   create_incident: YesNoType;
   is_active: YesNoType;
   severity: AlertSeverityType;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MonitorAlertConfigInsert {
@@ -707,8 +710,8 @@ export interface MonitorAlertConfigFilter {
 export interface MonitorAlertConfigTriggerRecord {
   monitor_alerts_id: number;
   trigger_id: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MonitorAlertConfigTriggerInsert {
@@ -720,8 +723,8 @@ export interface MonitorAlertConfigTriggerInsert {
 export interface MonitorAlertConfigMonitorRecord {
   monitor_alerts_id: number;
   monitor_tag: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MonitorAlertConfigMonitorInsert {
@@ -771,8 +774,8 @@ export interface MonitorAlertV2Record {
   monitor_tag: string | null;
   incident_id: number | null;
   alert_status: MonitorAlertStatusType;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface MonitorAlertV2Insert {
@@ -827,8 +830,8 @@ export interface SubscriptionConfigRecord {
   events_enabled: string;
   methods_enabled: string;
   method_triggers: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface SubscriptionConfigParsed {
@@ -836,8 +839,8 @@ export interface SubscriptionConfigParsed {
   events_enabled: SubscriptionEventsEnabled;
   methods_enabled: SubscriptionMethodsEnabled;
   method_triggers: SubscriptionMethodTriggers;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface SubscriptionConfigUpdate {
@@ -860,8 +863,8 @@ export interface SubscriberUserRecord {
   status: SubscriberUserStatus;
   verification_code: string | null;
   verification_expires_at: Date | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface SubscriberUserRecordInsert {
@@ -879,8 +882,8 @@ export interface SubscriberMethodRecord {
   method_value: string;
   status: SubscriptionStatus;
   meta: string | null; // JSON for extra config
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface SubscriberMethodRecordInsert {
@@ -899,8 +902,8 @@ export interface UserSubscriptionV2Record {
   event_type: SubscriptionEventType;
 
   status: SubscriptionStatus;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface UserSubscriptionV2RecordInsert {
@@ -928,8 +931,8 @@ export interface UserSubscriptionRecord {
   event_type: SubscriptionEventType;
 
   status: SubscriptionStatus;
-  created_at: Date;
-  updated_at: Date;
+  created_at: DbTimestamp;
+  updated_at: DbTimestamp;
 }
 
 export interface UserSubscriptionRecordInsert {
@@ -954,7 +957,7 @@ export interface SubscriberSummary {
   subscriber_send: string;
   subscriber_type: string;
   subscriber_status: string;
-  created_at: Date;
+  created_at: DbTimestamp;
   subscription_count: number;
   event_types: SubscriptionEventType[];
 }

--- a/src/lib/stores/datetime.test.ts
+++ b/src/lib/stores/datetime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { parseDateInput } from "./datetime";
+
+describe("parseDateInput", () => {
+  it("treats a naive DB audit-column string as UTC", () => {
+    expect(parseDateInput("2026-08-20 04:02:00").toISOString()).toBe("2026-08-20T04:02:00.000Z");
+  });
+
+  it("accepts epoch seconds, epoch milliseconds, ISO strings, and Dates", () => {
+    const iso = "2026-08-20T04:02:00.000Z";
+    expect(parseDateInput(1787198520).toISOString()).toBe(iso);
+    expect(parseDateInput(1787198520000).toISOString()).toBe(iso);
+    expect(parseDateInput(iso).toISOString()).toBe(iso);
+    expect(parseDateInput(new Date(iso)).toISOString()).toBe(iso);
+  });
+});

--- a/src/lib/stores/datetime.ts
+++ b/src/lib/stores/datetime.ts
@@ -215,7 +215,7 @@ export const dateFnsLocale = derived(currentLocale, ($locale) => getDateFnsLocal
  * - UTC strings from DB like "YYYY-MM-DD HH:mm:ss"
  * - ISO strings
  */
-function parseDateInput(date: Date | number | string): Date {
+export function parseDateInput(date: Date | number | string): Date {
   if (typeof date === "number") {
     // Check if timestamp is in seconds (Unix) or milliseconds
     return date < 10000000000 ? new Date(date * 1000) : new Date(date);

--- a/src/routes/(api)/api/v4/incidents/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/+server.ts
@@ -9,18 +9,9 @@ import type {
   BadRequestResponse,
 } from "$lib/types/api";
 import GC from "$lib/global-constants";
-import { GetMinuteStartTimestampUTC } from "$lib/server/tool";
+import { GetMinuteStartTimestampUTC, parseDbTimestamp } from "$lib/server/tool";
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
 import serverResolver from "$lib/server/resolver";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 export const GET: RequestHandler = async ({ url }) => {
   // Parse query params for filtering
@@ -73,8 +64,8 @@ export const GET: RequestHandler = async ({ url }) => {
         monitor_tag: m.monitor_tag,
         impact: m.monitor_impact || "DOWN",
       })),
-      created_at: formatDateToISO(incident.created_at),
-      updated_at: formatDateToISO(incident.updated_at),
+      created_at: parseDbTimestamp(incident.created_at).toISOString(),
+      updated_at: parseDbTimestamp(incident.updated_at).toISOString(),
       url: siteUrl + serverResolver(`/incidents/${incident.id}`),
     });
   }
@@ -209,8 +200,8 @@ export const POST: RequestHandler = async ({ request }) => {
         monitor_tag: m.monitor_tag,
         impact: m.monitor_impact || "DOWN",
       })),
-      created_at: formatDateToISO(createdIncident.created_at),
-      updated_at: formatDateToISO(createdIncident.updated_at),
+      created_at: parseDbTimestamp(createdIncident.created_at).toISOString(),
+      updated_at: parseDbTimestamp(createdIncident.updated_at).toISOString(),
       url: (await GetSiteURL()) + serverResolver(`/incidents/${createdIncident.id}`),
     },
   };

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/+server.ts
@@ -8,18 +8,9 @@ import type {
   IncidentDetailResponse,
   BadRequestResponse,
 } from "$lib/types/api";
-import { GetMinuteStartTimestampUTC } from "$lib/server/tool";
+import { GetMinuteStartTimestampUTC, parseDbTimestamp } from "$lib/server/tool";
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
 import serverResolver from "$lib/server/resolver";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 async function buildIncidentResponse(incidentId: number): Promise<IncidentDetailResponse | null> {
   const incident = await db.getIncidentById(incidentId);
@@ -43,8 +34,8 @@ async function buildIncidentResponse(incidentId: number): Promise<IncidentDetail
       monitor_tag: m.monitor_tag,
       impact: m.monitor_impact || "DOWN",
     })),
-    created_at: formatDateToISO(incident.created_at),
-    updated_at: formatDateToISO(incident.updated_at),
+    created_at: parseDbTimestamp(incident.created_at).toISOString(),
+    updated_at: parseDbTimestamp(incident.updated_at).toISOString(),
     url: (await GetSiteURL()) + serverResolver(`/incidents/${incident.id}`),
   };
 }

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/comments/+server.ts
@@ -8,18 +8,9 @@ import type {
   BadRequestResponse,
 } from "$lib/types/api";
 import GC from "$lib/global-constants";
-import { GetMinuteStartTimestampUTC, GetMinuteStartNowTimestampUTC } from "$lib/server/tool";
+import { GetMinuteStartTimestampUTC, GetMinuteStartNowTimestampUTC, parseDbTimestamp } from "$lib/server/tool";
 
 const VALID_STATES: string[] = [GC.INVESTIGATING, GC.IDENTIFIED, GC.MONITORING, GC.RESOLVED];
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 function formatCommentResponse(comment: {
   id: number;
@@ -36,8 +27,8 @@ function formatCommentResponse(comment: {
     comment: comment.comment,
     timestamp: comment.commented_at,
     state: comment.state,
-    created_at: formatDateToISO(comment.created_at),
-    updated_at: formatDateToISO(comment.updated_at),
+    created_at: parseDbTimestamp(comment.created_at).toISOString(),
+    updated_at: parseDbTimestamp(comment.updated_at).toISOString(),
   };
 }
 

--- a/src/routes/(api)/api/v4/incidents/[incident_id]/comments/[comment_id]/+server.ts
+++ b/src/routes/(api)/api/v4/incidents/[incident_id]/comments/[comment_id]/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type {
   GetCommentResponse,
@@ -13,15 +14,6 @@ import GC from "$lib/global-constants";
 import { GetMinuteStartTimestampUTC } from "$lib/server/tool";
 
 const VALID_STATES: string[] = [GC.INVESTIGATING, GC.IDENTIFIED, GC.MONITORING, GC.RESOLVED];
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 function formatCommentResponse(comment: {
   id: number;
@@ -38,8 +30,8 @@ function formatCommentResponse(comment: {
     comment: comment.comment,
     timestamp: comment.commented_at,
     state: comment.state,
-    created_at: formatDateToISO(comment.created_at),
-    updated_at: formatDateToISO(comment.updated_at),
+    created_at: parseDbTimestamp(comment.created_at).toISOString(),
+    updated_at: parseDbTimestamp(comment.updated_at).toISOString(),
   };
 }
 

--- a/src/routes/(api)/api/v4/maintenances/+server.ts
+++ b/src/routes/(api)/api/v4/maintenances/+server.ts
@@ -8,7 +8,7 @@ import type {
   BadRequestResponse,
   MaintenanceMonitor,
 } from "$lib/types/api";
-import { GetMinuteStartTimestampUTC } from "$lib/server/tool";
+import { GetMinuteStartTimestampUTC, parseDbTimestamp } from "$lib/server/tool";
 import {
   CreateMaintenance,
   GenerateMaintenanceEvents,
@@ -17,15 +17,6 @@ import {
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
 import serverResolver from "$lib/server/resolver";
 import { rrulestr } from "rrule";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 function isValidRrule(rrule: string): boolean {
   try {
@@ -85,8 +76,8 @@ export const GET: RequestHandler = async ({ url }) => {
         monitor_tag: m.monitor_tag,
         impact: m.monitor_impact as "UP" | "DOWN" | "DEGRADED" | "MAINTENANCE",
       })),
-      created_at: formatDateToISO(maintenance.created_at),
-      updated_at: formatDateToISO(maintenance.updated_at),
+      created_at: parseDbTimestamp(maintenance.created_at).toISOString(),
+      updated_at: parseDbTimestamp(maintenance.updated_at).toISOString(),
       url: siteUrl + serverResolver(`/maintenances/${maintenance.id}?type=maintenance`),
     });
   }
@@ -269,8 +260,8 @@ export const POST: RequestHandler = async ({ request }) => {
       monitor_tag: m.monitor_tag,
       impact: m.monitor_impact as "UP" | "DOWN" | "DEGRADED" | "MAINTENANCE",
     })),
-    created_at: formatDateToISO(maintenance.created_at),
-    updated_at: formatDateToISO(maintenance.updated_at),
+    created_at: parseDbTimestamp(maintenance.created_at).toISOString(),
+    updated_at: parseDbTimestamp(maintenance.updated_at).toISOString(),
     url: (await GetSiteURL()) + serverResolver(`/maintenances/${maintenance.id}?type=maintenance`),
   };
 

--- a/src/routes/(api)/api/v4/maintenances/[maintenance_id]/+server.ts
+++ b/src/routes/(api)/api/v4/maintenances/[maintenance_id]/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type {
   GetMaintenanceResponse,
@@ -13,15 +14,6 @@ import { GenerateMaintenanceEvents, isOneTimeRrule } from "$lib/server/controlle
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
 import serverResolver from "$lib/server/resolver";
 import { rrulestr } from "rrule";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 function isValidRrule(rrule: string): boolean {
   try {
@@ -55,8 +47,8 @@ async function buildMaintenanceResponse(maintenanceId: number): Promise<Maintena
       monitor_tag: m.monitor_tag,
       impact: m.monitor_impact as "UP" | "DOWN" | "DEGRADED" | "MAINTENANCE",
     })),
-    created_at: formatDateToISO(maintenance.created_at),
-    updated_at: formatDateToISO(maintenance.updated_at),
+    created_at: parseDbTimestamp(maintenance.created_at).toISOString(),
+    updated_at: parseDbTimestamp(maintenance.updated_at).toISOString(),
     url: (await GetSiteURL()) + serverResolver(`/maintenances/${maintenance.id}?type=maintenance`),
   };
 }

--- a/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/+server.ts
+++ b/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/+server.ts
@@ -1,17 +1,9 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type { GetMaintenanceEventsListResponse, MaintenanceEventResponse } from "$lib/types/api";
 import { GetSiteURL } from "$lib/server/controllers/siteDataController";
 import serverResolver from "$lib/server/resolver";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   // Maintenance is validated by middleware and available in locals
@@ -40,8 +32,8 @@ export const GET: RequestHandler = async ({ locals, url }) => {
     start_date_time: event.start_date_time,
     end_date_time: event.end_date_time,
     status: event.status as MaintenanceEventResponse["status"],
-    created_at: formatDateToISO(event.created_at),
-    updated_at: formatDateToISO(event.updated_at),
+    created_at: parseDbTimestamp(event.created_at).toISOString(),
+    updated_at: parseDbTimestamp(event.updated_at).toISOString(),
     url: siteUrl + serverResolver(`/maintenances/${event.id}`),
   }));
 

--- a/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/[event_id]/+server.ts
+++ b/src/routes/(api)/api/v4/maintenances/[maintenance_id]/events/[event_id]/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type {
   GetMaintenanceEventResponse,
@@ -15,15 +16,6 @@ import { UpdateMaintenanceEventStatus } from "$lib/server/controllers/maintenanc
 import GC from "$lib/global-constants";
 import serverResolver from "$lib/server/resolver";
 
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
-
 async function buildEventResponse(event: {
   id: number;
   maintenance_id: number;
@@ -39,8 +31,8 @@ async function buildEventResponse(event: {
     start_date_time: event.start_date_time,
     end_date_time: event.end_date_time,
     status: event.status as MaintenanceEventResponse["status"],
-    created_at: formatDateToISO(event.created_at),
-    updated_at: formatDateToISO(event.updated_at),
+    created_at: parseDbTimestamp(event.created_at).toISOString(),
+    updated_at: parseDbTimestamp(event.updated_at).toISOString(),
     url: (await GetSiteURL()) + serverResolver(`/maintenances/${event.id}`),
   };
 }

--- a/src/routes/(api)/api/v4/monitors/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/+server.ts
@@ -10,15 +10,6 @@ import type {
 import type { MonitorRecord } from "$lib/server/types/db";
 import { GetMonitorsParsed } from "$lib/server/controllers/monitorsController";
 
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
-
 export const GET: RequestHandler = async ({ url }) => {
   const status = url.searchParams.get("status") || undefined;
   const category_name = url.searchParams.get("category_name") || undefined;

--- a/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
+++ b/src/routes/(api)/api/v4/monitors/[monitor_tag]/+server.ts
@@ -10,15 +10,6 @@ import type {
   BadRequestResponse,
 } from "$lib/types/api";
 
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
-
 export const GET: RequestHandler = async ({ locals }) => {
   // Monitor is validated by middleware and available in locals
   const monitor = locals.monitor!;

--- a/src/routes/(api)/api/v4/pages/+server.ts
+++ b/src/routes/(api)/api/v4/pages/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type {
   GetPagesListResponse,
@@ -10,15 +11,6 @@ import type {
 import type { PageRecord } from "$lib/server/types/db";
 import GC from "$lib/global-constants";
 import { toApiPageSettings, applyPageSettingsPatch, validatePageSettings } from "$lib/server/pageSettings";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
   const pageSettings = toApiPageSettings(page.page_settings_json);
@@ -35,8 +27,8 @@ async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
     page_logo: page.page_logo,
     page_settings: pageSettings,
     monitors: pageMonitors.map((pm) => ({ monitor_tag: pm.monitor_tag, position: pm.position })),
-    created_at: formatDateToISO(page.created_at),
-    updated_at: formatDateToISO(page.updated_at),
+    created_at: parseDbTimestamp(page.created_at).toISOString(),
+    updated_at: parseDbTimestamp(page.updated_at).toISOString(),
   };
 }
 

--- a/src/routes/(api)/api/v4/pages/[page_path]/+server.ts
+++ b/src/routes/(api)/api/v4/pages/[page_path]/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { parseDbTimestamp } from "$lib/server/tool";
 import db from "$lib/server/db/db";
 import type {
   GetPageResponse,
@@ -12,15 +13,6 @@ import type {
 import type { PageRecord } from "$lib/server/types/db";
 import GC from "$lib/global-constants";
 import { toApiPageSettings, applyPageSettingsPatch, validatePageSettings } from "$lib/server/pageSettings";
-
-function formatDateToISO(date: Date | string): string {
-  if (date instanceof Date) {
-    return date.toISOString();
-  }
-  // Handle string dates (e.g., from SQLite: "2026-01-27 16:07:19")
-  const parsed = new Date(date.replace(" ", "T") + "Z");
-  return parsed.toISOString();
-}
 
 async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
   const pageSettings = toApiPageSettings(page.page_settings_json);
@@ -37,8 +29,8 @@ async function formatPageResponse(page: PageRecord): Promise<PageResponse> {
     page_logo: page.page_logo,
     page_settings: pageSettings,
     monitors: pageMonitors.map((pm) => ({ monitor_tag: pm.monitor_tag, position: pm.position })),
-    created_at: formatDateToISO(page.created_at),
-    updated_at: formatDateToISO(page.updated_at),
+    created_at: parseDbTimestamp(page.created_at).toISOString(),
+    updated_at: parseDbTimestamp(page.updated_at).toISOString(),
   };
 }
 

--- a/src/routes/(docs)/docs/content/v4/internationalization.md
+++ b/src/routes/(docs)/docs/content/v4/internationalization.md
@@ -74,6 +74,7 @@ node scripts/sort-translations.js
 - Kener stores timestamps in UTC (Unix seconds).
 - On the client, Kener detects browser timezone automatically.
 - If timezone switching is enabled, users can change timezone manually from the public page controls.
+- The admin dashboard (`/manage`) always uses your browser timezone and shows the GMT offset (for example `2026-08-20 12:02:00 GMT+8`); hover a time to see it in UTC.
 
 ### Admin toggle {#timezone-admin-toggle}
 

--- a/src/routes/(docs)/docs/content/v4/setup/database-setup.md
+++ b/src/routes/(docs)/docs/content/v4/setup/database-setup.md
@@ -85,6 +85,8 @@ DATABASE_URL=postgresql://user:pass@host:5432/kener?sslmode=require
 
 Use when MySQL/MariaDB is your standard stack.
 
+Run the server with `time_zone` set to UTC (for example `--default-time-zone=+00:00`). Kener runs in UTC and reads `created_at`/`updated_at` as UTC; a non-UTC server session shifts them. See [/docs/v4/setup/environment-variables#timezone](/docs/v4/setup/environment-variables#timezone).
+
 ```env
 DATABASE_URL=mysql://kener:password@localhost:3306/kener
 ```

--- a/src/routes/(manage)/manage/app/alerts/logs/[alert_config_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/alerts/logs/[alert_config_id]/+page.svelte
@@ -15,8 +15,8 @@
   import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
   import BellOffIcon from "@lucide/svelte/icons/bell-off";
   import TrashIcon from "@lucide/svelte/icons/trash";
-  import { format } from "date-fns";
   import { toast } from "svelte-sonner";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import type { MonitorAlertConfigWithTriggers, MonitorAlertV2WithConfig } from "$lib/server/types/db";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -150,16 +150,6 @@
     }
   }
 
-  // Format date
-  function formatDate(dateStr: string | Date): string {
-    try {
-      const date = typeof dateStr === "string" ? new Date(dateStr) : dateStr;
-      return format(date, "yyyy-MM-dd HH:mm:ss");
-    } catch {
-      return String(dateStr);
-    }
-  }
-
   // Handle filter change
   function handleStatusChange(value: string | undefined) {
     if (value) {
@@ -278,8 +268,8 @@
                   <span class="text-muted-foreground text-sm">—</span>
                 {/if}
               </Table.Cell>
-              <Table.Cell class="text-muted-foreground text-sm">{formatDate(alert.created_at)}</Table.Cell>
-              <Table.Cell class="text-muted-foreground text-sm">{formatDate(alert.updated_at)}</Table.Cell>
+              <Table.Cell class="text-muted-foreground text-sm"><LocalTime value={alert.created_at} /></Table.Cell>
+              <Table.Cell class="text-muted-foreground text-sm"><LocalTime value={alert.updated_at} /></Table.Cell>
               <Table.Cell class="text-right">
                 <Button variant="destructive" size="sm" class="text-xs" onclick={() => openDeleteDialog(alert)}>
                   <TrashIcon class="size-3" /> Delete

--- a/src/routes/(manage)/manage/app/api-keys/+page.svelte
+++ b/src/routes/(manage)/manage/app/api-keys/+page.svelte
@@ -15,7 +15,7 @@
   import KeyIcon from "@lucide/svelte/icons/key";
   import Trash2 from "@lucide/svelte/icons/trash-2";
   import { toast } from "svelte-sonner";
-  import { format } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { onMount } from "svelte";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -163,14 +163,6 @@
     }
   }
 
-  function formatDate(dateStr: string): string {
-    try {
-      return format(new Date(dateStr), "MMM d, yyyy HH:mm");
-    } catch {
-      return dateStr;
-    }
-  }
-
   function dismissNewKey() {
     newKeyResp = {};
   }
@@ -260,7 +252,7 @@
                   </code>
                 </Table.Cell>
                 <Table.Cell class="text-muted-foreground text-sm">
-                  {formatDate(apiKey.created_at)}
+                  <LocalTime value={apiKey.created_at} format="MMM d, yyyy HH:mm" />
                 </Table.Cell>
                 <Table.Cell class="pr-4 text-right">
                   <div class="flex items-center justify-end gap-2">

--- a/src/routes/(manage)/manage/app/incidents/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/+page.svelte
@@ -15,7 +15,7 @@
   import SirenIcon from "@lucide/svelte/icons/siren";
   import { goto } from "$app/navigation";
   import { formatDistanceToNow } from "date-fns";
-  import { formatDate } from "$lib/stores/datetime";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import GC from "$lib/global-constants";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -195,7 +195,7 @@
               </Table.Cell>
               <Table.Cell>
                 <span class="text-muted-foreground text-sm">
-                  {$formatDate(incident.start_date_time, "yyyy-MM-dd HH:mm")}
+                  <LocalTime value={incident.start_date_time} format="yyyy-MM-dd HH:mm" />
                 </span>
               </Table.Cell>
               <Table.Cell>
@@ -206,11 +206,11 @@
                   <Tooltip.Content>
                     <div class="text-sm">
                       <span class="text-muted-foreground">From:</span>
-                      {$formatDate(incident.start_date_time, "yyyy-MM-dd HH:mm")}
+                      <LocalTime value={incident.start_date_time} format="yyyy-MM-dd HH:mm" />
                       <br />
                       <span class="text-muted-foreground">To:</span>
                       {#if incident.end_date_time}
-                        {$formatDate(incident.end_date_time, "yyyy-MM-dd HH:mm")}
+                        <LocalTime value={incident.end_date_time} format="yyyy-MM-dd HH:mm" />
                       {:else}
                         Ongoing
                       {/if}

--- a/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/incidents/[incident_id]/+page.svelte
@@ -24,7 +24,7 @@
   import type { MonitorRecord, IncidentRecord, IncidentCommentRecord } from "$lib/server/types/db.js";
   import { goto } from "$app/navigation";
   import { toast } from "svelte-sonner";
-  import { format } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import GC from "$lib/global-constants";
   import { mode } from "mode-watcher";
   import { resolve } from "$app/paths";
@@ -1126,7 +1126,7 @@
                         <div class="flex items-center gap-2">
                           <Badge variant={getStateBadgeVariant(comment.state)}>{comment.state}</Badge>
                           <span class="text-muted-foreground text-sm">
-                            {format(new Date(comment.commented_at * 1000), "MMM d, yyyy HH:mm")}
+                            <LocalTime value={comment.commented_at} format="MMM d, yyyy HH:mm" />
                           </span>
                         </div>
                         <div

--- a/src/routes/(manage)/manage/app/maintenances/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/+page.svelte
@@ -17,7 +17,8 @@
   import ClockIcon from "@lucide/svelte/icons/clock";
   import UsersIcon from "@lucide/svelte/icons/users";
   import { goto } from "$app/navigation";
-  import { format, formatDistanceToNow, isPast, isFuture, isWithinInterval } from "date-fns";
+  import { formatDistanceToNow, isPast, isFuture, isWithinInterval } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
 
@@ -274,7 +275,7 @@
                     <div class="text-sm">
                       <div>
                         <span class="text-muted-foreground">Start:</span>
-                        {format(new Date(maintenance.start_date_time * 1000), "yyyy-MM-dd HH:mm")}
+                        <LocalTime value={maintenance.start_date_time} format="yyyy-MM-dd HH:mm" />
                       </div>
                       <div>
                         <span class="text-muted-foreground">Duration:</span>
@@ -322,11 +323,11 @@
                       <div class="text-sm">
                         <div>
                           <span class="text-muted-foreground">Start:</span>
-                          {format(new Date(maintenance.upcoming_event.start_date_time * 1000), "MMM d, yyyy HH:mm")}
+                          <LocalTime value={maintenance.upcoming_event.start_date_time} format="MMM d, yyyy HH:mm" />
                         </div>
                         <div>
                           <span class="text-muted-foreground">End:</span>
-                          {format(new Date(maintenance.upcoming_event.end_date_time * 1000), "MMM d, yyyy HH:mm")}
+                          <LocalTime value={maintenance.upcoming_event.end_date_time} format="MMM d, yyyy HH:mm" />
                         </div>
                       </div>
                     </Tooltip.Content>

--- a/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
+++ b/src/routes/(manage)/manage/app/maintenances/[id]/+page.svelte
@@ -29,6 +29,7 @@
   import { goto } from "$app/navigation";
   import { toast } from "svelte-sonner";
   import { format, formatDistanceToNow, isPast, isFuture, isWithinInterval } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { rrulestr } from "rrule";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
@@ -932,9 +933,9 @@
                         <Badge variant={displayStatus.variant}>{displayStatus.label}</Badge>
                       </div>
                       <p class="text-muted-foreground text-sm">
-                        {format(new Date(event.start_date_time * 1000), "MMM d, yyyy HH:mm")}
+                        <LocalTime value={event.start_date_time} format="MMM d, yyyy HH:mm" />
                         →
-                        {format(new Date(event.end_date_time * 1000), "MMM d, yyyy HH:mm")}
+                        <LocalTime value={event.end_date_time} format="MMM d, yyyy HH:mm" />
                       </p>
                     </div>
                   </div>

--- a/src/routes/(manage)/manage/app/monitoring-data/+page.svelte
+++ b/src/routes/(manage)/manage/app/monitoring-data/+page.svelte
@@ -15,6 +15,7 @@
   import FilterIcon from "@lucide/svelte/icons/filter";
   import XIcon from "@lucide/svelte/icons/x";
   import { format } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
   import { resolve } from "$app/paths";
@@ -235,16 +236,6 @@
     }
   }
 
-  // Format timestamp to date string
-  function formatTimestamp(timestamp: number): string {
-    try {
-      const date = new Date(timestamp * 1000);
-      return format(date, "yyyy-MM-dd HH:mm:ss");
-    } catch {
-      return String(timestamp);
-    }
-  }
-
   function handleMonitorChange(value: string | undefined) {
     if (value) {
       monitorTagFilter = value;
@@ -389,7 +380,7 @@
                 </Tooltip.Root>
               </Table.Cell>
               <Table.Cell>
-                <span class="text-muted-foreground text-sm">{formatTimestamp(row.timestamp)}</span>
+                <span class="text-muted-foreground text-sm"><LocalTime value={row.timestamp} /></span>
               </Table.Cell>
               <Table.Cell>
                 <span class="text-xs font-semibold text-{row.status?.toLowerCase()}">

--- a/src/routes/(manage)/manage/app/monitors/[tag]/components/MonitorRecentLogs.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/components/MonitorRecentLogs.svelte
@@ -7,8 +7,8 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
-  import { format } from "date-fns";
   import { onMount } from "svelte";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
 
@@ -73,16 +73,6 @@
     }
   }
 
-  // Format timestamp to date string
-  function formatTimestamp(timestamp: number): string {
-    try {
-      const date = new Date(timestamp * 1000);
-      return format(date, "yyyy-MM-dd HH:mm:ss");
-    } catch {
-      return String(timestamp);
-    }
-  }
-
   onMount(() => {
     fetchLogs();
   });
@@ -136,7 +126,7 @@
             {#each logs as log (log.timestamp)}
               <Table.Row class="hover:bg-muted/50">
                 <Table.Cell>
-                  <span class="text-muted-foreground text-sm">{formatTimestamp(log.timestamp)}</span>
+                  <span class="text-muted-foreground text-sm"><LocalTime value={log.timestamp} /></span>
                 </Table.Cell>
                 <Table.Cell>
                   <Badge variant={getStatusBadgeVariant(log.status)}>

--- a/src/routes/(manage)/manage/app/subscriptions/+page.svelte
+++ b/src/routes/(manage)/manage/app/subscriptions/+page.svelte
@@ -10,7 +10,7 @@
   import * as Dialog from "$lib/components/ui/dialog/index.js";
   import * as Alert from "$lib/components/ui/alert/index.js";
   import { toast } from "svelte-sonner";
-  import { format } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
   import { page as pageData } from "$app/state";
@@ -531,7 +531,7 @@
                     />
                   </Table.Cell>
                   <Table.Cell>
-                    {format(new Date(subscriber.created_at), "MMM d, yyyy")}
+                    <LocalTime value={subscriber.created_at} format="MMM d, yyyy" />
                   </Table.Cell>
                   <Table.Cell class="text-center">
                     <Button

--- a/src/routes/(manage)/manage/app/users/+page.svelte
+++ b/src/routes/(manage)/manage/app/users/+page.svelte
@@ -25,7 +25,7 @@
   import EyeOpenIcon from "@lucide/svelte/icons/eye";
   import * as Tooltip from "$lib/components/ui/tooltip/index.js";
   import { toast } from "svelte-sonner";
-  import { format } from "date-fns";
+  import LocalTime from "$lib/components/LocalTime.svelte";
   import { onMount } from "svelte";
   import type { UserRecordDashboard, UserRecordPublic, RoleRecord } from "$lib/server/types/db.js";
   import { resolve } from "$app/paths";
@@ -299,18 +299,6 @@
   function goToPage(newPage: number) {
     page = newPage;
     fetchUsers();
-  }
-
-  // Format date
-  function formatDate(dateStr: string | Date): string {
-    if (dateStr instanceof Date) {
-      return format(dateStr, "MMM dd, yyyy HH:mm");
-    }
-    try {
-      return format(new Date(dateStr), "MMM dd, yyyy HH:mm");
-    } catch {
-      return dateStr;
-    }
   }
 
   // Role badge variant by precedence: admin > editor > others
@@ -587,11 +575,11 @@
           <div class="space-y-2 text-sm">
             <p>
               <strong>Created At:</strong>
-              {formatDate(toEditUser.created_at)}
+              <LocalTime value={toEditUser.created_at} format="MMM dd, yyyy HH:mm" />
             </p>
             <p>
               <strong>Updated At:</strong>
-              {formatDate(toEditUser.updated_at)}
+              <LocalTime value={toEditUser.updated_at} format="MMM dd, yyyy HH:mm" />
             </p>
             <p>
               <strong>Name:</strong>


### PR DESCRIPTION
Alert Logs showed Created At / Updated At in UTC instead of the browser timezone (#813). SQLite returns `created_at`/`updated_at` as naive `YYYY-MM-DD HH:mm:ss` text, the manage API passes rows through, and the page did `new Date(str)`, which browsers parse as local time. Same bug on api-keys, subscriptions and users; pg/mysql hand back Date objects so they were fine.

One rule for the admin now: every timestamp renders through a `LocalTime` component in the browser timezone with the GMT offset (`2026-08-20 12:02:00 GMT+8`), UTC on hover. Audit columns get parsed by value shape before use: `parseDateInput` on the client, a new `parseDbTimestamp` on the server, which also replaces the 12 identical `formatDateToISO` copies in api/v4 and the raw `new Date(audit column)` calls in alertingQueue, notification_utils and incidentController. Record types now say `DbTimestamp = Date | string` so the SQLite shape is honest, and `/manage` no longer imports the public timezone store.

Docs: admin timezone note on the internationalization page, and MySQL must run with `time_zone` UTC (the process already forces `TZ=UTC`, so only a non-UTC MySQL session can skew audit columns; not touched here).

`npm run check` clean, `npm test` 118/118 with new tests for both parsers and the component (offset label, tooltip, invalid-value fallback). Closes #813.

https://claude.ai/code/session_018izL9dML7w5EVN7JyKkfU9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized timestamp display across the management dashboard, including GMT offsets and UTC details on hover.
  * Standardized date and time presentation across incidents, alerts, maintenance, monitoring, subscriptions, API keys, and user views.

* **Bug Fixes**
  * Improved handling of timestamps from different database formats, including UTC text, ISO strings, dates, and epoch values.
  * API responses now consistently return correctly formatted ISO timestamps.

* **Documentation**
  * Clarified timezone behavior and UTC requirements for MySQL database setup.

* **Tests**
  * Added coverage for timestamp parsing, localized display, UTC tooltips, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->