### PR TITLE
feat: HTTP proxy for outbound requests and API/Prometheus monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ docker run -d \
 
 Requirements:
 
-- Node.js `>= 20`
+- Node.js `>= 24.14`
 - Redis
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,7 @@
         "vitest-browser-svelte": "^3.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.14.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "vitest-browser-svelte": "^3.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.14.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.4",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,10 @@ import db from "$lib/server/db/db";
 import type { UnauthorizedResponse, NotFoundResponse } from "$lib/types/api";
 import { GetMonitorsParsed } from "$lib/server/controllers/monitorsController";
 import GC from "$lib/global-constants";
+import { InstallEnvProxy } from "$lib/server/proxy";
+
+// Dev runs the SvelteKit server and the scheduler as separate processes; each installs once.
+InstallEnvProxy();
 
 const API_PATH_PREFIX = "/api/";
 

--- a/src/lib/anywhere.ts
+++ b/src/lib/anywhere.ts
@@ -65,10 +65,22 @@ export const DOCKER_DEFAULT_TIMEOUT = 10 * 1000; // 10 seconds
 export const DOCKER_DEFAULT_SOCKET_PATH = "/var/run/docker.sock";
 
 // Outbound HTTP proxy for API/Prometheus monitors (type_data.proxy). Node silently ignores a
