### PR TITLE
fix(alerting): alert_name is only the monitor tag

### DIFF
--- a/src/lib/server/notification/notification_utils.test.ts
+++ b/src/lib/server/notification/notification_utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import Mustache from "mustache";
+import { alertToVariables } from "./notification_utils.js";
+import emailTemplate from "../templates/email_alert_template.js";
+import type { MonitorAlertConfigRecord, MonitorAlertV2Record } from "../types/db";
+import type { SiteDataForNotification } from "./types.js";
+
+const config: MonitorAlertConfigRecord = {
+  id: 1,
+  monitor_tag: "config-tag",
+  alert_for: "STATUS",
+  alert_value: "DOWN",
+  failure_threshold: 1,
+  success_threshold: 1,
+  alert_description: "desc",
+  create_incident: "NO",
+  is_active: "YES",
+  severity: "WARNING",
+  created_at: new Date("2026-09-02T13:26:00.514Z"),
+  updated_at: new Date("2026-09-02T13:26:00.514Z"),
+};
+
+const alert: MonitorAlertV2Record = {
+  id: 7,
+  config_id: 1,
+  monitor_tag: null,
+  incident_id: null,
+  alert_status: "TRIGGERED",
+  created_at: new Date("2026-09-02T13:26:00.514Z"),
+  updated_at: new Date("2026-09-02T13:26:00.514Z"),
+};
+
+const site: SiteDataForNotification = {
+  site_url: "https://status.example.com/",
+  site_name: "Example",
+  site_logo_url: "",
+  colors_up: "",
+  colors_down: "",
+  colors_degraded: "",
+  colors_maintenance: "",
+};
+
+describe("alertToVariables", () => {
+  it("alert_name is only the monitor tag (#830)", () => {
+    expect(alertToVariables(config, alert, site, "my-api").alert_name).toBe("my-api");
+  });
+
+  it("falls back to the config monitor tag, then 'unknown'", () => {
+    expect(alertToVariables(config, alert, site).alert_name).toBe("config-tag");
+    expect(alertToVariables({ ...config, monitor_tag: null }, alert, site).alert_name).toBe("unknown");
+  });
+
+  it("default email subject still renders the full headline", () => {
+    const vars = alertToVariables(config, alert, site, "my-api");
+    expect(Mustache.render(emailTemplate.email_subject, { ...vars, ...site })).toBe(
+      "Alert my-api for STATUS DOWN TRIGGERED at 2026-09-02T13:26:00.514Z",
+    );
+  });
+});

--- a/src/lib/server/notification/notification_utils.test.ts
+++ b/src/lib/server/notification/notification_utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import Mustache from "mustache";
 import { alertToVariables } from "./notification_utils.js";
 import emailTemplate from "../templates/email_alert_template.js";
+import discordTemplate from "../templates/discord_alert_template.js";
+import slackTemplate from "../templates/slack_alert_template.js";
 import type { MonitorAlertConfigRecord, MonitorAlertV2Record } from "../types/db";
 import type { SiteDataForNotification } from "./types.js";
 
@@ -40,6 +42,11 @@ const site: SiteDataForNotification = {
   colors_maintenance: "",
 };
 
