### PR TITLE
fix(analytics): escape provider values before injecting into /capture.js

### DIFF
--- a/src/routes/(docs)/docs/content/v4/analytics.md
+++ b/src/routes/(docs)/docs/content/v4/analytics.md
@@ -9,6 +9,8 @@ Kener supports injecting analytics scripts into the public status page. Go to **
 
 When a provider is enabled, Kener injects its tracking script into every public status page response via `/capture.js`. Multiple providers can be active simultaneously.
 
+Paste keys and URLs exactly as your provider shows them. Kener escapes every value before injecting it, so quotes or other special characters cannot break tracking for the other providers.
+
 ## Supported providers {#supported-providers}
 
 | Provider          | Key                          |

--- a/src/routes/(kener)/capture.js/+server.ts
+++ b/src/routes/(kener)/capture.js/+server.ts
@@ -29,6 +29,16 @@ export const GET: RequestHandler = async ({ params, url }) => {
     return acc;
   }, {});
 
+  // Every requirement is spliced into a double-quoted JS string literal inside a snippet.
+  // Escape once here so a pasted quote, backslash or newline can't turn /capture.js into a
+  // SyntaxError for every enabled provider.
+  for (const key in analyticsData) {
+    const req = analyticsData[key].requirements || {};
+    for (const name in req) {
+      req[name] = JSON.stringify(String(req[name] ?? "")).slice(1, -1);
+    }
+  }
+
   let captureScript = "";
 
   if (!!analyticsData["analytics.googleTagManager"]) {

--- a/src/routes/(kener)/capture.js/server.test.ts
+++ b/src/routes/(kener)/capture.js/server.test.ts
@@ -30,6 +30,31 @@ describe("GET /capture.js — OpenPanel", () => {
     expect(body).not.toContain("{{");
   });
 
+  it("escapes values so a stray quote in any provider cannot break the script", async () => {
+    vi.mocked(GetAllAnalyticsData).mockResolvedValue([
+      {
+        key: "analytics.openpanel",
+        value: {
+          isEnabled: true,
+          requirements: {
+            "Client ID": 'abc"; alert(1); //',
+            "API URL": "https://op.example.com/api\n",
+            "Script URL": "https://op.example.com/op1.js",
+          },
+        },
+      },
+      {
+        key: "analytics.posthog",
+        value: { isEnabled: true, requirements: { "API Key": 'phc_\\quote"', "API Host": "https://us.i.posthog.com" } },
+      },
+    ]);
+    const body = await (await call()).text();
+    expect(() => new Function(body)).not.toThrow();
+    expect(body).toContain('clientId: "abc\\"; alert(1); //"');
+    expect(body).toContain('apiUrl: "https://op.example.com/api\\n"');
+    expect(body).toContain('posthog.init("phc_\\\\quote\\"');
+  });
+
   it("emits nothing for OpenPanel when it is disabled", async () => {
     vi.mocked(GetAllAnalyticsData).mockResolvedValue([
       { key: "analytics.openpanel", value: { isEnabled: false, requirements: { "Client ID": "cid-123" } } },


### PR DESCRIPTION
Stacked on #824 (retarget to `main` once that merges).

Requirement values (keys, hosts, URLs) were spliced into double-quoted JS string literals via `replaceAll` with no escaping. A pasted `"`, `\` or newline in **any one** provider's field turned the single concatenated `/capture.js` into a SyntaxError and silently disabled **every** enabled provider.

**Fix:** escape once at the shared path in `capture.js/+server.ts`, right after the key/value reduce, so all eight providers go through it. Test asserts `new Function(body)` parses with hostile values in two providers at once. One-line note added to `/docs/v4/analytics` "How it works".

`npm run check` clean, `npm test` 126/126.

https://claude.ai/code/session_01CWyqQeLbmw54XeNr9Ggwr5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics tracking reliability when provider keys or URLs contain quotes, backslashes, newlines, or other special characters.
  * Prevented malformed tracking scripts caused by unusual configuration values.

* **Documentation**
  * Clarified that provider keys and URLs should be pasted exactly as provided.
  * Added guidance explaining how analytics values are safely handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->