-// proxy URL whose scheme is not exactly `http://` or `https://` (uppercase included), so the
-// scheme is checked on save instead. `$SECRET` tokens in the userinfo part pass.
-export function IsValidProxyURL(proxy: string): boolean {
-  return /^https?:\/\/\S+$/.test(proxy.trim());
+// proxy URL whose scheme is not exactly `http://` or `https://` (uppercase included) and throws
+// ERR_PROXY_INVALID_CONFIG on a malformed authority, either way at check time rather than at
+// save. Both are caught here. Takes `unknown` because type_data is parsed JSON, so the value
+// need not be a string. `$SECRET` tokens survive the parse: `$` is legal in a host and userinfo.
+export function IsValidProxyURL(proxy: unknown): boolean {
+  if (typeof proxy !== "string") return false;
+  const value = proxy.trim();
+  if (!value.startsWith("http://") && !value.startsWith("https://")) return false;
+  try {
+    // Rejects a bad port, an empty host, an unclosed IPv6 literal. A special scheme with an
+    // empty host is unparseable, so a host check after this would never fire.
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export const ErrorSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/lib/anywhere.ts
+++ b/src/lib/anywhere.ts
@@ -64,6 +64,13 @@ export type DockerCheckType = (typeof DOCKER_CHECK_TYPES)[number];
 export const DOCKER_DEFAULT_TIMEOUT = 10 * 1000; // 10 seconds
 export const DOCKER_DEFAULT_SOCKET_PATH = "/var/run/docker.sock";
 
+// Outbound HTTP proxy for API/Prometheus monitors (type_data.proxy). Node silently ignores a
+// proxy URL whose scheme is not exactly `http://` or `https://` (uppercase included), so the
+// scheme is checked on save instead. `$SECRET` tokens in the userinfo part pass.
+export function IsValidProxyURL(proxy: string): boolean {
+  return /^https?:\/\/\S+$/.test(proxy.trim());
+}
+
 export const ErrorSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <circle cx="30" cy="24" r="10"/>
   <path d="M26 27h8"/>

--- a/src/lib/server/controllers/monitorsController.test.ts
+++ b/src/lib/server/controllers/monitorsController.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/server/db/db", () => ({
+  default: {
+    insertMonitor: vi.fn().mockResolvedValue([1]),
+    updateMonitor: vi.fn().mockResolvedValue(1),
+  },
+}));
+
+import db from "$lib/server/db/db";
+import { CreateMonitor, CreateUpdateMonitor } from "./monitorsController";
+
+const mockedDb = vi.mocked(db);
+
+const apiMonitor = (typeData: Record<string, unknown>, id?: number) => ({
+  id,
+  tag: "api-proxy",
+  name: "API proxy",
+  monitor_type: "API",
+  type_data: JSON.stringify({ url: "https://example.com", method: "GET", ...typeData }),
+});
+
+beforeEach(() => {
+  mockedDb.insertMonitor.mockClear();
+  mockedDb.updateMonitor.mockClear();
+});
+
+describe("monitor save: type_data.proxy scheme check", () => {
+  // Node silently ignores a proxy URL that is not http(s)://, so a typo would run the check
+  // unproxied and look UP. Save is the only place a typo can be caught.
+  const rejection = "Proxy URL must start with http:// or https://";
+
+  it("rejects a non-http(s) proxy on create", async () => {
+    await expect(CreateUpdateMonitor(apiMonitor({ proxy: "socks5://proxy:1080" }))).rejects.toThrow(rejection);
+    await expect(CreateMonitor(apiMonitor({ proxy: "proxy.internal:3128" }))).rejects.toThrow(rejection);
+    // Node's proxyEnv parser only recognises lowercase schemes; "HTTP://" would save and run direct.
+    await expect(CreateMonitor(apiMonitor({ proxy: "HTTPS://proxy.internal:3128" }))).rejects.toThrow(rejection);
+    expect(mockedDb.insertMonitor).not.toHaveBeenCalled();
+  });
+
+  it("rejects it on update too", async () => {
+    await expect(CreateUpdateMonitor(apiMonitor({ proxy: "ftp://proxy" }, 7))).rejects.toThrow(rejection);
+    expect(mockedDb.updateMonitor).not.toHaveBeenCalled();
+  });
+
+  it("accepts http(s) proxies, including $SECRET credentials, and no proxy at all", async () => {
+    await CreateUpdateMonitor(apiMonitor({ proxy: "http://user:$PROXY_PASS@proxy.internal:3128" }));
+    await CreateUpdateMonitor(apiMonitor({ proxy: "https://proxy.internal:3128" }));
+    await CreateUpdateMonitor(apiMonitor({ proxy: "" }));
+    await CreateUpdateMonitor(apiMonitor({}));
+    expect(mockedDb.insertMonitor).toHaveBeenCalledTimes(4);
+  });
+
+  it("leaves monitors without parseable type_data alone", async () => {
+    await CreateUpdateMonitor({ tag: "none", name: "None", monitor_type: "NONE", type_data: null });
+    await CreateUpdateMonitor({ tag: "bad", name: "Bad", monitor_type: "API", type_data: "{not json" });
+    expect(mockedDb.insertMonitor).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/server/controllers/monitorsController.test.ts
+++ b/src/lib/server/controllers/monitorsController.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 describe("monitor save: type_data.proxy scheme check", () => {
   // Node silently ignores a proxy URL that is not http(s)://, so a typo would run the check
   // unproxied and look UP. Save is the only place a typo can be caught.
-  const rejection = "Proxy URL must start with http:// or https://";
+  const rejection = "Proxy URL must be a valid http:// or https:// URL";
 
   it("rejects a non-http(s) proxy on create", async () => {
     await expect(CreateUpdateMonitor(apiMonitor({ proxy: "socks5://proxy:1080" }))).rejects.toThrow(rejection);
@@ -49,6 +49,23 @@ describe("monitor save: type_data.proxy scheme check", () => {
     await CreateUpdateMonitor(apiMonitor({ proxy: "" }));
     await CreateUpdateMonitor(apiMonitor({}));
     expect(mockedDb.insertMonitor).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects a malformed authority the URL parser cannot take", async () => {
+    // Node throws ERR_PROXY_INVALID_CONFIG on these while building the agents, which would
+    // fail the check itself rather than the save.
+    for (const proxy of ["http://proxy:abc", "http://:3128", "http://proxy:99999", "http://[::1"]) {
+      await expect(CreateMonitor(apiMonitor({ proxy }))).rejects.toThrow(rejection);
+    }
+    expect(mockedDb.insertMonitor).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proxy that is not a string at all", async () => {
+    // type_data is parsed JSON: the API can hand us any shape here.
+    for (const proxy of [{}, 3128, true, ["http://proxy:3128"]]) {
+      await expect(CreateMonitor(apiMonitor({ proxy }))).rejects.toThrow(rejection);
+    }
+    expect(mockedDb.insertMonitor).not.toHaveBeenCalled();
   });
 
   it("leaves monitors without parseable type_data alone", async () => {

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -195,8 +195,8 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
 };
 
 /**
- * type_data.proxy must be an http(s):// URL. Node silently ignores any other scheme, which
- * would run the check unproxied and report UP, so save is where a typo has to fail.
+ * type_data.proxy must be a valid http(s):// URL. Node silently ignores any other scheme and
+ * throws on a malformed authority, both at check time, so save is where a typo has to fail.
  * `$SECRET` tokens are still raw here and pass. Unparseable type_data is not this check's problem.
  */
 function validateTypeDataProxy(monitor: MonitorInput): void {
@@ -207,9 +207,13 @@ function validateTypeDataProxy(monitor: MonitorInput): void {
   } catch {
     return;
   }
+  // type_data is parsed JSON, so `proxy` can be any type. Absent or blank means no proxy;
+  // anything else - an object or a number included - has to be a proxy URL.
   const proxy = (typeData as { proxy?: unknown } | null)?.proxy;
-  if (typeof proxy === "string" && proxy.trim() !== "" && !IsValidProxyURL(proxy)) {
-    throw new Error("Proxy URL must start with http:// or https://");
+  if (proxy === undefined || proxy === null) return;
+  if (typeof proxy === "string" && proxy.trim() === "") return;
+  if (!IsValidProxyURL(proxy)) {
+    throw new Error("Proxy URL must be a valid http:// or https:// URL");
   }
 }
 

--- a/src/lib/server/controllers/monitorsController.ts
+++ b/src/lib/server/controllers/monitorsController.ts
@@ -29,6 +29,7 @@ import { GetLastMonitoringValue, SetLastHeartbeat, DeleteMonitorCaches } from ".
 import { CollapseStatusCounts } from "../../clientTools.js";
 import { translate, isLocaleAvailable } from "../i18n.js";
 import type { HeartbeatMonitor, GroupMonitorTypeData } from "../types/monitor.js";
+import { IsValidProxyURL } from "../../anywhere.js";
 
 interface GroupUpdateData {
   monitor_tag: string;
@@ -193,8 +194,28 @@ export const GetMonitorsParsed = async (query: MonitorFilter): Promise<Array<Mon
   return parsedMonitors;
 };
 
+/**
+ * type_data.proxy must be an http(s):// URL. Node silently ignores any other scheme, which
+ * would run the check unproxied and report UP, so save is where a typo has to fail.
+ * `$SECRET` tokens are still raw here and pass. Unparseable type_data is not this check's problem.
+ */
+function validateTypeDataProxy(monitor: MonitorInput): void {
+  if (!monitor.type_data) return;
+  let typeData: unknown;
+  try {
+    typeData = typeof monitor.type_data === "string" ? JSON.parse(monitor.type_data) : monitor.type_data;
+  } catch {
+    return;
+  }
+  const proxy = (typeData as { proxy?: unknown } | null)?.proxy;
+  if (typeof proxy === "string" && proxy.trim() !== "" && !IsValidProxyURL(proxy)) {
+    throw new Error("Proxy URL must start with http:// or https://");
+  }
+}
+
 export const CreateUpdateMonitor = async (monitor: MonitorInput): Promise<number | number[]> => {
   let monitorData = { ...monitor };
+  validateTypeDataProxy(monitorData);
   if (monitorData.id) {
     return await db.updateMonitor(monitorData as MonitorRecord);
   } else {
@@ -209,6 +230,7 @@ export const CreateMonitor = async (monitor: MonitorInput): Promise<number[]> =>
     throw new Error("monitor id must be empty or 0");
   }
   validateMonitorTag(monitorData.tag);
+  validateTypeDataProxy(monitorData);
   return await db.insertMonitor(monitorData);
 };
 

--- a/src/lib/server/docker.test.ts
+++ b/src/lib/server/docker.test.ts
@@ -132,8 +132,17 @@ describe("buildRequestConfig", () => {
     expect(buildRequestConfig(connection("h", "tls"), "/_ping", 1000).httpsAgent).toBeDefined();
   });
 
-  it("does not attach an https agent for plain tcp", () => {
-    expect(buildRequestConfig(connection("h"), "/_ping", 1000).httpsAgent).toBeUndefined();
+  it("carries no TLS material for plain tcp, and honours the env proxy on both connection types", () => {
+    // Every axios call site opts out of axios's own env-proxy handling (plaintext, no CONNECT)
+    // and lets Node agents tunnel via proxyEnv; daemons use the process env only.
+    const tcp = buildRequestConfig(connection("h"), "/_ping", 1000);
+    expect(tcp.proxy).toBe(false);
+    expect(tcp.httpAgent.options.proxyEnv).toBe(process.env);
+    expect(tcp.httpsAgent.options.ca).toBeUndefined();
+    expect(tcp.httpsAgent.options.cert).toBeUndefined();
+    const tls = buildRequestConfig(connection("h", "tls"), "/_ping", 1000);
+    expect(tls.proxy).toBe(false);
+    expect(tls.httpsAgent.options.proxyEnv).toBe(process.env);
   });
 });
 

--- a/src/lib/server/docker.ts
+++ b/src/lib/server/docker.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosRequestConfig } from "axios";
-import https from "https";
+import type https from "https";
+import { AxiosProxyConfig } from "./proxy.js";
 import { performance } from "node:perf_hooks";
 import { DOCKER_CONNECTION_TYPES, DOCKER_DEFAULT_TIMEOUT } from "../anywhere.js";
 import { GetRequiredSecrets, ReplaceAllOccurrences } from "./tool.js";
@@ -154,20 +155,17 @@ export function buildRequestConfig(connection: DockerConnection, path: string, t
 
   config.baseURL = buildBaseURL(connection);
 
+  const tls: https.AgentOptions = {};
   if (connection.connectionType === "tls") {
     // A certificate without its key (or the reverse) only fails at handshake time
     // with an unhelpful message, so refuse it up front.
     if (!!connection.tlsCert !== !!connection.tlsKey) {
       throw new DockerError("Provide the TLS client certificate and key together");
     }
-    config.httpsAgent = new https.Agent({
-      ca: connection.tlsCa,
-      cert: connection.tlsCert,
-      key: connection.tlsKey,
-    });
+    Object.assign(tls, { ca: connection.tlsCa, cert: connection.tlsCert, key: connection.tlsKey });
   }
-
-  return config;
+  // Daemons honour the process env proxy only (put LAN daemons in NO_PROXY); no per-monitor proxy.
+  return { ...config, ...AxiosProxyConfig(undefined, {}, tls) };
 }
 
 interface DockerResponse<T> {

--- a/src/lib/server/notification/discord_notification.ts
+++ b/src/lib/server/notification/discord_notification.ts
@@ -1,4 +1,5 @@
 import { GetRequiredSecrets, ReplaceAllOccurrences } from "../tool.js";
+import { describeError } from "./notification_utils.js";
 import Mustache from "mustache";
 import version from "../../version.js";
 
@@ -53,6 +54,6 @@ export default async function send(
     return { success: true, status: response.status, data: responseData };
   } catch (error) {
     console.error("Error sending Discord notification", error);
-    return { error: "Error sending Discord notification", details: error };
+    return { error: `Error sending Discord notification: ${describeError(error)}`, details: error };
   }
 }

--- a/src/lib/server/notification/notification_utils.test.ts
+++ b/src/lib/server/notification/notification_utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import Mustache from "mustache";
-import { alertToVariables } from "./notification_utils.js";
+import { alertToVariables, describeError } from "./notification_utils.js";
 import emailTemplate from "../templates/email_alert_template.js";
 import discordTemplate from "../templates/discord_alert_template.js";
 import slackTemplate from "../templates/slack_alert_template.js";
@@ -68,5 +68,27 @@ describe("alertToVariables", () => {
 
     // The Slack template carries raw newlines inside strings, so compare the rendered text, not parsed JSON.
     expect(Mustache.render(slackTemplate.slack_body, vars, {}, raw)).toContain(`"text": "*${HEADLINE}*"`);
+  });
+});
+
+describe("describeError", () => {
+  // A failed fetch() throws TypeError("fetch failed") and hides the real reason in `cause`
+  // (a proxy tunnel refusal, a connect timeout). The trigger test shows this string.
+  it("appends the cause to the message", () => {
+    const err = new TypeError("fetch failed", { cause: new Error("Failed to establish tunnel to example.com:443") });
+    expect(describeError(err)).toBe("fetch failed: Failed to establish tunnel to example.com:443");
+  });
+
+  it("walks to the innermost cause (undici nests the proxy refusal two deep)", () => {
+    const tunnel = new Error("Proxy response (403) !== 200 when HTTP Tunneling");
+    const cancelled = new Error("Request was cancelled.", { cause: tunnel });
+    const err = new TypeError("fetch failed", { cause: cancelled });
+    expect(describeError(err)).toBe("fetch failed: Proxy response (403) !== 200 when HTTP Tunneling");
+  });
+
+  it("returns the plain message when there is no cause, and stringifies non-errors", () => {
+    expect(describeError(new Error("boom"))).toBe("boom");
+    expect(describeError("nope")).toBe("nope");
+    expect(describeError({ cause: 1 })).toBe("[object Object]");
   });
 });

--- a/src/lib/server/notification/notification_utils.ts
+++ b/src/lib/server/notification/notification_utils.ts
@@ -87,3 +87,19 @@ export function maintenanceToVariables(
     update_text: template,
   };
 }
+
+/**
+ * Error text for a failed send. A failed fetch() throws TypeError("fetch failed") and buries
+ * the real reason under `cause` (undici nests it two deep for a refused proxy tunnel:
+ * "Request was cancelled." -> "Proxy response (403) !== 200 when HTTP Tunneling"). Without
+ * this the trigger test only ever says "fetch failed".
+ */
+export function describeError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  let innermost = "";
+  for (let c: unknown = error.cause; c !== undefined && c !== null; c = c instanceof Error ? c.cause : undefined) {
+    if (c instanceof Error) innermost = c.message;
+    else if (typeof c === "string") innermost = c;
+  }
+  return innermost && innermost !== error.message ? `${error.message}: ${innermost}` : error.message;
+}

--- a/src/lib/server/notification/slack_notification.ts
+++ b/src/lib/server/notification/slack_notification.ts
@@ -1,4 +1,5 @@
 import { GetRequiredSecrets, ReplaceAllOccurrences } from "../tool.js";
+import { describeError } from "./notification_utils.js";
 import Mustache from "mustache";
 import version from "../../version.js";
 
@@ -45,14 +46,14 @@ export default async function send(
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error(`Discord webhook request failed with status ${response.status}: ${errorText}`);
-      return { error: `Discord webhook request failed with status ${response.status}`, details: errorText };
+      console.error(`Slack webhook request failed with status ${response.status}: ${errorText}`);
+      return { error: `Slack webhook request failed with status ${response.status}`, details: errorText };
     }
 
     const responseData = await response.text();
     return { success: true, status: response.status, data: responseData };
   } catch (error) {
-    console.error("Error sending Discord notification", error);
-    return { error: "Error sending Discord notification", details: error };
+    console.error("Error sending Slack notification", error);
+    return { error: `Error sending Slack notification: ${describeError(error)}`, details: error };
   }
 }

--- a/src/lib/server/notification/webhook_notification.ts
+++ b/src/lib/server/notification/webhook_notification.ts
@@ -1,4 +1,5 @@
 import type { WebhookTemplateJson } from "../types/db";
+import { describeError } from "./notification_utils.js";
 import { GetRequiredSecrets, ReplaceAllOccurrences } from "../tool.js";
 import Mustache from "mustache";
 import type { SiteDataForNotification, TemplateVariableMap } from "./types.js";
@@ -76,6 +77,6 @@ export default async function send(
     return { success: true, status: response.status, data: responseData };
   } catch (error) {
     console.error("Error sending webhook", error);
-    return { error: "Error sending webhook", details: error };
+    return { error: `Error sending webhook: ${describeError(error)}`, details: error };
   }
 }

--- a/src/lib/server/proxy.test.ts
+++ b/src/lib/server/proxy.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import http from "http";
+import https from "https";
+import { AxiosProxyConfig, InstallEnvProxy } from "./proxy";
+
+describe("AxiosProxyConfig", () => {
+  it("switches axios's own proxy off and puts the monitor's proxy on both agents, no NO_PROXY key", () => {
+    const c = AxiosProxyConfig(" http://user:pw@proxy.internal:3128 ");
+    expect(c.proxy).toBe(false);
+    const expected = {
+      HTTPS_PROXY: "http://user:pw@proxy.internal:3128",
+      HTTP_PROXY: "http://user:pw@proxy.internal:3128",
+    };
+    expect(c.httpAgent.options.proxyEnv).toEqual(expected);
+    expect(c.httpsAgent.options.proxyEnv).toEqual(expected);
+    expect("NO_PROXY" in c.httpsAgent.options.proxyEnv).toBe(false);
+  });
+
+  it("falls back to the process env when the monitor has no proxy", () => {
+    for (const proxy of [undefined, "", "   "]) {
+      expect(AxiosProxyConfig(proxy).httpsAgent.options.proxyEnv).toBe(process.env);
+    }
+  });
+
+  it("applies agent options to both agents and tls options to the https one only", () => {
+    const c = AxiosProxyConfig("http://p:3128", { keepAlive: true }, { rejectUnauthorized: false });
+    expect(c.httpAgent.options.keepAlive).toBe(true);
+    expect(c.httpsAgent.options.keepAlive).toBe(true);
+    expect(c.httpsAgent.options.rejectUnauthorized).toBe(false);
+    expect("rejectUnauthorized" in c.httpAgent.options).toBe(false);
+  });
+});
+
+describe("InstallEnvProxy", () => {
+  let restore: (() => void) | undefined;
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  it("is a no-op when no proxy variable is set", () => {
+    const before = https.globalAgent;
+    expect(InstallEnvProxy({})).toBeUndefined();
+    expect(https.globalAgent).toBe(before);
+  });
+
+  it("installs once per process (swaps the global agents) and hands back a restore function", () => {
+    const [httpBefore, httpsBefore] = [http.globalAgent, https.globalAgent];
+    // Node swaps each global agent only when its own scheme has a proxy variable.
+    restore = InstallEnvProxy({ HTTPS_PROXY: "http://127.0.0.1:9", HTTP_PROXY: "http://127.0.0.1:9" });
+    expect(typeof restore).toBe("function");
+    expect(https.globalAgent).not.toBe(httpsBefore);
+    expect(http.globalAgent).not.toBe(httpBefore);
+    // second call in the same process: already installed
+    expect(InstallEnvProxy({ HTTPS_PROXY: "http://127.0.0.1:9" })).toBeUndefined();
+    restore?.();
+    restore = undefined;
+    expect(https.globalAgent).toBe(httpsBefore);
+    expect(http.globalAgent).toBe(httpBefore);
+  });
+
+  it("reads the lowercase spelling too", () => {
+    restore = InstallEnvProxy({ https_proxy: "http://127.0.0.1:9" });
+    expect(typeof restore).toBe("function");
+  });
+});

--- a/src/lib/server/proxy.ts
+++ b/src/lib/server/proxy.ts
@@ -1,0 +1,73 @@
+import http from "http";
+import https from "https";
+import type { ProxyEnv } from "http";
+import type { AxiosRequestConfig } from "axios";
+
+// Node's own --use-env-proxy startup check looks at exactly these four.
+const PROXY_VARS = ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"] as const;
+
+// The production process loads two bundles (esbuild main.js and the SvelteKit server) that each
+// carry a copy of this module, so a module-level flag cannot make "once per process" true.
+// A well-known symbol on globalThis can.
+const INSTALLED = Symbol.for("kener.envProxyInstalled");
+
+type SetGlobalProxyFromEnv = (env: NodeJS.ProcessEnv) => () => void;
+
+/**
+ * Route global `fetch` and the global http/https agents through HTTP_PROXY / HTTPS_PROXY /
+ * NO_PROXY. Call after dotenv has populated `process.env`. No-op when no proxy variable is
+ * set, or when this process already did it. Returns Node's restore function otherwise.
+ *
+ * Custom `https.Agent`s (the monitor services) never inherit this; they pass `proxyEnv`
+ * themselves via `ProxyEnvFor`.
+ */
+export function InstallEnvProxy(env: NodeJS.ProcessEnv = process.env): (() => void) | undefined {
+  const g = globalThis as { [INSTALLED]?: boolean };
+  if (g[INSTALLED]) return undefined;
+  if (!PROXY_VARS.some((k) => !!env[k])) return undefined;
+
+  // Node >= 24.14.0; @types/node does not declare it yet.
+  const setGlobalProxyFromEnv = (http as unknown as { setGlobalProxyFromEnv?: SetGlobalProxyFromEnv })
+    .setGlobalProxyFromEnv;
+  if (typeof setGlobalProxyFromEnv !== "function") {
+    throw new Error(
+      `HTTP_PROXY/HTTPS_PROXY is set but this Node (${process.version}) has no http.setGlobalProxyFromEnv; Kener needs Node >= 24.14.0`,
+    );
+  }
+  const restore = setGlobalProxyFromEnv(env);
+  g[INSTALLED] = true;
+  return () => {
+    restore();
+    g[INSTALLED] = false;
+  };
+}
+
+/**
+ * The `proxyEnv` for a monitor's agents. The monitor's own proxy wins outright when set;
+ * otherwise the process env, from which Node reads only HTTP_PROXY / HTTPS_PROXY / NO_PROXY.
+ * NO_PROXY therefore applies to the env path only: a monitor that must bypass the env proxy
+ * is a NO_PROXY entry, not a special value here.
+ */
+function ProxyEnvFor(proxy: string | undefined): ProxyEnv {
+  const p = proxy?.trim();
+  return p ? { HTTPS_PROXY: p, HTTP_PROXY: p } : process.env;
+}
+
+/**
+ * The axios options that make one request honour the proxy. axios's own env-proxy code sends
+ * https URLs to the proxy in plaintext (no CONNECT) and, for an http:// proxy, drops httpsAgent;
+ * so it is switched off and both Node agents carry `proxyEnv` instead. `agent` options go on
+ * both agents, `tls` options on the https one only.
+ */
+export function AxiosProxyConfig(
+  proxy: string | undefined,
+  agent: http.AgentOptions = {},
+  tls: https.AgentOptions = {},
+): Pick<AxiosRequestConfig, "proxy" | "httpAgent" | "httpsAgent"> {
+  const proxyEnv = ProxyEnvFor(proxy);
+  return {
+    proxy: false,
+    httpAgent: new http.Agent({ ...agent, proxyEnv }),
+    httpsAgent: new https.Agent({ ...agent, ...tls, proxyEnv }),
+  };
+}

--- a/src/lib/server/services/apiCall.test.ts
+++ b/src/lib/server/services/apiCall.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
 import ApiCall from "./apiCall";
 import type { ApiMonitor } from "../types/monitor";
+
+vi.mock("axios", () => ({ default: vi.fn() }));
+const mockedAxios = vi.mocked(axios);
+
+beforeEach(() => {
+  mockedAxios.mockReset();
+  mockedAxios.mockResolvedValue({ status: 200, data: "ok" });
+});
 
 describe("ApiCall.execute", () => {
   it("does not throw in the constructor and records ERROR when type_data is null", async () => {
@@ -12,5 +21,57 @@ describe("ApiCall.execute", () => {
     expect(r.status).toBe("DOWN");
     expect(r.type).toBe("ERROR");
     expect(r.error_message).toBe("API monitor is missing configuration");
+  });
+});
+
+describe("ApiCall proxy", () => {
+  const withEnv = (key: string, value: string) => {
+    const prev = process.env[key];
+    process.env[key] = value;
+    return () => {
+      if (prev === undefined) delete process.env[key];
+      else process.env[key] = prev;
+    };
+  };
+  let restoreEnv: (() => void) | undefined;
+  afterEach(() => {
+    restoreEnv?.();
+    restoreEnv = undefined;
+  });
+
+  const monitor = (overrides: Partial<NonNullable<ApiMonitor["type_data"]>> = {}): ApiMonitor =>
+    ({
+      tag: "api-proxy",
+      type_data: { url: "https://example.com/health", method: "GET", ...overrides },
+    }) as ApiMonitor;
+
+  // axios's own env-proxy code never CONNECT-tunnels and drops httpsAgent for http:// proxies,
+  // so every call must opt out of it and let Node's agents do the proxying.
+  const optionsOfLastCall = () => mockedAxios.mock.calls[0][1] as Record<string, any>;
+
+  it("routes through the monitor's own proxy, with $SECRET substituted, on both agents", async () => {
+    restoreEnv = withEnv("PROXY_PASS", "pw");
+    await new ApiCall(monitor({ proxy: "http://user:$PROXY_PASS@proxy.internal:3128" })).execute();
+    const o = optionsOfLastCall();
+    expect(o.proxy).toBe(false);
+    const expected = {
+      HTTPS_PROXY: "http://user:pw@proxy.internal:3128",
+      HTTP_PROXY: "http://user:pw@proxy.internal:3128",
+    };
+    expect(o.httpsAgent.options.proxyEnv).toEqual(expected);
+    expect(o.httpAgent.options.proxyEnv).toEqual(expected);
+  });
+
+  it("falls back to the process env (HTTP_PROXY / HTTPS_PROXY / NO_PROXY) without a monitor proxy", async () => {
+    await new ApiCall(monitor()).execute();
+    const o = optionsOfLastCall();
+    expect(o.proxy).toBe(false);
+    expect(o.httpsAgent.options.proxyEnv).toBe(process.env);
+    expect(o.httpAgent.options.proxyEnv).toBe(process.env);
+  });
+
+  it("keeps allowSelfSignedCert on the https agent", async () => {
+    await new ApiCall(monitor({ allowSelfSignedCert: true, proxy: "http://proxy.internal:3128" })).execute();
+    expect(optionsOfLastCall().httpsAgent.options.rejectUnauthorized).toBe(false);
   });
 });

--- a/src/lib/server/services/apiCall.ts
+++ b/src/lib/server/services/apiCall.ts
@@ -4,7 +4,7 @@ import GC from "../../global-constants.js";
 import * as cheerio from "cheerio";
 import { DefaultAPIEval } from "../../anywhere.js";
 import version from "../../version.js";
-import https from "https";
+import { AxiosProxyConfig } from "../proxy.js";
 import { performance } from "node:perf_hooks";
 import type { ApiMonitor, EvalResponse, MonitoringResult } from "../types/monitor.js";
 
@@ -18,7 +18,9 @@ class ApiCall {
     // be reported by execute() as an ERROR result, so the constructor must not
     // throw before execute() ever runs.
     const td = monitor.type_data;
-    this.envSecrets = GetRequiredSecrets(`${td?.url ?? ""} ${td?.body || ""} ${JSON.stringify(td?.headers || [])}`);
+    this.envSecrets = GetRequiredSecrets(
+      `${td?.url ?? ""} ${td?.body || ""} ${td?.proxy ?? ""} ${JSON.stringify(td?.headers || [])}`,
+    );
   }
 
   async execute(): Promise<MonitoringResult> {
@@ -39,6 +41,7 @@ class ApiCall {
 
     let body = this.monitor.type_data.body;
     let url = this.monitor.type_data.url;
+    let proxy = this.monitor.type_data.proxy;
 
     let method = this.monitor.type_data.method;
     let timeout = this.monitor.type_data.timeout || 10000;
@@ -53,6 +56,9 @@ class ApiCall {
       }
       if (!!url) {
         url = ReplaceAllOccurrences(url, secret.find, secret.replace);
+      }
+      if (!!proxy) {
+        proxy = ReplaceAllOccurrences(proxy, secret.find, secret.replace);
       }
     }
 
@@ -72,19 +78,12 @@ class ApiCall {
       validateStatus: () => true,
       maxContentLength: Infinity,
       maxBodyLength: Infinity,
+      ...AxiosProxyConfig(
+        proxy,
+        { keepAlive: true, keepAliveMsecs: 30000, maxSockets: 50, maxFreeSockets: 10, timeout },
+        { rejectUnauthorized: !this.monitor.type_data.allowSelfSignedCert },
+      ),
     };
-
-    // Always configure HTTPS agent for better connection handling
-    const httpsAgentOptions: https.AgentOptions = {
-      keepAlive: true,
-      keepAliveMsecs: 30000,
-      maxSockets: 50,
-      maxFreeSockets: 10,
-      timeout: timeout,
-      rejectUnauthorized: !this.monitor.type_data.allowSelfSignedCert,
-    };
-
-    options.httpsAgent = new https.Agent(httpsAgentOptions);
 
     if (!!body) {
       options.data = body;

--- a/src/lib/server/services/prometheusCall.test.ts
+++ b/src/lib/server/services/prometheusCall.test.ts
@@ -378,3 +378,24 @@ describe("PrometheusCall.execute", () => {
     expect(r.status).toBe("DEGRADED");
   });
 });
+
+// --- Proxy -----------------------------------------------------------------
+describe("PrometheusCall proxy", () => {
+  it("opts out of axios's env proxy and passes the monitor proxy to both Node agents", async () => {
+    mockedAxios.mockResolvedValue({ status: 200, data: successBody("vector", [vec("1")]) });
+    await new PrometheusCall(makeMonitor({ proxy: "http://proxy.internal:3128" })).execute();
+    const o = mockedAxios.mock.calls[0][1] as Record<string, any>;
+    expect(o.proxy).toBe(false);
+    const expected = { HTTPS_PROXY: "http://proxy.internal:3128", HTTP_PROXY: "http://proxy.internal:3128" };
+    expect(o.httpsAgent.options.proxyEnv).toEqual(expected);
+    expect(o.httpAgent.options.proxyEnv).toEqual(expected);
+  });
+
+  it("uses the process env when the monitor has no proxy", async () => {
+    mockedAxios.mockResolvedValue({ status: 200, data: successBody("vector", [vec("1")]) });
+    await new PrometheusCall(makeMonitor()).execute();
+    const o = mockedAxios.mock.calls[0][1] as Record<string, any>;
+    expect(o.proxy).toBe(false);
+    expect(o.httpsAgent.options.proxyEnv).toBe(process.env);
+  });
+});

--- a/src/lib/server/services/prometheusCall.ts
+++ b/src/lib/server/services/prometheusCall.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosRequestConfig } from "axios";
-import https from "https";
+import { AxiosProxyConfig } from "../proxy.js";
 import GC from "../../global-constants.js";
 import version from "../../version.js";
 import { GetRequiredSecrets, ReplaceAllOccurrences, ApplySecretsToHeaders } from "../tool.js";
@@ -46,12 +46,12 @@ class PrometheusCall {
 
   constructor(monitor: PrometheusMonitor) {
     this.monitor = monitor;
-    // Secret substitution applies to url + header values only, never the query.
+    // Secret substitution applies to url, proxy and header values only, never the query.
     // Read type_data defensively: a malformed monitor (missing type_data) must
     // be reported by execute() as an ERROR result, so the constructor must not
     // throw before execute() ever runs.
     const td = monitor.type_data;
-    this.envSecrets = GetRequiredSecrets(`${td?.url ?? ""} ${JSON.stringify(td?.headers || [])}`);
+    this.envSecrets = GetRequiredSecrets(`${td?.url ?? ""} ${td?.proxy ?? ""} ${JSON.stringify(td?.headers || [])}`);
   }
 
   /**
@@ -72,12 +72,14 @@ class PrometheusCall {
 
     const timeout = data.timeout || 10000;
 
-    // Apply secrets to the url only (never the query). Header secrets are
+    // Apply secrets to the url and proxy (never the query). Header secrets are
     // substituted per-field below.
     let url = data.url;
+    let proxy = data.proxy;
     for (const secret of this.envSecrets) {
       if (secret.replace === undefined) continue;
       url = ReplaceAllOccurrences(url, secret.find, secret.replace);
+      if (proxy) proxy = ReplaceAllOccurrences(proxy, secret.find, secret.replace);
     }
 
     // Build the query endpoint: strip trailing slashes, append /api/v1/query.
@@ -99,9 +101,7 @@ class PrometheusCall {
       timeout,
       data: `query=${encodeURIComponent(data.query)}`,
       validateStatus: () => true, // handle non-2xx ourselves
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: !data.allowSelfSignedCert,
-      }),
+      ...AxiosProxyConfig(proxy, {}, { rejectUnauthorized: !data.allowSelfSignedCert }),
     };
 
     // 1. Transport errors -> DOWN.

--- a/src/lib/server/startup.ts
+++ b/src/lib/server/startup.ts
@@ -3,10 +3,14 @@ import version from "../version.js";
 import mainScheduler from "./schedulers/appScheduler.js";
 import maintenanceScheduler from "./schedulers/maintenanceScheduler.js";
 import dailyCleanupScheduler from "./schedulers/dailyCleanup.js";
+import { InstallEnvProxy } from "./proxy.js";
 
 process.env.TZ = "UTC";
 
 async function Startup(): Promise<void> {
+  // After dotenv: main.ts calls dotenv.config() in its body, which runs after static imports,
+  // so this cannot be module top-level. Covers fetch (triggers, Resend, OIDC) and the global agents.
+  InstallEnvProxy();
   await mainScheduler.start();
   await maintenanceScheduler.start();
   await dailyCleanupScheduler.start();

--- a/src/lib/server/types/monitor.ts
+++ b/src/lib/server/types/monitor.ts
@@ -29,6 +29,7 @@ export interface ApiMonitorTypeData {
   allowSelfSignedCert?: boolean;
   follow_redirects?: boolean;
   max_redirects?: number;
+  proxy?: string; // http(s):// proxy URL; `$SECRET` substitution applies; empty = process env proxy
 }
 
 export interface DnsMonitorTypeData {
@@ -117,6 +118,7 @@ export interface PrometheusMonitorTypeData {
   headers?: { key: string; value: string }[]; // optional; secret substitution applies
   timeout?: number; // ms, default 10000
   allowSelfSignedCert?: boolean; // default false
+  proxy?: string; // as ApiMonitorTypeData.proxy
 }
 
 export type MonitorTypeData =

--- a/src/routes/(docs)/docs/content/v4/monitors/api.md
+++ b/src/routes/(docs)/docs/content/v4/monitors/api.md
@@ -14,15 +14,16 @@ API monitors send HTTP requests and evaluate the response with JavaScript.
 
 ## Configuration fields {#configuration-fields}
 
-| Field                 | Type                                           | Default          | Notes                         |
-| :-------------------- | :--------------------------------------------- | :--------------- | :---------------------------- |
-| `url`                 | `string`                                       | —                | Required                      |
-| `method`              | `GET\|POST\|PUT\|PATCH\|DELETE\|HEAD\|OPTIONS` | `GET`            |                               |
-| `headers`             | `{ key, value }[]`                             | `[]`             | Optional custom headers       |
-| `body`                | `string`                                       | `""`             | Sent for non-GET/HEAD methods |
-| `timeout`             | `number`                                       | `10000`          | Request timeout in ms         |
-| `allowSelfSignedCert` | `boolean`                                      | `false`          | Disables TLS verify when true |
-| `eval`                | `string` (JS function)                         | built-in default | Receives response details     |
+| Field                 | Type                                           | Default          | Notes                                                                                                                                                          |
+| :-------------------- | :--------------------------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`                 | `string`                                       | —                | Required                                                                                                                                                       |
+| `method`              | `GET\|POST\|PUT\|PATCH\|DELETE\|HEAD\|OPTIONS` | `GET`            |                                                                                                                                                                |
+| `headers`             | `{ key, value }[]`                             | `[]`             | Optional custom headers                                                                                                                                        |
+| `body`                | `string`                                       | `""`             | Sent for non-GET/HEAD methods                                                                                                                                  |
+| `timeout`             | `number`                                       | `10000`          | Request timeout in ms                                                                                                                                          |
+| `allowSelfSignedCert` | `boolean`                                      | `false`          | Disables TLS verify when true                                                                                                                                  |
+| `proxy`               | `string`                                       | —                | Optional forward proxy, e.g. `http://user:$PROXY_PASS@proxy.internal:3128`; overrides the [environment proxy](/docs/v4/setup/environment-variables#http-proxy) |
+| `eval`                | `string` (JS function)                         | built-in default | Receives response details                                                                                                                                      |
 
 ## Default eval behavior {#default-eval}
 
@@ -66,3 +67,4 @@ It must return:
 - **Always DOWN**: verify URL/method/headers/body
 - **TLS errors**: enable `allowSelfSignedCert` only for trusted self-signed endpoints
 - **Eval errors**: simplify eval and validate return shape
+- **`Failed to establish tunnel`**: the proxy refused the connection; see [proxy settings](/docs/v4/setup/environment-variables#http-proxy)

--- a/src/routes/(docs)/docs/content/v4/monitors/prometheus.md
+++ b/src/routes/(docs)/docs/content/v4/monitors/prometheus.md
@@ -42,17 +42,18 @@ The charted per-check number is always the **metric value**, not the HTTP round-
 
 ## Configuration fields {#configuration-fields}
 
-| Field                 | Type      | Default  | Notes                                                            |
-| :-------------------- | :-------- | :------- | :--------------------------------------------------------------- |
-| `url`                 | `string`  | —        | Required. Prometheus base URL; base paths like `/prom` work      |
-| `query`               | `string`  | —        | Required. PromQL instant query                                   |
-| `down`                | `object`  | —        | Optional `{ operator, value }`; matches → DOWN                   |
-| `degraded`            | `object`  | —        | Optional `{ operator, value }`; matches → DEGRADED               |
-| `noDataStatus`        | `string`  | `"DOWN"` | Empty-result status: `UP` / `DEGRADED` / `DOWN`                  |
-| `errorStatus`         | `string`  | `"DOWN"` | Unreachable/unusable-response status: `UP` / `DEGRADED` / `DOWN` |
-| `headers`             | `array`   | `[]`     | Key/value pairs; `$SECRET` env substitution applies              |
-| `timeout`             | `number`  | `10000`  | Request timeout in ms                                            |
-| `allowSelfSignedCert` | `boolean` | `false`  | Skip TLS certificate verification                                |
+| Field                 | Type      | Default  | Notes                                                                                                                                                          |
+| :-------------------- | :-------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`                 | `string`  | —        | Required. Prometheus base URL; base paths like `/prom` work                                                                                                    |
+| `query`               | `string`  | —        | Required. PromQL instant query                                                                                                                                 |
+| `down`                | `object`  | —        | Optional `{ operator, value }`; matches → DOWN                                                                                                                 |
+| `degraded`            | `object`  | —        | Optional `{ operator, value }`; matches → DEGRADED                                                                                                             |
+| `noDataStatus`        | `string`  | `"DOWN"` | Empty-result status: `UP` / `DEGRADED` / `DOWN`                                                                                                                |
+| `errorStatus`         | `string`  | `"DOWN"` | Unreachable/unusable-response status: `UP` / `DEGRADED` / `DOWN`                                                                                               |
+| `headers`             | `array`   | `[]`     | Key/value pairs; `$SECRET` env substitution applies                                                                                                            |
+| `timeout`             | `number`  | `10000`  | Request timeout in ms                                                                                                                                          |
+| `allowSelfSignedCert` | `boolean` | `false`  | Skip TLS certificate verification                                                                                                                              |
+| `proxy`               | `string`  | —        | Optional forward proxy, e.g. `http://user:$PROXY_PASS@proxy.internal:3128`; overrides the [environment proxy](/docs/v4/setup/environment-variables#http-proxy) |
 
 `operator` is one of `>`, `>=`, `<`, `<=`, `==`, `!=`.
 
@@ -86,3 +87,4 @@ The charted per-check number is always the **metric value**, not the HTTP round-
 - **Immediate DOWN with an error message**: use "Test Monitor" — a bad PromQL query surfaces the Prometheus `error` field; an unreachable server surfaces the network error.
 - **Always no-data**: the query matched no series. Verify the query in Prometheus's own UI, or append `or vector(0)`.
 - **"query must return an instant vector or scalar"**: the query produced a range/matrix result. Use an instant query (no `[range]` in the outermost expression), or aggregate.
+- **`Failed to establish tunnel`**: the proxy refused the connection; see [proxy settings](/docs/v4/setup/environment-variables#http-proxy)

--- a/src/routes/(docs)/docs/content/v4/setup/deployment.md
+++ b/src/routes/(docs)/docs/content/v4/setup/deployment.md
@@ -247,7 +247,7 @@ Use this when you prefer managing runtime directly on a VM/server.
 
 Requirements:
 
-- Node.js `>= 20`
+- Node.js `>= 24.14`
 - Redis
 
 ```bash

--- a/src/routes/(docs)/docs/content/v4/setup/environment-variables.md
+++ b/src/routes/(docs)/docs/content/v4/setup/environment-variables.md
@@ -215,6 +215,28 @@ BODY_SIZE_LIMIT=10M
 > [!NOTE]
 > The Docker image sets `BODY_SIZE_LIMIT=3M` by default. Override it by passing the variable to your container.
 
+### HTTP_PROXY / HTTPS_PROXY / NO_PROXY {#http-proxy}
+
+**Purpose**: Route Kener's outbound HTTP through a forward proxy: API and Prometheus monitor checks, webhook/Discord/Slack triggers, Resend email, and OIDC discovery. HTTPS targets are tunnelled with `CONNECT`.
+
+**Default**: unset (direct connections)
+
+**Examples**:
+
+```bash
+HTTPS_PROXY=http://proxy.internal:3128
+HTTP_PROXY=http://proxy.internal:3128
+NO_PROXY=localhost,127.0.0.1,prometheus.lan,.internal
+```
+
+**Important**:
+
+- Requires Node.js `>= 24.14`; the Docker image satisfies this.
+- Proxy credentials go in the URL: `http://user:pass@proxy.internal:3128`.
+- `NO_PROXY` accepts exact hosts, `host:port`, `.suffix`, `*.host`, and IPv4 ranges (`10.0.0.1-10.0.0.255`). CIDR is not supported. Put LAN Prometheus servers and Docker daemons here. Triggers, Resend and OIDC go through `fetch`, whose `NO_PROXY` matcher can differ from the monitors' on unusual entries; stick to hostnames and `.suffix` forms.
+- An API or Prometheus monitor can set its own **Proxy URL** (for example `http://user:$PROXY_PASS@proxy.internal:3128`, with `$SECRET` substitution), which overrides these variables for that monitor.
+- A monitor error of `Failed to establish tunnel to host:443 via …` means the proxy refused the connection: check the proxy credentials, or add the host to `NO_PROXY`.
+
 ## Integration Variables {#integration-variables}
 
 For detailed configuration of these integrations, see their dedicated documentation pages.

--- a/src/routes/(docs)/docs/content/v4/setup/environment-variables.md
+++ b/src/routes/(docs)/docs/content/v4/setup/environment-variables.md
@@ -232,7 +232,7 @@ NO_PROXY=localhost,127.0.0.1,prometheus.lan,.internal
 **Important**:
 
 - Requires Node.js `>= 24.14`; the Docker image satisfies this.
-- Proxy credentials go in the URL: `http://user:pass@proxy.internal:3128`.
+- Proxy credentials go in the URL: `http://user:pass@proxy.internal:3128`. Percent-encode any reserved character in the username or password (`#` &rarr; `%23`, `/` &rarr; `%2F`, `?` &rarr; `%3F`, `@` &rarr; `%40`, `:` &rarr; `%3A`); an unencoded one changes where the URL ends. The same applies to a secret substituted into a monitor's **Proxy URL** &mdash; store the value already encoded.
 - `NO_PROXY` accepts exact hosts, `host:port`, `.suffix`, `*.host`, and IPv4 ranges (`10.0.0.1-10.0.0.255`). CIDR is not supported. Put LAN Prometheus servers and Docker daemons here. Triggers, Resend and OIDC go through `fetch`, whose `NO_PROXY` matcher can differ from the monitors' on unusual entries; stick to hostnames and `.suffix` forms.
 - An API or Prometheus monitor can set its own **Proxy URL** (for example `http://user:$PROXY_PASS@proxy.internal:3128`, with `$SECRET` substitution), which overrides these variables for that monitor.
 - A monitor error of `Failed to establish tunnel to host:443 via …` means the proxy refused the connection: check the proxy credentials, or add the host to `NO_PROXY`.

--- a/src/routes/(manage)/manage/app/monitors/[tag]/components/MonitorTypeCard.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/components/MonitorTypeCard.svelte
@@ -19,7 +19,7 @@
     IsValidURL,
     IsValidPort
   } from "$lib/clientTools";
-  import { GAMEDIG_SOCKET_TIMEOUT, DOCKER_CONNECTION_TYPES, DOCKER_CHECK_TYPES } from "$lib/anywhere";
+  import { GAMEDIG_SOCKET_TIMEOUT, DOCKER_CONNECTION_TYPES, DOCKER_CHECK_TYPES, IsValidProxyURL } from "$lib/anywhere";
   import { resolve } from "$app/paths";
   import clientResolver from "$lib/client/resolver.js";
   // Type-specific components
@@ -133,6 +133,7 @@
         if (!data.url) return false;
         if (!IsValidURL(data.url)) return false;
         if (!data.timeout || data.timeout < 1) return false;
+        if (data.proxy && !IsValidProxyURL(data.proxy)) return false;
         return true;
       }
 
@@ -239,6 +240,7 @@
       case "PROMETHEUS": {
         const data = typeData as any;
         if (!data.url || !IsValidURL(data.url)) return false;
+        if (data.proxy && !IsValidProxyURL(data.proxy)) return false;
         if (!data.query || !data.query.trim()) return false;
         for (const key of ["down", "degraded"] as const) {
           const t = data[key];

--- a/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-api.svelte
@@ -28,7 +28,6 @@
   if (data.follow_redirects === undefined) data.follow_redirects = true;
   if (data.max_redirects === undefined) data.max_redirects = 5;
 
-
   const methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
   function addHeader() {
@@ -70,6 +69,12 @@
   <div class="flex flex-col gap-2">
     <Label for="api-timeout">Timeout (ms)</Label>
     <Input id="api-timeout" type="number" bind:value={data.timeout} placeholder="10000" />
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <Label for="api-proxy">Proxy URL</Label>
+    <Input id="api-proxy" bind:value={data.proxy} placeholder="http://user:$PROXY_PASS@proxy.internal:3128" />
+    <p class="text-muted-foreground text-xs">Leave empty to use HTTP_PROXY / HTTPS_PROXY from the environment.</p>
   </div>
 
   <div>
@@ -124,7 +129,6 @@
       disabled={!data.follow_redirects}
     />
   </div>
-
 
   <div class="flex flex-col gap-2">
     <Label for="api-eval">Custom Eval Function</Label>

--- a/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-prometheus.svelte
+++ b/src/routes/(manage)/manage/app/monitors/[tag]/types/monitor-prometheus.svelte
@@ -193,6 +193,13 @@
     <Input id="prom-timeout" type="number" bind:value={data.timeout} placeholder="10000" />
   </div>
 
+  <!-- Proxy -->
+  <div class="flex flex-col gap-2">
+    <Label for="prom-proxy">Proxy URL</Label>
+    <Input id="prom-proxy" bind:value={data.proxy} placeholder="http://user:$PROXY_PASS@proxy.internal:3128" />
+    <p class="text-muted-foreground text-xs">Leave empty to use HTTP_PROXY / HTTPS_PROXY from the environment.</p>
+  </div>
+
   <!-- Self-signed -->
   <div class="flex items-center space-x-2">
     <Switch id="prom-self-signed" bind:checked={data.allowSelfSignedCert} />


### PR DESCRIPTION
Closes #438, closes #458.

Kener now honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` for every outbound HTTP call, and API and Prometheus monitors can set their own proxy in `type_data`.

- env proxy goes through Node's built-in support (`http.setGlobalProxyFromEnv`), installed once per process after dotenv. Covers webhook / Discord / Slack triggers, Resend, OIDC discovery. No new dependency.
- `type_data.proxy` on API and Prometheus: an `http(s)://` URL, `$SECRET` substitution same as headers. Monitor proxy wins over the env; `NO_PROXY` applies to the env path only. Plain input under Timeout in both forms.
- axios's own env-proxy code sends https URLs to the proxy in plaintext (no CONNECT) and drops `httpsAgent` for `http://` proxies, so every axios call site (API, Prometheus, Docker) sets `proxy: false` and uses Node agents with `proxyEnv`. Docker daemons stay on the env path, no per-monitor field.
- save rejects a proxy whose scheme is not lowercase `http://` / `https://`; Node silently ignores anything else and the check would run direct and look UP
- trigger test errors show the innermost cause (`Proxy response (403) !== 200 when HTTP Tunneling`) instead of `fetch failed`
- `engines.node` >= 24.14.0 (`setGlobalProxyFromEnv` landed there). Docker image is already `node:24`.
- docs: `setup/environment-variables` (new section), `monitors/api`, `monitors/prometheus`

`npm run check` 0 errors, `npm test` 205 pass. Verified against a local CONNECT proxy: https targets tunnel with Basic auth and substituted `$SECRET`, http targets go absolute-form, `NO_PROXY` bypasses, a refused tunnel surfaces `Failed to establish tunnel to host:443 via …` in the monitor error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional proxy URL configuration for API and Prometheus monitors.
  - Added environment-based proxy support for outbound requests and notifications.
  - Added proxy URL fields and validation to monitor configuration forms.

- **Bug Fixes**
  - Improved Slack, Discord, and webhook error messages with detailed failure information.
  - Corrected Slack webhook failure labeling.

- **Documentation**
  - Documented monitor-specific and environment-based proxy settings and troubleshooting guidance.

- **Chores**
  - Updated the minimum supported Node.js version to 24.14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->