+// What the old alert_name used to be; the default templates must still render it.
+const HEADLINE = "Alert my-api for STATUS DOWN TRIGGERED at 2026-09-02T13:26:00.514Z";
+// JSON templates are rendered without HTML escaping, same as the senders do.
+const raw = { escape: (text: string) => text };
+
 describe("alertToVariables", () => {
   it("alert_name is only the monitor tag (#830)", () => {
     expect(alertToVariables(config, alert, site, "my-api").alert_name).toBe("my-api");
@@ -50,10 +57,16 @@ describe("alertToVariables", () => {
     expect(alertToVariables({ ...config, monitor_tag: null }, alert, site).alert_name).toBe("unknown");
   });
 
-  it("default email subject still renders the full headline", () => {
-    const vars = alertToVariables(config, alert, site, "my-api");
-    expect(Mustache.render(emailTemplate.email_subject, { ...vars, ...site })).toBe(
-      "Alert my-api for STATUS DOWN TRIGGERED at 2026-09-02T13:26:00.514Z",
-    );
+  it("every default template still renders the full headline", () => {
+    const vars = { ...alertToVariables(config, alert, site, "my-api"), ...site };
+
+    expect(Mustache.render(emailTemplate.email_subject, vars)).toBe(HEADLINE);
+    expect(Mustache.render(emailTemplate.email_body, vars)).toContain(`<h1 class="alert-title">${HEADLINE}</h1>`);
+
+    const discord = JSON.parse(Mustache.render(discordTemplate.discord_body, vars, {}, raw));
+    expect(discord.embeds[0].title).toBe(HEADLINE);
+
+    // The Slack template carries raw newlines inside strings, so compare the rendered text, not parsed JSON.
+    expect(Mustache.render(slackTemplate.slack_body, vars, {}, raw)).toContain(`"text": "*${HEADLINE}*"`);
   });
 });

--- a/src/lib/server/notification/notification_utils.ts
+++ b/src/lib/server/notification/notification_utils.ts
@@ -15,11 +15,10 @@ export function alertToVariables(
 ): AlertVariableMap {
   const createdAtDate = parseDbTimestamp(alert.created_at);
   const effectiveMonitorTag = monitorTag || config.monitor_tag || "unknown";
-  const alert_name = `Alert ${effectiveMonitorTag} for ${config.alert_for} ${config.alert_value} ${alert.alert_status} at ${createdAtDate.toISOString()}`;
 
   return {
     alert_id: alert.id,
-    alert_name: alert_name,
+    alert_name: effectiveMonitorTag,
     alert_for: config.alert_for,
     alert_value: config.alert_value,
     alert_status: alert.alert_status,

--- a/src/lib/server/templates/discord_alert_template.ts
+++ b/src/lib/server/templates/discord_alert_template.ts
@@ -5,7 +5,7 @@ const template = `{
   "content": "{{#is_triggered}}🚨 **Alert Triggered**{{/is_triggered}}{{#is_resolved}}✅ **Alert Resolved**{{/is_resolved}}",
   "embeds": [
     {
-      "title": "{{alert_name}}",
+      "title": "Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}",
       "url": "{{alert_cta_url}}",
       "color": {{#is_triggered}}15158332{{/is_triggered}}{{#is_resolved}}3066993{{/is_resolved}},
       "fields": [

--- a/src/lib/server/templates/email_alert_template.ts
+++ b/src/lib/server/templates/email_alert_template.ts
@@ -87,7 +87,7 @@ const emailTemplate = `<!DOCTYPE html>
     </div>
     <div class="header">
       <div class="alert-badge">{{alert_status}}</div>
-      <h1 class="alert-title">{{alert_name}}</h1>
+      <h1 class="alert-title">Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}</h1>
     </div>
     <table width="100%" border="0" cellspacing="0" cellpadding="8">
       <tr style="border-bottom: 1px solid #eee;">
@@ -152,6 +152,6 @@ const emailTemplate = `<!DOCTYPE html>
 </html>`;
 
 export default {
-  email_subject: "{{alert_name}}",
+  email_subject: "Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}",
   email_body: emailTemplate,
 };

--- a/src/lib/server/templates/slack_alert_template.ts
+++ b/src/lib/server/templates/slack_alert_template.ts
@@ -13,7 +13,7 @@ const template = `{
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*{{alert_name}}*"
+        "text": "*Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}*"
       }
     },
     {

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -27,7 +27,7 @@ Templates define the body and subject sent by triggers. Kener uses Mustache rend
 | `{{is_resolved}}`             |
 | `{{is_triggered}}`            |
 
-`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Triggers created before this change that still use the default templates hold a bare `{{alert_name}}` in four places: the email subject, the email heading, the Discord embed title, and the Slack section text. Paste the headline string into each to keep the full headline.
+`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Any trigger created before this change whose stored template still uses a bare `{{alert_name}}` as a headline now shows only the tag there. The old defaults did this in four places: the email subject, the email heading, the Discord embed title, and the Slack section text. Paste the headline string wherever you want the full headline back.
 
 ## Canonical site variables {#canonical-site-variables}
 

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -27,7 +27,7 @@ Templates define the body and subject sent by triggers. Kener uses Mustache rend
 | `{{is_resolved}}`             |
 | `{{is_triggered}}`            |
 
-`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Existing triggers whose subject or title is a bare `{{alert_name}}` can paste that string to keep the full headline.
+`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Triggers created before this change hold a bare `{{alert_name}}` in four places: the email subject, the email heading, the Discord embed title, and the Slack section text. Paste the headline string into each to keep the full headline.
 
 ## Canonical site variables {#canonical-site-variables}
 

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -27,7 +27,7 @@ Templates define the body and subject sent by triggers. Kener uses Mustache rend
 | `{{is_resolved}}`             |
 | `{{is_triggered}}`            |
 
-`{{alert_name}}` is the tag of the monitor the alert fired for. Build headlines from the separate variables, for example `{{alert_name}} {{alert_for}} {{alert_value}} {{alert_status}}`.
+`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Existing triggers whose subject or title is a bare `{{alert_name}}` can paste that string to keep the full headline.
 
 ## Canonical site variables {#canonical-site-variables}
 

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -27,7 +27,7 @@ Templates define the body and subject sent by triggers. Kener uses Mustache rend
 | `{{is_resolved}}`             |
 | `{{is_triggered}}`            |
 
-`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Triggers created before this change hold a bare `{{alert_name}}` in four places: the email subject, the email heading, the Discord embed title, and the Slack section text. Paste the headline string into each to keep the full headline.
+`{{alert_name}}` is the tag of the monitor the alert fired for. The shipped templates build their headline as `Alert {{alert_name}} for {{alert_for}} {{alert_value}} {{alert_status}} at {{alert_timestamp}}`. Triggers created before this change that still use the default templates hold a bare `{{alert_name}}` in four places: the email subject, the email heading, the Discord embed title, and the Slack section text. Paste the headline string into each to keep the full headline.
 
 ## Canonical site variables {#canonical-site-variables}
 

--- a/src/routes/(docs)/docs/content/v4/alerting/templates.md
+++ b/src/routes/(docs)/docs/content/v4/alerting/templates.md
@@ -27,6 +27,8 @@ Templates define the body and subject sent by triggers. Kener uses Mustache rend
 | `{{is_resolved}}`             |
 | `{{is_triggered}}`            |
 
+`{{alert_name}}` is the tag of the monitor the alert fired for. Build headlines from the separate variables, for example `{{alert_name}} {{alert_for}} {{alert_value}} {{alert_status}}`.
+
 ## Canonical site variables {#canonical-site-variables}
 
 | Variable                 |


### PR DESCRIPTION
Fixes #830

`{{alert_name}}` was the whole headline (`Alert my-api for STATUS DOWN TRIGGERED at 2026-09-02T13:26:00.514Z`). It is now just the monitor tag (`my-api`).

The default email subject/heading, slack section and discord embed title now build that same headline from `{{alert_name}} {{alert_for}} {{alert_value}} {{alert_status}} {{alert_timestamp}}`, so new triggers render exactly as before.

Note for the changelog: default templates are copied into each trigger at creation, so existing triggers that still have a bare `{{alert_name}}` as email subject / slack line / discord title will show only the tag after upgrade. Pasting the new default string restores the old headline.

Added `notification_utils.test.ts` and a line in the templates doc saying what `alert_name` is.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Alert notifications in email, Slack, and Discord now provide clearer summaries, including the alert name, target, value, status, and timestamp.
  - Alert names now consistently reflect the monitor tag associated with the alert.
  - Email subjects and headings include the full alert headline for easier identification.

- **Documentation**
  - Clarified the meaning of the `alert_name` variable and demonstrated how to combine alert variables into a complete headline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->