### PR TITLE
fixed color error two colors

### DIFF
--- a/src/routes/(docs)/+layout.svelte
+++ b/src/routes/(docs)/+layout.svelte
@@ -16,6 +16,12 @@
 <ModeWatcher />
 <Toaster />
 
-<main>
+<svelte:head>
+  <!-- Docs-only font. A <link> here rather than an @import in docs.css so it does not ride along in the
+       single CSS bundle and get fetched by every status page. -->
+  <link rel="stylesheet" href="https://fonts.bunny.net/css?family=geist:400,500,600,700|geist-mono:400,500" />
+</svelte:head>
+
+<main class="kener-docs">
   {@render children()}
 </main>

--- a/src/routes/(embed)/+layout.svelte
+++ b/src/routes/(embed)/+layout.svelte
@@ -20,7 +20,7 @@
   {/if}
   {@html `
 	<style id="dynamic-styles">
-		.body {
+		body {
 			--up: ${data.siteStatusColors.UP};
 			--degraded: ${data.siteStatusColors.DEGRADED};
 			--down: ${data.siteStatusColors.DOWN};

--- a/src/routes/docs.css
+++ b/src/routes/docs.css
@@ -1,12 +1,15 @@
-@import url("https://fonts.bunny.net/css?family=geist:400,500,600,700|geist-mono:400,500");
-
 /* Docs typography + brand accent.
    Single family (Geist) with weight contrast; Geist Mono for code and labels.
    Brand accent is the Kener logo orange (#ff6600 = oklch(0.696 0.204 43.5)),
    deepened in light mode so it passes AA as text on white (4.6:1) and
    brightened in dark mode (6.9:1 on the dark background).
-   Tokens live on body so portaled dialogs inherit them too. */
-body {
+   Tokens live on body so portaled dialogs inherit them too.
+
+   Every route group's CSS ends up in one file (kit.output.bundleStrategy "single"), so the whole
+   sheet is scoped to pages that mount <main class="kener-docs">: the status page and /manage render
+   the same .prose and .markdown-alert markup and must keep their own look. Geist is loaded by the
+   docs layout's <link>, not an @import here, for the same reason. */
+body:has(.kener-docs) {
   font-family:
     "Geist",
     ui-sans-serif,
@@ -16,99 +19,99 @@ body {
   --primary: oklch(0.58 0.175 43);
   --primary-foreground: oklch(0.985 0.005 43);
   --ring: oklch(0.58 0.175 43);
-}
 
-.dark body {
-  --primary: oklch(0.7 0.18 43);
-  --primary-foreground: oklch(0.18 0.035 43);
-  --ring: oklch(0.7 0.18 43);
-}
+  .dark & {
+    --primary: oklch(0.7 0.18 43);
+    --primary-foreground: oklch(0.18 0.035 43);
+    --ring: oklch(0.7 0.18 43);
+  }
 
-::selection {
-  background: color-mix(in oklch, var(--primary) 25%, transparent);
-}
+  & ::selection {
+    background: color-mix(in oklch, var(--primary) 25%, transparent);
+  }
 
-/* Prose dark mode fixes */
-.dark .prose {
-  --tw-prose-body: var(--foreground);
-  --tw-prose-headings: var(--foreground);
-  --tw-prose-links: var(--primary);
-  --tw-prose-bold: var(--foreground);
-  --tw-prose-code: var(--foreground);
-  --tw-prose-pre-bg: var(--muted);
-}
+  /* Prose dark mode fixes */
+  .dark & .prose {
+    --tw-prose-body: var(--foreground);
+    --tw-prose-headings: var(--foreground);
+    --tw-prose-links: var(--primary);
+    --tw-prose-bold: var(--foreground);
+    --tw-prose-code: var(--foreground);
+    --tw-prose-pre-bg: var(--muted);
+  }
 
-/* Markdown Alerts (from marked-alert) */
-.markdown-alert {
-  padding: 0.75rem 1rem;
-  margin: 1.5rem 0;
-  border: 2px solid;
-  border-radius: 1rem;
-  background-color: var(--secondary);
-}
+  /* Markdown Alerts (from marked-alert) */
+  .markdown-alert {
+    padding: 0.75rem 1rem;
+    margin: 1.5rem 0;
+    border: 2px solid;
+    border-radius: 1rem;
+    background-color: var(--secondary);
+  }
 
-.markdown-alert > :first-child {
-  margin-top: 0;
-}
+  .markdown-alert > :first-child {
+    margin-top: 0;
+  }
 
-.markdown-alert > :last-child {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 24px;
-}
+  .markdown-alert > :last-child {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 24px;
+  }
 
-.markdown-alert .markdown-alert-title svg {
-  fill: currentColor;
-}
-.markdown-alert .markdown-alert-title {
-  display: flex;
-  align-items: center;
-  gap: 0rem;
-  font-weight: 600;
-  margin-bottom: 0rem;
-}
+  .markdown-alert .markdown-alert-title svg {
+    fill: currentColor;
+  }
+  .markdown-alert .markdown-alert-title {
+    display: flex;
+    align-items: center;
+    gap: 0rem;
+    font-weight: 600;
+    margin-bottom: 0rem;
+  }
 
-.markdown-alert-note {
-  border-color: hsl(220 90% 56%);
-  background-color: hsl(220 90% 56% / 0.3);
-}
+  .markdown-alert-note {
+    border-color: hsl(220 90% 56%);
+    background-color: hsl(220 90% 56% / 0.3);
+  }
 
-.markdown-alert-note .markdown-alert-title {
-  color: hsl(220 90% 56%);
-}
+  .markdown-alert-note .markdown-alert-title {
+    color: hsl(220 90% 56%);
+  }
 
-.markdown-alert-tip {
-  border-color: hsl(142 76% 36%);
-  background-color: hsl(142 76% 36% / 0.3);
-}
+  .markdown-alert-tip {
+    border-color: hsl(142 76% 36%);
+    background-color: hsl(142 76% 36% / 0.3);
+  }
 
-.markdown-alert-tip .markdown-alert-title {
-  color: hsl(142 76% 36%);
-}
+  .markdown-alert-tip .markdown-alert-title {
+    color: hsl(142 76% 36%);
+  }
 
-.markdown-alert-important {
-  border-color: hsl(271 81% 56%);
-  background-color: hsl(271 81% 56% / 0.3);
-}
+  .markdown-alert-important {
+    border-color: hsl(271 81% 56%);
+    background-color: hsl(271 81% 56% / 0.3);
+  }
 
-.markdown-alert-important .markdown-alert-title {
-  color: hsl(271 81% 56%);
-}
+  .markdown-alert-important .markdown-alert-title {
+    color: hsl(271 81% 56%);
+  }
 
-.markdown-alert-warning {
-  border-color: hsl(38 92% 50%);
-  background-color: hsl(38 92% 50% / 0.3);
-}
+  .markdown-alert-warning {
+    border-color: hsl(38 92% 50%);
+    background-color: hsl(38 92% 50% / 0.3);
+  }
 
-.markdown-alert-warning .markdown-alert-title {
-  color: hsl(38 92% 50%);
-}
+  .markdown-alert-warning .markdown-alert-title {
+    color: hsl(38 92% 50%);
+  }
 
-.markdown-alert-caution {
-  border-color: hsl(0 84% 60%);
-  background-color: hsl(0 84% 60% / 0.3);
-}
+  .markdown-alert-caution {
+    border-color: hsl(0 84% 60%);
+    background-color: hsl(0 84% 60% / 0.3);
+  }
 
-.markdown-alert-caution .markdown-alert-title {
-  color: hsl(0 84% 60%);
+  .markdown-alert-caution .markdown-alert-title {
+    color: hsl(0 84% 60%);
+  }
 }

--- a/src/routes/embed.css
+++ b/src/routes/embed.css
@@ -1,4 +1,7 @@
-html,
-body {
+/* Embeds render inside an <iframe> on the host page, so the canvas must stay transparent.
+   Scoped with :has() because every route group's CSS ends up in one file
+   (kit.output.bundleStrategy "single"): a bare `body` rule here would paint every page transparent. */
+html:has(.embed-app),
+body:has(.embed-app) {
   background-color: transparent;
 }

--- a/src/routes/manage.css
+++ b/src/routes/manage.css
@@ -1,21 +1,31 @@
-[aria-label="color picker"] input {
-  color: rgba(255, 255, 255, 0.5) !important;
-}
-
-.dark [aria-label="color picker"] input {
-  color: rgba(0, 0, 0, 0.5) !important;
-}
-.bg-card {
-  background-color: var(--background) !important;
-}
-
-@supports (background-color: color-mix(in oklch, white, black)) {
-  .bg-card {
-    background-color: color-mix(in oklch, var(--background) 94%, rgb(206, 203, 203) 6%) !important;
-    box-shadow: none;
+/* Manage-only overrides. Every route group's CSS ends up in one file (kit.output.bundleStrategy
+   "single"), so this sheet is scoped to pages that mount <main class="kener-manage">. body:has()
+   rather than a .kener-manage ancestor because bits-ui portals dialogs and popovers to <body>. */
+body:has(.kener-manage) {
+  [aria-label="color picker"] input {
+    color: rgba(255, 255, 255, 0.5) !important;
   }
 
-  .dark .bg-card {
-    background-color: color-mix(in oklch, var(--background) 90%, rgb(82, 81, 79) 10%) !important;
+  .dark & [aria-label="color picker"] input {
+    color: rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .bg-card {
+    background-color: var(--background) !important;
+  }
+
+  @supports (background-color: color-mix(in oklch, white, black)) {
+    .bg-card {
+      background-color: color-mix(
+        in oklch,
+        var(--background) 94%,
+        rgb(206, 203, 203) 6%
+      ) !important;
+      box-shadow: none;
+    }
+
+    .dark & .bg-card {
+      background-color: color-mix(in oklch, var(--background) 90%, rgb(82, 81, 79) 10%) !important;
+    }
   }
 }

--- a/src/routes/prose.css
+++ b/src/routes/prose.css
@@ -1,134 +1,139 @@
 @reference "../routes/layout.css";
 
-/* Custom styles for prose code blocks */
-.prose pre,
-.prose .code-block {
-  border-radius: 0.5rem;
-  border: 1px solid #374151;
-  background-color: #111827;
-  color: #f3f4f6;
-  padding: 1rem;
-  overflow-x: auto;
-  margin: 1rem 0;
-  display: block;
-}
-
-.prose strong {
-  @apply text-foreground font-semibold;
-}
-
-.prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  @apply text-primary hover:underline;
-}
-
-.prose code,
-.prose pre,
-.prose .code-block {
-  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.prose code {
-  background-color: var(--muted);
-  color: var(--foreground);
-  border-radius: 0.375rem;
-  padding: 0.0125rem 0.375rem;
-  font-size: 12px;
-  word-break: keep-all;
-  display: inline-block;
-  opacity: 0.85;
-}
-
-.prose pre code,
-.prose .code-block code {
-  border-radius: 0;
-  background: transparent;
-  padding: 0;
-  color: #f3f4f6;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  display: block;
-  white-space: pre;
-}
-
-/* Dark mode adjustments for code blocks */
-.dark .prose pre,
-.dark .prose .code-block {
-  border-color: #1d2024;
-  background-color: #16181a;
-  color: #f9fafb;
-}
-
-.dark .prose pre code,
-.dark .prose .code-block code {
-  color: #f9fafb;
-}
-
-/* Custom styles for prose lists */
-.prose ul > li::marker {
-  @apply text-muted-foreground;
-}
-
-.prose ol > li::marker {
-  @apply text-muted-foreground;
-}
-
-.prose h1,
-.prose h2,
-.prose h3,
-.prose h4,
-.prose h5,
-.prose th,
-.prose td,
-.prose h6 {
-  @apply text-foreground;
-}
-
-.prose p,
-.prose li {
-  @apply text-foreground/75;
-  font-weight: 400;
-}
-
-.prose.user-message p,
-.proseuser-message li,
-.prose.user-message h1,
-.prose.user-message h2,
-.prose.user-message h3,
-.prose.user-message h4,
-.prose.user-message h5,
-.prose.user-message h6 {
-  @apply text-white;
-}
-
-.prose hr {
-  @apply border-border border-t;
-}
-
-/* Blockquotes: full hairline border + brand tint (replaces the typography
-   plugin's thick border-left stripe and its quote marks) */
-.prose blockquote {
-  border: 1px solid color-mix(in oklch, var(--primary) 25%, transparent);
-  border-inline-start-width: 1px;
-  background: color-mix(in oklch, var(--primary) 5%, transparent);
-  border-radius: var(--radius);
-  padding: 0.5rem 1rem;
-  font-style: normal;
-  font-weight: 400;
-  color: var(--muted-foreground);
-}
-
-.prose blockquote p:first-of-type::before,
-.prose blockquote p:last-of-type::after {
-  content: none;
-}
-
-.prose {
-  :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before {
-    content: "";
+/* Docs-only prose styling. Every route group's CSS ends up in one file (kit.output.bundleStrategy
+   "single"), so this sheet is scoped to pages that mount <main class="kener-docs">; incident and
+   maintenance markdown on the status page and /manage also use .prose and must keep their own look. */
+body:has(.kener-docs) {
+  /* Custom styles for prose code blocks */
+  .prose pre,
+  .prose .code-block {
+    border-radius: 0.5rem;
+    border: 1px solid #374151;
+    background-color: #111827;
+    color: #f3f4f6;
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 1rem 0;
+    display: block;
   }
-}
-.prose {
-  :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
-    content: "";
+
+  .prose strong {
+    @apply text-foreground font-semibold;
+  }
+
+  .prose :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+    @apply text-primary hover:underline;
+  }
+
+  .prose code,
+  .prose pre,
+  .prose .code-block {
+    font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  .prose code {
+    background-color: var(--muted);
+    color: var(--foreground);
+    border-radius: 0.375rem;
+    padding: 0.0125rem 0.375rem;
+    font-size: 12px;
+    word-break: keep-all;
+    display: inline-block;
+    opacity: 0.85;
+  }
+
+  .prose pre code,
+  .prose .code-block code {
+    border-radius: 0;
+    background: transparent;
+    padding: 0;
+    color: #f3f4f6;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    display: block;
+    white-space: pre;
+  }
+
+  /* Dark mode adjustments for code blocks */
+  .dark & .prose pre,
+  .dark & .prose .code-block {
+    border-color: #1d2024;
+    background-color: #16181a;
+    color: #f9fafb;
+  }
+
+  .dark & .prose pre code,
+  .dark & .prose .code-block code {
+    color: #f9fafb;
+  }
+
+  /* Custom styles for prose lists */
+  .prose ul > li::marker {
+    @apply text-muted-foreground;
+  }
+
+  .prose ol > li::marker {
+    @apply text-muted-foreground;
+  }
+
+  .prose h1,
+  .prose h2,
+  .prose h3,
+  .prose h4,
+  .prose h5,
+  .prose th,
+  .prose td,
+  .prose h6 {
+    @apply text-foreground;
+  }
+
+  .prose p,
+  .prose li {
+    @apply text-foreground/75;
+    font-weight: 400;
+  }
+
+  .prose.user-message p,
+  .prose.user-message li,
+  .prose.user-message h1,
+  .prose.user-message h2,
+  .prose.user-message h3,
+  .prose.user-message h4,
+  .prose.user-message h5,
+  .prose.user-message h6 {
+    @apply text-white;
+  }
+
+  .prose hr {
+    @apply border-border border-t;
+  }
+
+  /* Blockquotes: full hairline border + brand tint (replaces the typography
+   plugin's thick border-left stripe and its quote marks) */
+  .prose blockquote {
+    border: 1px solid color-mix(in oklch, var(--primary) 25%, transparent);
+    border-inline-start-width: 1px;
+    background: color-mix(in oklch, var(--primary) 5%, transparent);
+    border-radius: var(--radius);
+    padding: 0.5rem 1rem;
+    font-style: normal;
+    font-weight: 400;
+    color: var(--muted-foreground);
+  }
+
+  .prose blockquote p:first-of-type::before,
+  .prose blockquote p:last-of-type::after {
+    content: none;
+  }
+
+  .prose {
+    :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before {
+      content: "";
+    }
+  }
+  .prose {
+    :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
+      content: "";
+    }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation pages now use dedicated Geist and Geist Mono fonts.

- **Bug Fixes**
  - Embedded pages correctly apply status colors and fonts to the document body.
  - Documentation and management styling is now limited to its respective pages, preventing unintended effects elsewhere.
  - Transparent backgrounds are restricted to embedded content.
  - Corrected styling for user messages in documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->