### PR TITLE
Create changelog for version 4.1.3

### DIFF
--- a/src/routes/(docs)/docs.json
+++ b/src/routes/(docs)/docs.json
@@ -319,6 +319,10 @@
                   "collapsible": false,
                   "pages": [
                     {
+                      "title": "v4.1.3",
+                      "content": "v4/changelogs/v4.1.3"
+                    },
+                    {
                       "title": "v4.1.2",
                       "content": "v4/changelogs/v4.1.2"
                     },

--- a/src/routes/(docs)/docs/content/v4/changelogs/v4.1.3.md
+++ b/src/routes/(docs)/docs/content/v4/changelogs/v4.1.3.md
@@ -1,0 +1,51 @@
+---
+title: v4.1.3 Changelog
+description: See what's new in Kener v4.1.3, including new features, improvements, and bug fixes
+---
+
+Release date: **August 31, 2026**
+
+## New features {#new-features}
+
+### OpenID Connect single sign-on {#oidc}
+
+Kener now supports login through an external identity provider (Keycloak, Authentik, Azure AD, Okta, and others) using the OIDC Authorization Code Flow with PKCE. Configure it under **Manage → OpenID Connect**: set the issuer, client credentials, and optional group-to-role mappings so provider groups map to Kener admin, editor, or member roles. OIDC users stay separate from local accounts. See [OpenID Connect](/docs/v4/oidc). Thanks to [@Plattenspatz](https://github.com/Plattenspatz).
+
+### Prometheus monitors {#prometheus-monitors}
+
+A new **Prometheus** monitor type queries a Prometheus server, evaluates the returned value against thresholds, and maps it to `UP`, `DEGRADED`, or `DOWN`. Two options control failure semantics: **`noDataStatus`** decides what an empty query result means, and **`errorStatus`** decides what an unreachable server or unusable response means — useful when the metric measures capacity or lag rather than liveness, so a lost scrape does not show up as an outage. See [Prometheus Monitor](/docs/v4/monitors/prometheus). Thanks to [@123FLO321](https://github.com/123FLO321).
+
+### OpenPanel analytics {#openpanel}
+
+[OpenPanel](https://openpanel.dev) joins the list of supported analytics providers. Add your client ID in site settings and Kener injects the tracker on the status page. See [Analytics](/docs/v4/analytics).
+
+### Filter monitoring data by status {#monitoring-status-filter}
+
+The **Monitoring Data** admin page gained a status dropdown. Pick a status (`UP`, `DOWN`, `DEGRADED`, …) to filter the table and the row count, and deletion respects the same filter — so you can remove, say, only the `DOWN` rows a misconfigured monitor wrote. Thanks to [@lokiee0](https://github.com/lokiee0).
+
+## Improvements {#improvements}
+
+### Faster status pages on large databases {#status-page-performance}
+
+The latest-status lookup used a `MAX(timestamp)` self-join that PostgreSQL planned as a full scan of `monitoring_data` (~500ms per page load at 1.7M rows). It now runs one indexed descent per monitor on every supported database. A migration also tunes PostgreSQL autovacuum on `monitoring_data` so the nightly retention cleanup no longer leaves the table bloated. Existing large PostgreSQL installs should run a one-time `VACUUM (ANALYZE)` — see [Database Setup](/docs/v4/setup/database-setup).
+
+### Inline event labels {#inline-event-labels}
+
+Incidents and maintenances rendered inline on the status page now carry a localized **INCIDENT** or **MAINTENANCE** tag, so the two event types are distinguishable at a glance.
+
+### Validation hardening {#validation-hardening}
+
+IP address validation now goes through one shared validator with correct octet and IPv6 checks, backing both DNS resolver and nameserver validation. API and Prometheus monitors guard against malformed stored configuration instead of crashing, and Prometheus responses with mismatched scalar/vector shapes are rejected. The `axios` dependency floor rose to `1.13.5`.
+
+### Updated translations {#translations}
+
+Turkish translations were refreshed.
+
+## Bug fixes {#bug-fixes}
+
+- **Admin timestamps show your timezone.** Admin pages (alert logs, API keys, subscriptions, users) parsed naive UTC strings as local time, so timestamps were off by your UTC offset on SQLite. They now render in the browser timezone with a GMT offset, and hovering shows the UTC value.
+- **Mixed-case emails can sign up.** Signup stored emails lowercased but looked them up with the original casing, so addresses like `Timothy.Pace@example.com` failed with "Failed to create user". Lookups are now case-insensitive.
+- **Sparse monthly maintenance rules expand.** RRULEs with an ordinal weekday, such as `FREQ=MONTHLY;BYDAY=1WE` (first Wednesday), now generate the right occurrences, and the maintenance preview no longer skips them. See [RRULE Patterns](/docs/v4/maintenances/rrule-patterns).
+- **Monitor secrets work in headers.** Secret placeholders inside header fields are now substituted, and secret values containing `$` characters are inserted literally instead of being mangled by replacement-pattern expansion.
+- **Affected-monitor badges wrap.** Incident and maintenance cards with many affected monitors overflowed or hid badges behind a scrollbar; badges now wrap inside the card.
+- **Analytics values are escaped.** Provider IDs are escaped before injection into `/capture.js`, so a malformed value cannot break or script the tracker bootstrap.


### PR DESCRIPTION
Adds the v4.1.3 changelog page at `/docs/v4/changelogs/v4.1.3` and lists it in the docs sidebar, covering everything merged since the `v4.1.2` tag.

## Contents

- **New features**: OIDC single sign-on (#733), Prometheus monitor type (#791), OpenPanel analytics (#824), monitoring-data status filter (#799)
- **Improvements**: status-page query rewrite + Postgres autovacuum tuning (#826), inline INCIDENT/MAINTENANCE labels, IP-validation hardening, Turkish translations
- **Bug fixes**: admin timestamps in browser timezone (#813), case-insensitive signup emails (#820), sparse monthly RRULE expansion, secrets in header fields, badge wrapping (#794), `/capture.js` escaping

Release date in the page: August 31, 2026. The favicon `KENER_BASE_PATH` and reactive chartId fixes landed after the tag but are already documented in the v4.1.2 changelog, so they are excluded. Test/CI infrastructure and chores are left out as non-user-facing.

https://claude.ai/code/session_01FLbhAsFr3MTVgJibdrdoY8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect single sign-on support.
  * Added Prometheus monitoring and OpenPanel analytics integrations.
  * Added status filtering to the Monitoring Data administration page.
* **Improvements**
  * Improved performance for status pages with large databases.
  * Added inline event labels and updated Turkish translations.
  * Strengthened validation and resolved issues with time zones, maintenance schedules, headers, badges, email lookups, and analytics values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->