### PR TITLE
Create changelog for version 4.1.5

### DIFF
--- a/src/routes/(docs)/docs.json
+++ b/src/routes/(docs)/docs.json
@@ -327,6 +327,10 @@
                   "collapsible": false,
                   "pages": [
                     {
+                      "title": "v4.1.5",
+                      "content": "v4/changelogs/v4.1.5"
+                    },
+                    {
                       "title": "v4.1.3",
                       "content": "v4/changelogs/v4.1.3"
                     },

--- a/src/routes/(docs)/docs/content/v4/changelogs/v4.1.5.md
+++ b/src/routes/(docs)/docs/content/v4/changelogs/v4.1.5.md
@@ -1,0 +1,53 @@
+---
+title: v4.1.5 Changelog
+description: See what's new in Kener v4.1.5, including new features, improvements, and bug fixes
+---
+
+Release date: **September 6, 2026**
+
+This release also carries everything that shipped in v4.1.4, which had no changelog of its own.
+
+> [!IMPORTANT]
+> Kener now requires **Node.js 24.14 or newer** (previously 20). The official Docker image already ships Node 24. If you run Kener from source on Node 20 or 22, upgrade Node before upgrading Kener.
+
+## New features {#new-features}
+
+### Docker container monitors {#docker-monitors}
+
+A new **Docker Container** monitor type reads container state from the Docker Engine API and maps it to a Kener status, including the container's `HEALTHCHECK` result when it has one. A running container with a healthy or absent healthcheck is `UP`, a `starting` healthcheck or a restarting container is `DEGRADED`, and unhealthy, paused, exited, or missing containers are `DOWN` with the exit code or last probe output attached. Set `checkType` to `daemon` to ping the daemon itself, which makes a useful parent monitor for a host.
+
+The daemon connection lives on the monitor: local socket, plain `tcp`, or `tls` with an optional client certificate. The three PEM fields accept `$SECRET` references, so the client key stays in an environment variable instead of the database. A **Browse** button lists containers from the daemon so you do not have to type the name. See [Docker Monitors](/docs/v4/monitors/docker). Thanks to [@kensac](https://github.com/kensac).
+
+Read the security note before mounting the socket: anything that can reach the Docker socket is root on the host, a `:ro` mount does not restrict the API, and Kener only needs three `GET` endpoints, so put a deny-by-default socket proxy in front of it.
+
+### CAPTCHA on the subscribe form {#captcha}
+
+The public subscribe form can now require a CAPTCHA before Kener sends the verification email. Configure a provider under **Manage → Captcha Providers**: hCaptcha, Google reCAPTCHA (v2 checkbox), or Cloudflare Turnstile. One provider is active at a time, enabling one disables the others, and the token is verified server-side before the OTP goes out. With no provider enabled the form behaves exactly as before. Changes apply immediately, no restart. See [Captcha](/docs/v4/captcha). Thanks to [@otherwiseGG](https://github.com/otherwiseGG).
+
+### Outbound HTTP proxy {#http-proxy}
+
+Kener can route its outbound traffic through a forward proxy. `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` cover API and Prometheus checks, webhook, Discord and Slack triggers, Resend email, and OIDC discovery, with HTTPS targets tunnelled through `CONNECT`. API and Prometheus monitors also take a per-monitor **Proxy URL** that overrides the environment for that monitor, with `$SECRET` substitution for the credentials.
+
+`NO_PROXY` accepts exact hosts, `host:port`, `.suffix`, `*.host`, and IPv4 ranges; CIDR is not supported. Put LAN Prometheus servers and Docker daemons there. Proxy credentials go in the URL and reserved characters have to be percent-encoded. See [Environment Variables](/docs/v4/setup/environment-variables#http-proxy).
+
+## Improvements {#improvements}
+
+### Trigger failures say what actually failed {#trigger-errors}
+
+A failed `fetch` throws `TypeError: fetch failed` and buries the real cause two levels down, so testing a webhook, Discord, or Slack trigger only ever reported "fetch failed". Errors now unwrap to the innermost cause, so a refused proxy tunnel reads as `Proxy response (403) !== 200 when HTTP Tunneling` instead.
+
+### Proxy URLs are validated on save {#proxy-validation}
+
+Node silently ignores a proxy URL whose scheme is not `http://` or `https://` and throws on a malformed authority, both at check time rather than at save time. Saving a monitor now rejects a proxy URL that is not a valid `http(s)` URL, so a typo fails where you made it.
+
+### RepoCloud deploy button {#repocloud}
+
+The README gained a one-click **Deploy on RepoCloud** button. Thanks to [@cosark](https://github.com/cosark).
+
+## Bug fixes {#bug-fixes}
+
+- **`{{alert_name}}` is the monitor tag again.** It expanded to a whole sentence (`Alert <tag> for <for> <value> <status> at <time>`), so custom webhook bodies using `{{alert_name}}` got the full headline instead of the tag. It is now just the tag, and the shipped templates compose the headline from the separate placeholders, so default triggers render unchanged. A trigger created before this change whose stored template still uses a bare `{{alert_name}}` as a headline, in the email subject, email heading, Discord embed title, or Slack section text, now shows only the tag there. See [Templates](/docs/v4/alerting/templates) for the headline string to paste back.
+- **Docs styling no longer leaks onto the status page and admin.** Bundling every route group's CSS into one file let the docs typography, prose rules, and admin overrides apply everywhere. Each sheet is now scoped to its own route group, and the docs font loads only on the docs.
+- **Embedded widgets use your status colors.** A `.body` selector that should have been `body` meant the custom `UP`, `DEGRADED`, and `DOWN` colors never reached embeds.
+- **Test files stay out of the production bundle.** The Express API handler auto-loader globbed `./*/*.ts`, so a co-located test file in an action folder was eagerly imported into the build. It now matches only `get`, `post`, `put`, and `delete`.
+- **Outdated documentation links.** Stale links in the contributing guide, the v3 monitor examples, and the admin users page now point at the right pages. Thanks to [@ilyhalight](https://github.com/ilyhalight).


### PR DESCRIPTION
Changelog for v4.1.5, covering everything merged since v4.1.3. v4.1.4 shipped without a changelog, so its changes are folded in here.

Adds `src/routes/(docs)/docs/content/v4/changelogs/v4.1.5.md` and its nav entry in `docs.json`.

Covered:

- Docker container monitor (#818, #835) — thanks @kensac
- CAPTCHA on the subscribe form (#803, closes #729) — thanks @otherwiseGG
- Outbound HTTP proxy, env vars and per-monitor (#838), with the Node 20 → 24.14 floor called out as an upgrade note
- `{{alert_name}}` back to the bare monitor tag (#833), with the note for triggers on customised templates
- From 4.1.4: CSS scoping and embed status colors (#832), doc links (#800, thanks @ilyhalight), RepoCloud deploy button (#816, thanks @cosark)

`package.json` still says 4.1.4 — the version bump has been a separate release commit each time, so I left it out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the Kener v4.1.5 changelog to the v4.x documentation navigation.
  - Documented Docker Container monitoring, optional CAPTCHA for public subscriptions, outbound proxy support, improved error handling, proxy validation, and RepoCloud deployment.
  - Documented fixes for alert placeholders, styling leaks, embedded widget colors, production bundling, and outdated links.
  - Recorded the updated minimum Node.js requirement of 24.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->