### PR TITLE
doing single bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,22 +135,6 @@
         "node": ">=20.0.0"
       }
     },
-    "../aven": {
-      "name": "@rajnandan1/aven",
-      "version": "0.1.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@openai/agents": "^0.3.7",
-        "@webfuse-com/d2snap": "github:webfuse-com/D2Snap",
-        "zod": "^3.25.76"
-      },
-      "devDependencies": {
-        "serve": "^14.2.4",
-        "tsup": "^8.5.0",
-        "typescript": "^5.8.3"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,6 +14,9 @@ const config = {
 
   kit: {
     adapter: adapter(),
+    output: {
+      bundleStrategy: 'single'
+    },
     paths: {
       base: basePath,
     },


### PR DESCRIPTION
This pull request makes a small configuration change to the SvelteKit setup. The most notable update is the addition of a `bundleStrategy: 'single'` option to the `output` configuration in `svelte.config.js`, which will bundle the output into a single file.

- SvelteKit configuration:
  * Added `output.bundleStrategy: 'single'` to the `kit` configuration in `svelte.config.js` to produce a single bundled output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application build configuration to generate a single output bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->