### PR TITLE
perf: add a 15 minute rollup of monitoring_data

### DIFF
--- a/migrations/20260906120000_add_monitoring_data_bucket.ts
+++ b/migrations/20260906120000_add_monitoring_data_bucket.ts
@@ -32,6 +32,10 @@ export async function up(knex: Knex): Promise<void> {
     table.float("max_latency");
     table.float("min_latency");
     table.primary(["monitor_tag", "bucket_ts"]);
+    // Retention deletes by bucket_ts alone. The primary key leads with
+    // monitor_tag, so it gives no useful path for that, and the nightly cleanup
+    // would scan the whole table as the monitor count grows.
+    table.index(["bucket_ts"], "idx_monitoring_data_bucket_ts");
   });
 }
 

--- a/migrations/20260906120000_add_monitoring_data_bucket.ts
+++ b/migrations/20260906120000_add_monitoring_data_bucket.ts
@@ -26,11 +26,13 @@ export async function up(knex: Knex): Promise<void> {
     table.integer("count_of_down").notNullable().defaultTo(0);
     table.integer("count_of_degraded").notNullable().defaultTo(0);
     table.integer("count_of_maintenance").notNullable().defaultTo(0);
-    // Totals rather than an average, so buckets stay addable.
-    table.float("latency_sum").notNullable().defaultTo(0);
+    // Totals rather than an average, so buckets stay addable. Double, not float:
+    // knex float maps to a 4 byte real on Postgres, which holds about 7
+    // significant digits, and this column accumulates a sum.
+    table.double("latency_sum").notNullable().defaultTo(0);
     table.integer("latency_count").notNullable().defaultTo(0);
-    table.float("max_latency");
-    table.float("min_latency");
+    table.double("max_latency");
+    table.double("min_latency");
     table.primary(["monitor_tag", "bucket_ts"]);
     // Retention deletes by bucket_ts alone. The primary key leads with
     // monitor_tag, so it gives no useful path for that, and the nightly cleanup

--- a/migrations/20260906120000_add_monitoring_data_bucket.ts
+++ b/migrations/20260906120000_add_monitoring_data_bucket.ts
@@ -1,0 +1,40 @@
+import type { Knex } from "knex";
+
+/**
+ * Rollup of monitoring_data into fixed 15 minute buckets.
+ *
+ * The status page groups raw per-minute rows into days on every request, which
+ * means scanning millions of rows per page load. This table holds the same
+ * counts pre-aggregated, so a page reads thousands of rows instead.
+ *
+ * Buckets are 15 minutes, not days, because the day boundary is not fixed: the
+ * status page asks for days that start at midnight in the VIEWER's timezone.
+ * Every current IANA offset is a whole number of 15 minute steps, including the
+ * :30 and :45 ones, so any viewer's day is an exact whole number of buckets.
+ *
+ * Latency is stored as a sum and a count, not an average, so that buckets can
+ * be added together without the error that averaging averages would introduce.
+ */
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable("monitoring_data_bucket")) return;
+
+  await knex.schema.createTable("monitoring_data_bucket", (table) => {
+    table.string("monitor_tag", 255).notNullable();
+    // Start of the bucket, UTC seconds, always a multiple of 900.
+    table.integer("bucket_ts").notNullable();
+    table.integer("count_of_up").notNullable().defaultTo(0);
+    table.integer("count_of_down").notNullable().defaultTo(0);
+    table.integer("count_of_degraded").notNullable().defaultTo(0);
+    table.integer("count_of_maintenance").notNullable().defaultTo(0);
+    // Totals rather than an average, so buckets stay addable.
+    table.float("latency_sum").notNullable().defaultTo(0);
+    table.integer("latency_count").notNullable().defaultTo(0);
+    table.float("max_latency");
+    table.float("min_latency");
+    table.primary(["monitor_tag", "bucket_ts"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("monitoring_data_bucket");
+}

--- a/src/lib/server/db/dbimpl.ts
+++ b/src/lib/server/db/dbimpl.ts
@@ -77,6 +77,8 @@ class DbImpl {
   getStatusCountsByIntervalGroupedByMonitor!: MonitoringRepository["getStatusCountsByIntervalGroupedByMonitor"];
   getStatusCountsForLastN!: MonitoringRepository["getStatusCountsForLastN"];
   getLastKnownStatus!: MonitoringRepository["getLastKnownStatus"];
+  rebuildAllBucketsForTag!: MonitoringRepository["rebuildAllBucketsForTag"];
+  verifyBucketsForTag!: MonitoringRepository["verifyBucketsForTag"];
 
   // ============ Monitors ============
   getMonitorsByTags!: MonitorsRepository["getMonitorsByTags"];
@@ -455,6 +457,8 @@ class DbImpl {
     );
     this.getStatusCountsForLastN = this.monitoring.getStatusCountsForLastN.bind(this.monitoring);
     this.getLastKnownStatus = this.monitoring.getLastKnownStatus.bind(this.monitoring);
+    this.rebuildAllBucketsForTag = this.monitoring.rebuildAllBucketsForTag.bind(this.monitoring);
+    this.verifyBucketsForTag = this.monitoring.verifyBucketsForTag.bind(this.monitoring);
   }
 
   private bindMonitorsMethods(): void {

--- a/src/lib/server/db/repositories/monitoring.ts
+++ b/src/lib/server/db/repositories/monitoring.ts
@@ -1,6 +1,12 @@
 import type { Knex as KnexType } from "knex";
 import { BaseRepository } from "./base.js";
 import GC from "../../../global-constants.js";
+import {
+  rebuildBuckets,
+  rebuildAllBucketsForTag,
+  deleteBucketsBefore,
+  verifyBucketsForTag,
+} from "./monitoringBuckets.js";
 import type { MonitoringStatus } from "../../../types/status.js";
 import { GetMinuteStartNowTimestampUTC } from "../../tool.js";
 import type {
@@ -42,17 +48,23 @@ export class MonitoringRepository extends BaseRepository {
   async insertMonitoringData(data: MonitoringDataInsert): Promise<MonitoringData | null> {
     const { monitor_tag, timestamp, status, latency, type, error_message, raw_status } = data;
 
-    // Perform insert/update - works across PostgreSQL, MySQL, and SQLite
-    await this.knex("monitoring_data")
-      .insert({ monitor_tag, timestamp, status, latency, type, error_message, raw_status })
-      .onConflict(["monitor_tag", "timestamp"])
-      .merge({ status, latency, type, error_message, raw_status });
+    // The write and the rollup rebuild share one transaction so the two can not
+    // disagree if the process dies between them.
+    const record = await this.knex.transaction(async (trx: KnexType.Transaction) => {
+      // Perform insert/update - works across PostgreSQL, MySQL, and SQLite
+      await trx("monitoring_data")
+        .insert({ monitor_tag, timestamp, status, latency, type, error_message, raw_status })
+        .onConflict(["monitor_tag", "timestamp"])
+        .merge({ status, latency, type, error_message, raw_status });
 
-    // Query and return the inserted/updated record (works consistently across all databases)
-    const record = await this.knex("monitoring_data")
-      .where("monitor_tag", monitor_tag)
-      .where("timestamp", timestamp)
-      .first();
+      // This is an upsert, not an append: the row may already have existed with a
+      // different status. So rebuild the bucket from the raw rows rather than
+      // adding a delta, which would double count.
+      await rebuildBuckets(trx, monitor_tag, timestamp, timestamp);
+
+      // Query and return the inserted/updated record (works consistently across all databases)
+      return await trx("monitoring_data").where("monitor_tag", monitor_tag).where("timestamp", timestamp).first();
+    });
 
     return record as MonitoringData | null;
   }
@@ -262,10 +274,40 @@ export class MonitoringRepository extends BaseRepository {
       .first();
   }
 
+  /** Rebuilds every rollup bucket for one monitor, in a single transaction. */
+  async rebuildAllBucketsForTag(monitor_tag: string): Promise<number> {
+    return await this.knex.transaction(async (trx: KnexType.Transaction) => {
+      return await rebuildAllBucketsForTag(trx, monitor_tag);
+    });
+  }
+
+  /** Compares the rollup against the raw rows and returns any difference. */
+  async verifyBucketsForTag(monitor_tag: string, fromTs: number, toTs: number) {
+    return await verifyBucketsForTag(this.knex, monitor_tag, fromTs, toTs);
+  }
+
   async background(retentionDays: number = 100): Promise<number> {
     const safeRetentionDays = Math.max(1, Math.floor(retentionDays || 100));
     const cutoffTimestamp = GetMinuteStartNowTimestampUTC() - 86400 * safeRetentionDays;
-    return await this.knex("monitoring_data").where("timestamp", "<", cutoffTimestamp).del();
+
+    return await this.knex.transaction(async (trx: KnexType.Transaction) => {
+      const affected = (await trx("monitoring_data")
+        .where("timestamp", "<", cutoffTimestamp)
+        .distinct("monitor_tag")) as Array<{ monitor_tag: string }>;
+
+      const deleted = await trx("monitoring_data").where("timestamp", "<", cutoffTimestamp).del();
+
+      // Buckets that fall entirely before the cutoff go with the raw rows.
+      await deleteBucketsBefore(trx, cutoffTimestamp);
+
+      // The cutoff is minute aligned, so it usually lands inside a bucket. That
+      // one straddling bucket per monitor still has raw rows and must be redone.
+      for (const row of affected) {
+        await rebuildBuckets(trx, row.monitor_tag, cutoffTimestamp, cutoffTimestamp);
+      }
+
+      return deleted;
+    });
   }
 
   async consecutivelyStatusFor(monitor_tag: string, status: string, lastX: number): Promise<boolean> {
@@ -395,14 +437,22 @@ export class MonitoringRepository extends BaseRepository {
 
     // Recovery (confirmed UP): rows become the UP side — clear any held error text in one update.
     if (confirmThreshold === null) {
-      return await this.knex("monitoring_data")
-        .where("monitor_tag", monitor_tag)
-        .whereIn("timestamp", timestamps)
-        .whereNotNull("raw_status")
-        .update({
-          status: this.knex.ref("raw_status"),
-          error_message: null,
-        });
+      return await this.knex.transaction(async (trx: KnexType.Transaction) => {
+        const updated = await trx("monitoring_data")
+          .where("monitor_tag", monitor_tag)
+          .whereIn("timestamp", timestamps)
+          .whereNotNull("raw_status")
+          .update({
+            status: trx.ref("raw_status"),
+            error_message: null,
+          });
+
+        // This rewrites status on existing rows, so the buckets behind them are
+        // now stale. Same span handling as the confirmed-unhealthy branch below.
+        await rebuildBuckets(trx, monitor_tag, Math.min(...timestamps), Math.max(...timestamps));
+
+        return updated;
+      });
     }
 
     // Confirmed unhealthy: set each row's status from its observed raw_status and APPEND a
@@ -435,6 +485,13 @@ export class MonitoringRepository extends BaseRepository {
           .where({ monitor_tag, timestamp: row.timestamp })
           .update({ status: row.raw_status, error_message: nextMessage });
       }
+
+      // The grace window can straddle midnight, so this can rewrite yesterday's
+      // rows as well as today's. Rebuild across the whole span it touched.
+      if (timestamps.length > 0) {
+        await rebuildBuckets(trx, monitor_tag, Math.min(...timestamps), Math.max(...timestamps));
+      }
+
       return updated;
     });
   }
@@ -481,25 +538,45 @@ export class MonitoringRepository extends BaseRepository {
         results.push(result);
       }
 
+      // An admin can rewrite any past range from the manage UI, so rebuild every
+      // bucket the edit touched.
+      await rebuildBuckets(trx, monitor_tag, start, end);
+
       return results;
     });
   }
 
   async deleteMonitorDataByTag(tag?: string, start?: number, end?: number, status?: MonitoringStatus): Promise<number> {
-    const query = this.knex("monitoring_data");
-    if (tag) {
-      query.where("monitor_tag", tag);
-    }
-    if (start !== undefined) {
-      query.where("timestamp", ">=", start);
-    }
-    if (end !== undefined) {
-      query.where("timestamp", "<=", end);
-    }
-    if (status) {
-      query.where("status", status);
-    }
-    return await query.del();
+    return await this.knex.transaction(async (trx: KnexType.Transaction) => {
+      const applyFilters = (q: KnexType.QueryBuilder) => {
+        if (tag) q.where("monitor_tag", tag);
+        if (start !== undefined) q.where("timestamp", ">=", start);
+        if (end !== undefined) q.where("timestamp", "<=", end);
+        if (status) q.where("status", status);
+        return q;
+      };
+
+      // Every argument is optional, so this can delete anything from one minute
+      // of one monitor up to the entire table. Collect the affected monitors
+      // BEFORE the delete, while their raw rows still exist.
+      const affected = (await applyFilters(trx("monitoring_data")).distinct("monitor_tag")) as Array<{
+        monitor_tag: string;
+      }>;
+
+      const deleted = await applyFilters(trx("monitoring_data")).del();
+
+      for (const row of affected) {
+        if (start !== undefined && end !== undefined) {
+          await rebuildBuckets(trx, row.monitor_tag, start, end);
+        } else {
+          // An open-ended delete has no bounded window to rebuild, so rebuild
+          // the monitor wholesale rather than guess at the range.
+          await rebuildAllBucketsForTag(trx, row.monitor_tag);
+        }
+      }
+
+      return deleted;
+    });
   }
 
   /**

--- a/src/lib/server/db/repositories/monitoring.ts
+++ b/src/lib/server/db/repositories/monitoring.ts
@@ -291,19 +291,20 @@ export class MonitoringRepository extends BaseRepository {
     const cutoffTimestamp = GetMinuteStartNowTimestampUTC() - 86400 * safeRetentionDays;
 
     return await this.knex.transaction(async (trx: KnexType.Transaction) => {
-      const affected = (await trx("monitoring_data")
-        .where("timestamp", "<", cutoffTimestamp)
-        .distinct("monitor_tag")) as Array<{ monitor_tag: string }>;
-
       const deleted = await trx("monitoring_data").where("timestamp", "<", cutoffTimestamp).del();
 
       // Buckets that fall entirely before the cutoff go with the raw rows.
       await deleteBucketsBefore(trx, cutoffTimestamp);
 
-      // The cutoff is minute aligned, so it usually lands inside a bucket. That
-      // one straddling bucket per monitor still has raw rows and must be redone.
-      for (const row of affected) {
-        await rebuildBuckets(trx, row.monitor_tag, cutoffTimestamp, cutoffTimestamp);
+      // The cutoff is minute aligned, so it usually lands inside a bucket, and
+      // that straddling bucket still holds the rows at or after the cutoff.
+      // Walk the monitors table rather than asking monitoring_data which tags
+      // were touched: the monitor list is small and already indexed, while that
+      // question means a second scan of everything the delete just matched.
+      // Rebuilding a bucket with no rows behind it is a no-op.
+      const monitors = (await trx("monitors").select("tag")) as Array<{ tag: string }>;
+      for (const monitor of monitors) {
+        await rebuildBuckets(trx, monitor.tag, cutoffTimestamp, cutoffTimestamp);
       }
 
       return deleted;

--- a/src/lib/server/db/repositories/monitoringBuckets.test.ts
+++ b/src/lib/server/db/repositories/monitoringBuckets.test.ts
@@ -3,6 +3,8 @@ import Knex from "knex";
 import type { Knex as KnexType } from "knex";
 import {
   BUCKET_SECONDS,
+  bucketExpression,
+  isSingleWriter,
   aggregateRawIntoBuckets,
   bucketStart,
   deleteBucketsBefore,
@@ -112,6 +114,31 @@ describe("bucket boundaries", () => {
     expect(bucketStart(T0)).toBe(T0);
     expect(bucketStart(T0 + 899)).toBe(T0);
     expect(bucketStart(T0 + 900)).toBe(T0 + 900);
+  });
+});
+
+// The bucket expression has to be written differently per dialect. MySQL has no
+// INTEGER cast target and SQLite has no FLOOR, so a single expression cannot
+// serve both. These tests only ever run against SQLite, so the other dialects
+// need checking here rather than through a query.
+describe("dialect handling", () => {
+  const fake = (client: string) => ({ client: { config: { client } } }) as never;
+
+  it("uses a CAST on SQLite", () => {
+    expect(bucketExpression(fake("better-sqlite3"))).toContain("CAST");
+    expect(bucketExpression(fake("sqlite3"))).toContain("CAST");
+  });
+
+  it.each(["pg", "mysql", "mysql2"])("uses FLOOR on %s, because INTEGER is not a valid cast target", (client) => {
+    const expr = bucketExpression(fake(client));
+    expect(expr).toContain("FLOOR");
+    expect(expr).not.toContain("CAST");
+  });
+
+  it("treats only SQLite as a single writer, so the others take a row lock", () => {
+    expect(isSingleWriter(fake("better-sqlite3"))).toBe(true);
+    expect(isSingleWriter(fake("sqlite3"))).toBe(true);
+    for (const client of ["pg", "mysql", "mysql2"]) expect(isSingleWriter(fake(client))).toBe(false);
   });
 });
 

--- a/src/lib/server/db/repositories/monitoringBuckets.test.ts
+++ b/src/lib/server/db/repositories/monitoringBuckets.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Knex from "knex";
+import type { Knex as KnexType } from "knex";
+import {
+  BUCKET_SECONDS,
+  aggregateRawIntoBuckets,
+  bucketStart,
+  deleteBucketsBefore,
+  rebuildAllBucketsForTag,
+  rebuildBuckets,
+  verifyBucketsForTag,
+} from "./monitoringBuckets";
+
+let knex: KnexType;
+
+const DAY = 86400;
+// A fixed UTC midnight, so the fixtures do not move with the wall clock.
+const T0 = 1767225600; // 2026-01-01T00:00:00Z
+
+beforeEach(async () => {
+  knex = Knex({ client: "better-sqlite3", connection: { filename: ":memory:" }, useNullAsDefault: true });
+  await knex.schema.createTable("monitoring_data", (t) => {
+    t.string("monitor_tag", 255).notNullable();
+    t.integer("timestamp").notNullable();
+    t.text("status");
+    t.float("latency");
+    t.text("type");
+    t.text("raw_status");
+    t.text("error_message");
+    t.primary(["monitor_tag", "timestamp"]);
+  });
+  await knex.schema.createTable("monitoring_data_bucket", (t) => {
+    t.string("monitor_tag", 255).notNullable();
+    t.integer("bucket_ts").notNullable();
+    t.integer("count_of_up").notNullable().defaultTo(0);
+    t.integer("count_of_down").notNullable().defaultTo(0);
+    t.integer("count_of_degraded").notNullable().defaultTo(0);
+    t.integer("count_of_maintenance").notNullable().defaultTo(0);
+    t.float("latency_sum").notNullable().defaultTo(0);
+    t.integer("latency_count").notNullable().defaultTo(0);
+    t.float("max_latency");
+    t.float("min_latency");
+    t.primary(["monitor_tag", "bucket_ts"]);
+  });
+});
+
+afterEach(async () => {
+  await knex.destroy();
+});
+
+/** Writes one row per minute over `minutes`, cycling through the given statuses. */
+async function seed(tag: string, from: number, minutes: number, statuses: string[] = ["UP"]) {
+  const rows = Array.from({ length: minutes }, (_, i) => ({
+    monitor_tag: tag,
+    timestamp: from + i * 60,
+    status: statuses[i % statuses.length],
+    latency: 100 + (i % 50),
+    type: "REALTIME",
+  }));
+  for (let i = 0; i < rows.length; i += 400) await knex("monitoring_data").insert(rows.slice(i, i + 400));
+}
+
+const rebuildAll = (tag: string) => knex.transaction((trx) => rebuildAllBucketsForTag(trx, tag));
+
+/** The live aggregation the status page does today, straight from raw rows. */
+async function rawDayCounts(tag: string, dayStart: number) {
+  const r = (await knex("monitoring_data")
+    .where("monitor_tag", tag)
+    .where("timestamp", ">=", dayStart)
+    .where("timestamp", "<", dayStart + DAY)
+    .select(
+      knex.raw("SUM(CASE WHEN status = 'UP' THEN 1 ELSE 0 END) as up"),
+      knex.raw("SUM(CASE WHEN status = 'DOWN' THEN 1 ELSE 0 END) as down"),
+      knex.raw("AVG(latency) as avg_latency"),
+      knex.raw("MAX(latency) as max_latency"),
+      knex.raw("MIN(latency) as min_latency"),
+    )
+    .first()) as Record<string, number | null>;
+  return r;
+}
+
+/** The same day, assembled by summing rollup buckets. */
+async function bucketDayCounts(tag: string, dayStart: number) {
+  const r = (await knex("monitoring_data_bucket")
+    .where("monitor_tag", tag)
+    .where("bucket_ts", ">=", dayStart)
+    .where("bucket_ts", "<", dayStart + DAY)
+    .select(
+      knex.raw("SUM(count_of_up) as up"),
+      knex.raw("SUM(count_of_down) as down"),
+      knex.raw("SUM(latency_sum) as latency_sum"),
+      knex.raw("SUM(latency_count) as latency_count"),
+      knex.raw("MAX(max_latency) as max_latency"),
+      knex.raw("MIN(min_latency) as min_latency"),
+    )
+    .first()) as Record<string, number | null>;
+  return {
+    up: r.up,
+    down: r.down,
+    avg_latency: r.latency_count ? Number(r.latency_sum) / Number(r.latency_count) : null,
+    max_latency: r.max_latency,
+    min_latency: r.min_latency,
+  };
+}
+
+describe("bucket boundaries", () => {
+  it("uses 15 minute buckets", () => {
+    expect(BUCKET_SECONDS).toBe(900);
+  });
+
+  it("snaps a timestamp down to its bucket", () => {
+    expect(bucketStart(T0)).toBe(T0);
+    expect(bucketStart(T0 + 899)).toBe(T0);
+    expect(bucketStart(T0 + 900)).toBe(T0 + 900);
+  });
+});
+
+describe("aggregation matches the raw data", () => {
+  it("counts each status and totals latency", async () => {
+    await seed("a", T0, 60, ["UP", "UP", "DOWN", "DEGRADED", "MAINTENANCE"]);
+    await rebuildAll("a");
+
+    const raw = await rawDayCounts("a", T0);
+    const rolled = await bucketDayCounts("a", T0);
+
+    expect(Number(rolled.up)).toBe(Number(raw.up));
+    expect(Number(rolled.down)).toBe(Number(raw.down));
+    expect(rolled.avg_latency).toBeCloseTo(Number(raw.avg_latency), 6);
+    expect(Number(rolled.max_latency)).toBe(Number(raw.max_latency));
+    expect(Number(rolled.min_latency)).toBe(Number(raw.min_latency));
+  });
+
+  it("stores latency as a sum and a count, so buckets stay addable", async () => {
+    // Two buckets with different sample counts. An unweighted mean of the two
+    // bucket averages would not equal the true average.
+    await seed("a", T0, 15);
+    await seed("a", T0 + BUCKET_SECONDS, 3);
+    await rebuildAll("a");
+
+    const raw = await rawDayCounts("a", T0);
+    const rolled = await bucketDayCounts("a", T0);
+    expect(rolled.avg_latency).toBeCloseTo(Number(raw.avg_latency), 6);
+
+    const buckets = await knex("monitoring_data_bucket").where("monitor_tag", "a").orderBy("bucket_ts");
+    const unweighted = buckets.reduce((acc, b) => acc + b.latency_sum / b.latency_count, 0) / buckets.length;
+    expect(unweighted).not.toBeCloseTo(Number(raw.avg_latency), 6);
+  });
+});
+
+// The reason buckets are 15 minutes rather than a day: the status page asks for
+// days that start at midnight in the VIEWER's timezone.
+describe("viewer timezone alignment", () => {
+  const OFFSETS: Array<[string, number]> = [
+    ["UTC", 0],
+    ["UTC+5:30 India", 5.5 * 3600],
+    ["UTC-4 New York", -4 * 3600],
+    ["UTC+12:45 Chatham", 12.75 * 3600],
+    ["UTC-9:30 Marquesas", -9.5 * 3600],
+  ];
+
+  it.each(OFFSETS)("a day starting at %s midnight sums exactly", async (_label, offset) => {
+    await seed("a", T0, 3 * 1440, ["UP", "UP", "UP", "DOWN"]);
+    await rebuildAll("a");
+
+    // Viewer midnight, expressed as a UTC timestamp.
+    const dayStart = T0 + DAY - offset;
+    const raw = await rawDayCounts("a", dayStart);
+    const rolled = await bucketDayCounts("a", dayStart);
+
+    expect(Number(rolled.up)).toBe(Number(raw.up));
+    expect(Number(rolled.down)).toBe(Number(raw.down));
+    expect(rolled.avg_latency).toBeCloseTo(Number(raw.avg_latency), 6);
+  });
+
+  it("every offset lands on a bucket boundary", () => {
+    // Math.abs because a negative offset gives -0, which is not Object.is(+0).
+    for (const [, offset] of OFFSETS) expect(Math.abs(offset % BUCKET_SECONDS)).toBe(0);
+  });
+});
+
+describe("rebuilds stay correct as raw data changes", () => {
+  it("is idempotent", async () => {
+    await seed("a", T0, 30);
+    await rebuildAll("a");
+    const first = await knex("monitoring_data_bucket").where("monitor_tag", "a").orderBy("bucket_ts");
+    await rebuildAll("a");
+    const second = await knex("monitoring_data_bucket").where("monitor_tag", "a").orderBy("bucket_ts");
+    expect(second).toEqual(first);
+  });
+
+  it("does not double count when a row is overwritten", async () => {
+    await seed("a", T0, 15, ["UP"]);
+    await rebuildAll("a");
+    expect((await bucketDayCounts("a", T0)).up).toBe(15);
+
+    // The raw table is written with upsert-and-merge, so this REPLACES a row.
+    await knex("monitoring_data")
+      .insert({ monitor_tag: "a", timestamp: T0, status: "DOWN", latency: 10, type: "REALTIME" })
+      .onConflict(["monitor_tag", "timestamp"])
+      .merge();
+    await knex.transaction((trx) => rebuildBuckets(trx, "a", T0, T0));
+
+    const after = await bucketDayCounts("a", T0);
+    expect(Number(after.up)).toBe(14);
+    expect(Number(after.down)).toBe(1);
+  });
+
+  it("drops buckets whose raw rows were deleted", async () => {
+    await seed("a", T0, 60);
+    await rebuildAll("a");
+    expect(await knex("monitoring_data_bucket").where("monitor_tag", "a").count({ c: "*" }).first()).toEqual({ c: 4 });
+
+    await knex("monitoring_data")
+      .where("monitor_tag", "a")
+      .where("timestamp", "<", T0 + 1800)
+      .del();
+    await knex.transaction((trx) => rebuildBuckets(trx, "a", T0, T0 + 1800));
+
+    const left = (await knex("monitoring_data_bucket").where("monitor_tag", "a").orderBy("bucket_ts")) as Array<{
+      bucket_ts: number;
+    }>;
+    expect(left.map((b) => b.bucket_ts)).toEqual([T0 + 1800, T0 + 2700]);
+  });
+
+  it("keeps a bucket that still has rows after a partial delete", async () => {
+    await seed("a", T0, 15);
+    await rebuildAll("a");
+    await knex("monitoring_data")
+      .where("monitor_tag", "a")
+      .where("timestamp", "<", T0 + 300)
+      .del();
+    await knex.transaction((trx) => rebuildBuckets(trx, "a", T0, T0 + 300));
+    expect(Number((await bucketDayCounts("a", T0)).up)).toBe(10);
+  });
+
+  it("recomputes min and max after the extreme row is removed", async () => {
+    await seed("a", T0, 15);
+    await knex("monitoring_data").insert({
+      monitor_tag: "a",
+      timestamp: T0 + 900,
+      status: "UP",
+      latency: 9999,
+      type: "REALTIME",
+    });
+    await rebuildAll("a");
+    expect(Number((await bucketDayCounts("a", T0)).max_latency)).toBe(9999);
+
+    await knex("monitoring_data")
+      .where({ monitor_tag: "a", timestamp: T0 + 900 })
+      .del();
+    await knex.transaction((trx) => rebuildBuckets(trx, "a", T0 + 900, T0 + 900));
+    expect(Number((await bucketDayCounts("a", T0)).max_latency)).toBeLessThan(9999);
+  });
+
+  it("isolates monitors from each other", async () => {
+    await seed("a", T0, 15);
+    await seed("b", T0, 15);
+    await rebuildAll("a");
+    await rebuildAll("b");
+    await knex("monitoring_data").where("monitor_tag", "a").del();
+    await knex.transaction((trx) => rebuildAllBucketsForTag(trx, "a"));
+
+    expect(await knex("monitoring_data_bucket").where("monitor_tag", "a").count({ c: "*" }).first()).toEqual({ c: 0 });
+    expect(await knex("monitoring_data_bucket").where("monitor_tag", "b").count({ c: "*" }).first()).toEqual({ c: 1 });
+  });
+});
+
+describe("retention", () => {
+  it("drops whole buckets before the cutoff and leaves the straddling one", async () => {
+    await seed("a", T0, 60);
+    await rebuildAll("a");
+    // Cutoff inside the second bucket.
+    const cutoff = T0 + 1200;
+    await knex("monitoring_data").where("timestamp", "<", cutoff).del();
+    await deleteBucketsBefore(knex, cutoff);
+    await knex.transaction((trx) => rebuildBuckets(trx, "a", cutoff, cutoff));
+
+    const left = (await knex("monitoring_data_bucket").orderBy("bucket_ts")) as Array<{
+      bucket_ts: number;
+      count_of_up: number;
+    }>;
+    expect(left[0].bucket_ts).toBe(T0 + 900);
+    // The straddling bucket spans minutes 15 to 29 and the cutoff is minute 20,
+    // so the 10 rows from minute 20 onward survive.
+    expect(left[0].count_of_up).toBe(10);
+  });
+});
+
+describe("verify", () => {
+  it("reports nothing when the rollup matches", async () => {
+    await seed("a", T0, 60);
+    await rebuildAll("a");
+    expect(await verifyBucketsForTag(knex, "a", T0, T0 + DAY)).toEqual([]);
+  });
+
+  it("reports a bucket that drifted", async () => {
+    await seed("a", T0, 60);
+    await rebuildAll("a");
+    await knex("monitoring_data_bucket").where({ monitor_tag: "a", bucket_ts: T0 }).update({ count_of_up: 999 });
+
+    const d = await verifyBucketsForTag(knex, "a", T0, T0 + DAY);
+    expect(d).toHaveLength(1);
+    expect(d[0]).toMatchObject({ bucket_ts: T0, field: "count_of_up", raw: 15, rollup: 999 });
+  });
+
+  it("reports a bucket with no raw rows behind it", async () => {
+    await seed("a", T0, 15);
+    await rebuildAll("a");
+    await knex("monitoring_data_bucket").insert({ monitor_tag: "a", bucket_ts: T0 + 900, count_of_up: 5 });
+
+    const d = await verifyBucketsForTag(knex, "a", T0, T0 + DAY);
+    expect(d).toHaveLength(1);
+    expect(d[0]).toMatchObject({ bucket_ts: T0 + 900, field: "*", raw: null, rollup: 1 });
+  });
+
+  it("reports a bucket that is missing entirely", async () => {
+    await seed("a", T0, 30);
+    await rebuildAll("a");
+    await knex("monitoring_data_bucket").where({ monitor_tag: "a", bucket_ts: T0 }).del();
+
+    const d = await verifyBucketsForTag(knex, "a", T0, T0 + DAY);
+    expect(d).toHaveLength(1);
+    expect(d[0]).toMatchObject({ bucket_ts: T0, field: "*", rollup: null });
+  });
+});
+
+describe("aggregateRawIntoBuckets", () => {
+  it("returns nothing for a monitor with no rows", async () => {
+    expect(await aggregateRawIntoBuckets(knex, "nobody", T0, T0 + DAY)).toEqual([]);
+  });
+});

--- a/src/lib/server/db/repositories/monitoringBuckets.ts
+++ b/src/lib/server/db/repositories/monitoringBuckets.ts
@@ -1,0 +1,203 @@
+import type { Knex } from "knex";
+
+/**
+ * Bucket width for the monitoring_data rollup, in seconds.
+ *
+ * 15 minutes, because the status page asks for days that begin at midnight in
+ * the VIEWER's timezone, not at UTC midnight. Every current IANA offset is a
+ * whole number of 15 minute steps (including the :30 and :45 ones, such as
+ * India and Chatham), so any viewer's day is an exact whole number of buckets.
+ * A daily rollup would put outages on the wrong day for anyone off UTC.
+ */
+export const BUCKET_SECONDS = 900;
+
+/** Start of the bucket that contains `ts`. */
+export const bucketStart = (ts: number): number => Math.floor(ts / BUCKET_SECONDS) * BUCKET_SECONDS;
+
+export interface BucketRow {
+  monitor_tag: string;
+  bucket_ts: number;
+  count_of_up: number;
+  count_of_down: number;
+  count_of_degraded: number;
+  count_of_maintenance: number;
+  latency_sum: number;
+  latency_count: number;
+  max_latency: number | null;
+  min_latency: number | null;
+}
+
+/**
+ * Aggregates raw rows into bucket rows for one monitor over [fromTs, toTs).
+ *
+ * Deliberately does NOT filter on `type`, and takes latency over every row in
+ * the bucket regardless of status. That matches what the live query does today,
+ * so switching a read over to the rollup cannot change a published number.
+ * Latency is kept as a sum and a count so buckets can be added together.
+ */
+export async function aggregateRawIntoBuckets(
+  knex: Knex | Knex.Transaction,
+  monitorTag: string,
+  fromTs: number,
+  toTs: number,
+): Promise<BucketRow[]> {
+  const rows = await knex("monitoring_data")
+    .select(
+      knex.raw("CAST(timestamp / ? AS INTEGER) * ? as bucket_ts", [BUCKET_SECONDS, BUCKET_SECONDS]),
+      knex.raw("SUM(CASE WHEN status = 'UP' THEN 1 ELSE 0 END) as count_of_up"),
+      knex.raw("SUM(CASE WHEN status = 'DOWN' THEN 1 ELSE 0 END) as count_of_down"),
+      knex.raw("SUM(CASE WHEN status = 'DEGRADED' THEN 1 ELSE 0 END) as count_of_degraded"),
+      knex.raw("SUM(CASE WHEN status = 'MAINTENANCE' THEN 1 ELSE 0 END) as count_of_maintenance"),
+      knex.raw("SUM(latency) as latency_sum"),
+      knex.raw("COUNT(latency) as latency_count"),
+      knex.raw("MAX(latency) as max_latency"),
+      knex.raw("MIN(latency) as min_latency"),
+    )
+    .where("monitor_tag", monitorTag)
+    .where("timestamp", ">=", fromTs)
+    .where("timestamp", "<", toTs)
+    .groupByRaw("CAST(timestamp / ? AS INTEGER) * ?", [BUCKET_SECONDS, BUCKET_SECONDS]);
+
+  return (rows as Array<Record<string, unknown>>).map((r) => ({
+    monitor_tag: monitorTag,
+    bucket_ts: Number(r.bucket_ts),
+    count_of_up: Number(r.count_of_up ?? 0),
+    count_of_down: Number(r.count_of_down ?? 0),
+    count_of_degraded: Number(r.count_of_degraded ?? 0),
+    count_of_maintenance: Number(r.count_of_maintenance ?? 0),
+    latency_sum: Number(r.latency_sum ?? 0),
+    latency_count: Number(r.latency_count ?? 0),
+    max_latency: r.max_latency === null || r.max_latency === undefined ? null : Number(r.max_latency),
+    min_latency: r.min_latency === null || r.min_latency === undefined ? null : Number(r.min_latency),
+  }));
+}
+
+/**
+ * Rebuilds every bucket overlapping [fromTs, toTs] for one monitor.
+ *
+ * Always a full recompute from the raw rows, never a delta. The raw table is
+ * written with upsert-and-merge, and overlays and the grace period rewrite rows
+ * that already exist, so adding or subtracting a delta would drift. A recompute
+ * is also idempotent, so a retry cannot corrupt a bucket.
+ *
+ * Buckets left with no raw rows are deleted rather than kept at zero, so that
+ * "no data" and "all checks failed" stay distinguishable.
+ */
+export async function rebuildBuckets(
+  trx: Knex.Transaction,
+  monitorTag: string,
+  fromTs: number,
+  toTs: number,
+): Promise<number> {
+  const rangeStart = bucketStart(fromTs);
+  const rangeEnd = bucketStart(toTs) + BUCKET_SECONDS;
+
+  const fresh = await aggregateRawIntoBuckets(trx, monitorTag, rangeStart, rangeEnd);
+
+  // Clear the window first so buckets whose raw rows were deleted disappear
+  // instead of lingering with stale counts.
+  await trx("monitoring_data_bucket")
+    .where("monitor_tag", monitorTag)
+    .where("bucket_ts", ">=", rangeStart)
+    .where("bucket_ts", "<", rangeEnd)
+    .del();
+
+  if (fresh.length > 0) {
+    const batchSize = 500;
+    for (let i = 0; i < fresh.length; i += batchSize) {
+      await trx("monitoring_data_bucket").insert(fresh.slice(i, i + batchSize));
+    }
+  }
+
+  return fresh.length;
+}
+
+/** Rebuilds every bucket for a monitor, used by the backfill. */
+export async function rebuildAllBucketsForTag(trx: Knex.Transaction, monitorTag: string): Promise<number> {
+  const bounds = (await trx("monitoring_data")
+    .where("monitor_tag", monitorTag)
+    .min({ lo: "timestamp" })
+    .max({ hi: "timestamp" })
+    .first()) as { lo: number | null; hi: number | null } | undefined;
+
+  if (!bounds || bounds.lo === null || bounds.hi === null) {
+    await trx("monitoring_data_bucket").where("monitor_tag", monitorTag).del();
+    return 0;
+  }
+
+  return await rebuildBuckets(trx, monitorTag, bounds.lo, bounds.hi);
+}
+
+/** Drops buckets that fall entirely before `cutoff`, mirroring retention deletes. */
+export async function deleteBucketsBefore(knex: Knex | Knex.Transaction, cutoff: number): Promise<number> {
+  return await knex("monitoring_data_bucket").where("bucket_ts", "<", bucketStart(cutoff)).del();
+}
+
+export interface BucketDivergence {
+  monitor_tag: string;
+  bucket_ts: number;
+  field: string;
+  raw: number | null;
+  rollup: number | null;
+}
+
+/**
+ * Compares the rollup against the raw rows for one monitor and reports any
+ * difference. Used by the verify job so the rollup can be proven correct in
+ * production before anything reads from it.
+ */
+export async function verifyBucketsForTag(
+  knex: Knex,
+  monitorTag: string,
+  fromTs: number,
+  toTs: number,
+): Promise<BucketDivergence[]> {
+  const expected = await aggregateRawIntoBuckets(
+    knex,
+    monitorTag,
+    bucketStart(fromTs),
+    bucketStart(toTs) + BUCKET_SECONDS,
+  );
+  const storedRows = (await knex("monitoring_data_bucket")
+    .where("monitor_tag", monitorTag)
+    .where("bucket_ts", ">=", bucketStart(fromTs))
+    .where("bucket_ts", "<", bucketStart(toTs) + BUCKET_SECONDS)) as BucketRow[];
+
+  const stored = new Map(storedRows.map((r) => [r.bucket_ts, r]));
+  const out: BucketDivergence[] = [];
+  const fields: Array<keyof BucketRow> = [
+    "count_of_up",
+    "count_of_down",
+    "count_of_degraded",
+    "count_of_maintenance",
+    "latency_sum",
+    "latency_count",
+    "max_latency",
+    "min_latency",
+  ];
+
+  for (const want of expected) {
+    const got = stored.get(want.bucket_ts);
+    if (!got) {
+      out.push({ monitor_tag: monitorTag, bucket_ts: want.bucket_ts, field: "*", raw: 1, rollup: null });
+      continue;
+    }
+    for (const f of fields) {
+      const a = want[f] as number | null;
+      const b = got[f] as number | null;
+      // Latency sums are floats, so compare them with a tolerance.
+      const same = a === null || b === null ? a === b : Math.abs(Number(a) - Number(b)) < 0.001;
+      if (!same) {
+        out.push({ monitor_tag: monitorTag, bucket_ts: want.bucket_ts, field: f, raw: a, rollup: b });
+      }
+    }
+    stored.delete(want.bucket_ts);
+  }
+
+  // Anything left in the rollup has no raw rows behind it.
+  for (const [ts] of stored) {
+    out.push({ monitor_tag: monitorTag, bucket_ts: ts, field: "*", raw: null, rollup: 1 });
+  }
+
+  return out;
+}

--- a/src/lib/server/db/repositories/monitoringBuckets.ts
+++ b/src/lib/server/db/repositories/monitoringBuckets.ts
@@ -14,6 +14,27 @@ export const BUCKET_SECONDS = 900;
 /** Start of the bucket that contains `ts`. */
 export const bucketStart = (ts: number): number => Math.floor(ts / BUCKET_SECONDS) * BUCKET_SECONDS;
 
+/**
+ * The bucket-start expression, per dialect.
+ *
+ * MySQL has no INTEGER cast target, so a plain CAST(... AS INTEGER) is a syntax
+ * error there. SQLite has no FLOOR. This mirrors the split already used by
+ * getStatusCountsByIntervalGroupedByMonitor.
+ */
+export function bucketExpression(knex: Knex | Knex.Transaction): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = (knex as any).client?.config?.client;
+  const isSQLite = client === "better-sqlite3" || client === "sqlite3";
+  return isSQLite ? `CAST(timestamp / ? AS INT) * ?` : `FLOOR(timestamp / ?) * ?`;
+}
+
+/** True when the connection cannot take row locks, which is SQLite. */
+export function isSingleWriter(knex: Knex | Knex.Transaction): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = (knex as any).client?.config?.client;
+  return client === "better-sqlite3" || client === "sqlite3";
+}
+
 export interface BucketRow {
   monitor_tag: string;
   bucket_ts: number;
@@ -41,9 +62,10 @@ export async function aggregateRawIntoBuckets(
   fromTs: number,
   toTs: number,
 ): Promise<BucketRow[]> {
+  const bucketExpr = bucketExpression(knex);
   const rows = await knex("monitoring_data")
     .select(
-      knex.raw("CAST(timestamp / ? AS INTEGER) * ? as bucket_ts", [BUCKET_SECONDS, BUCKET_SECONDS]),
+      knex.raw(`${bucketExpr} as bucket_ts`, [BUCKET_SECONDS, BUCKET_SECONDS]),
       knex.raw("SUM(CASE WHEN status = 'UP' THEN 1 ELSE 0 END) as count_of_up"),
       knex.raw("SUM(CASE WHEN status = 'DOWN' THEN 1 ELSE 0 END) as count_of_down"),
       knex.raw("SUM(CASE WHEN status = 'DEGRADED' THEN 1 ELSE 0 END) as count_of_degraded"),
@@ -56,7 +78,7 @@ export async function aggregateRawIntoBuckets(
     .where("monitor_tag", monitorTag)
     .where("timestamp", ">=", fromTs)
     .where("timestamp", "<", toTs)
-    .groupByRaw("CAST(timestamp / ? AS INTEGER) * ?", [BUCKET_SECONDS, BUCKET_SECONDS]);
+    .groupByRaw(bucketExpr, [BUCKET_SECONDS, BUCKET_SECONDS]);
 
   return (rows as Array<Record<string, unknown>>).map((r) => ({
     monitor_tag: monitorTag,
@@ -91,6 +113,16 @@ export async function rebuildBuckets(
 ): Promise<number> {
   const rangeStart = bucketStart(fromTs);
   const rangeEnd = bucketStart(toTs) + BUCKET_SECONDS;
+
+  // Serialise rebuilds for this monitor. Several response workers can write
+  // different timestamps for the same monitor at once, and the backfill can
+  // overlap them. Without this, two transactions each read a snapshot that is
+  // missing the other's row and the later write replaces the bucket with counts
+  // that are short. Taking the monitor row first makes them queue instead.
+  // SQLite takes a database-wide write lock already, so it needs nothing here.
+  if (!isSingleWriter(trx)) {
+    await trx("monitors").where("tag", monitorTag).forUpdate().first();
+  }
 
   const fresh = await aggregateRawIntoBuckets(trx, monitorTag, rangeStart, rangeEnd);
 

--- a/src/lib/server/schedulers/rollupBackfill.ts
+++ b/src/lib/server/schedulers/rollupBackfill.ts
@@ -1,4 +1,4 @@
-import db from "../db/db.js";
+import db from "$lib/server/db/db";
 import { rebuildAllBucketsForTag } from "../db/repositories/monitoringBuckets.js";
 
 /**
@@ -35,14 +35,19 @@ const writeState = async (state: BackfillState): Promise<void> => {
   await db.insertOrUpdateSiteData(STATE_KEY, JSON.stringify(state), "object");
 };
 
-export async function runRollupBackfill(): Promise<{ built: number; skipped: number }> {
+/** How long to wait before another attempt when some monitors failed. */
+const RETRY_DELAY_MS = 5 * 60 * 1000;
+const MAX_ATTEMPTS = 5;
+
+export async function runRollupBackfill(): Promise<{ built: number; skipped: number; failed: number }> {
   const state = await readState();
-  if (state.done) return { built: 0, skipped: 0 };
+  if (state.done) return { built: 0, skipped: 0, failed: 0 };
 
   const monitors = await db.getMonitors({});
   const completed = new Set(state.completedTags);
   let built = 0;
   let skipped = 0;
+  let failed = 0;
 
   for (const monitor of monitors) {
     if (completed.has(monitor.tag)) {
@@ -57,6 +62,7 @@ export async function runRollupBackfill(): Promise<{ built: number; skipped: num
       completed.add(monitor.tag);
       await writeState({ done: false, completedTags: [...completed] });
     } catch (error) {
+      failed++;
       const message = error instanceof Error ? error.message : String(error);
       console.log(`Rollup backfill failed for ${monitor.tag}: ${message}`);
     }
@@ -68,7 +74,39 @@ export async function runRollupBackfill(): Promise<{ built: number; skipped: num
     console.log(`Rollup backfill complete: ${built} buckets built, ${skipped} monitors already done.`);
   }
 
-  return { built, skipped };
+  return { built, skipped, failed };
 }
 
-export default { runRollupBackfill };
+/**
+ * Runs the backfill and tries again if any monitor failed.
+ *
+ * A failure is usually transient, for example a busy database. Without a retry
+ * the monitors that failed would stay without a rollup until the next restart,
+ * because the backfill only ran at startup.
+ */
+export async function runRollupBackfillWithRetry(attempt = 1): Promise<void> {
+  try {
+    const { failed } = await runRollupBackfill();
+    if (failed === 0 || attempt >= MAX_ATTEMPTS) {
+      if (failed > 0) {
+        console.log(`Rollup backfill gave up after ${attempt} attempts with ${failed} monitor(s) incomplete.`);
+      }
+      return;
+    }
+    console.log(`Rollup backfill has ${failed} monitor(s) left, trying again in ${RETRY_DELAY_MS / 60000} minutes.`);
+  } catch (error) {
+    if (attempt >= MAX_ATTEMPTS) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`Rollup backfill gave up after ${attempt} attempts: ${message}`);
+      return;
+    }
+  }
+
+  const timer = setTimeout(() => {
+    void runRollupBackfillWithRetry(attempt + 1);
+  }, RETRY_DELAY_MS);
+  // Do not hold the process open just for a retry.
+  if (typeof timer.unref === "function") timer.unref();
+}
+
+export default { runRollupBackfill, runRollupBackfillWithRetry };

--- a/src/lib/server/schedulers/rollupBackfill.ts
+++ b/src/lib/server/schedulers/rollupBackfill.ts
@@ -1,0 +1,74 @@
+import db from "../db/db.js";
+import { rebuildAllBucketsForTag } from "../db/repositories/monitoringBuckets.js";
+
+/**
+ * One-time backfill of monitoring_data_bucket from the existing raw history.
+ *
+ * Kept out of the Knex migration on purpose. Migrations run while the app is
+ * starting, and on a large install this walks millions of rows, so doing it in
+ * a migration would hold up the boot and, on Postgres, hold a lock while it
+ * did. Here it runs after startup, one monitor at a time, and records progress
+ * so a restart continues instead of beginning again.
+ *
+ * Nothing reads the rollup yet. This only fills it so it can be checked against
+ * the raw data before any read path is switched over.
+ */
+const STATE_KEY = "monitoringRollupBackfill";
+
+interface BackfillState {
+  done: boolean;
+  completedTags: string[];
+}
+
+const readState = async (): Promise<BackfillState> => {
+  const row = await db.getSiteDataByKey(STATE_KEY);
+  if (!row?.value) return { done: false, completedTags: [] };
+  try {
+    const parsed = JSON.parse(row.value) as Partial<BackfillState>;
+    return { done: parsed.done === true, completedTags: parsed.completedTags ?? [] };
+  } catch {
+    return { done: false, completedTags: [] };
+  }
+};
+
+const writeState = async (state: BackfillState): Promise<void> => {
+  await db.insertOrUpdateSiteData(STATE_KEY, JSON.stringify(state), "object");
+};
+
+export async function runRollupBackfill(): Promise<{ built: number; skipped: number }> {
+  const state = await readState();
+  if (state.done) return { built: 0, skipped: 0 };
+
+  const monitors = await db.getMonitors({});
+  const completed = new Set(state.completedTags);
+  let built = 0;
+  let skipped = 0;
+
+  for (const monitor of monitors) {
+    if (completed.has(monitor.tag)) {
+      skipped++;
+      continue;
+    }
+    try {
+      // One transaction per monitor, so a failure part way through leaves the
+      // finished monitors intact and only retries the one that failed.
+      const count = await db.rebuildAllBucketsForTag(monitor.tag);
+      built += count;
+      completed.add(monitor.tag);
+      await writeState({ done: false, completedTags: [...completed] });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`Rollup backfill failed for ${monitor.tag}: ${message}`);
+    }
+  }
+
+  const allDone = monitors.every((m) => completed.has(m.tag));
+  await writeState({ done: allDone, completedTags: [...completed] });
+  if (allDone) {
+    console.log(`Rollup backfill complete: ${built} buckets built, ${skipped} monitors already done.`);
+  }
+
+  return { built, skipped };
+}
+
+export default { runRollupBackfill };

--- a/src/lib/server/startup.ts
+++ b/src/lib/server/startup.ts
@@ -4,6 +4,7 @@ import mainScheduler from "./schedulers/appScheduler.js";
 import maintenanceScheduler from "./schedulers/maintenanceScheduler.js";
 import dailyCleanupScheduler from "./schedulers/dailyCleanup.js";
 import { InstallEnvProxy } from "./proxy.js";
+import { runRollupBackfill } from "./schedulers/rollupBackfill.js";
 
 process.env.TZ = "UTC";
 
@@ -14,6 +15,14 @@ async function Startup(): Promise<void> {
   await mainScheduler.start();
   await maintenanceScheduler.start();
   await dailyCleanupScheduler.start();
+
+  // Fills monitoring_data_bucket from the existing history. Runs after the
+  // schedulers rather than in a migration, so a large install is not held at
+  // the boot screen while it walks the raw rows. Nothing reads the rollup yet.
+  runRollupBackfill().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`Rollup backfill did not finish: ${message}`);
+  });
 
   const runtimeVersion = version();
 

--- a/src/lib/server/startup.ts
+++ b/src/lib/server/startup.ts
@@ -4,7 +4,7 @@ import mainScheduler from "./schedulers/appScheduler.js";
 import maintenanceScheduler from "./schedulers/maintenanceScheduler.js";
 import dailyCleanupScheduler from "./schedulers/dailyCleanup.js";
 import { InstallEnvProxy } from "./proxy.js";
-import { runRollupBackfill } from "./schedulers/rollupBackfill.js";
+import { runRollupBackfillWithRetry } from "./schedulers/rollupBackfill.js";
 
 process.env.TZ = "UTC";
 
@@ -19,7 +19,7 @@ async function Startup(): Promise<void> {
   // Fills monitoring_data_bucket from the existing history. Runs after the
   // schedulers rather than in a migration, so a large install is not held at
   // the boot screen while it walks the raw rows. Nothing reads the rollup yet.
-  runRollupBackfill().catch((error: unknown) => {
+  runRollupBackfillWithRetry().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     console.log(`Rollup backfill did not finish: ${message}`);
   });


### PR DESCRIPTION
Part of #840. Second of three. Nothing reads the rollup in this PR.

The status page groups raw per-minute rows into days on every request. For a 90 day window on my instance that is 4.4M rows per page load, and about 5.6 seconds of database time. This adds a table that holds the same counts already aggregated, so a later PR can read thousands of rows instead of millions.

## Why 15 minute buckets and not daily

This is the part worth reviewing closely.

`endOfDayTodayAtTz` comes from the viewer's own timezone (`src/lib/client/datetime.ts`), and the timezone is switchable in the UI and kept in localStorage. So "a day" is not a fixed window: two people looking at the same page ask for different boundaries.

A daily rollup at UTC days would answer the wrong question for everyone who is not on UTC. Outages would land on the wrong day and the uptime figure would be wrong, with no error to show that anything went wrong.

Every current IANA offset is a whole number of 15 minute steps, including the :30 and :45 ones such as India and Chatham. So a 15 minute bucket is small enough that any viewer's day is an exact whole number of buckets. There is a test that sums a viewer's day from buckets and compares it against the raw aggregation for UTC, UTC+5:30, UTC-4, UTC+12:45 and UTC-9:30.

## Why latency is a sum and a count

Buckets have to be added together to make a day. An average cannot be added, because averaging averages weights a quiet bucket the same as a busy one. Storing `latency_sum` and `latency_count` keeps the day average exact. There is a test that shows the unweighted version giving a different answer.

The aggregation deliberately does not filter on `type`, and takes latency over every row in the bucket whatever its status, because that is what the live query does today. The point is that switching a read over later cannot change a published number.

## Keeping it correct when history changes

History is not append only. Four paths change it, and all four are in `MonitoringRepository`:

| path | what it does | what the rollup does |
| :-- | :-- | :-- |
| `insertMonitoringData` | upserts one row | rebuilds that bucket |
| `updateMonitoringData` | rewrites an arbitrary past range from the admin UI | rebuilds the range |
| `deleteMonitorDataByTag` | deletes a range, and every argument is optional | rebuilds the range, or the whole monitor when the range is open ended |
| `background` | nightly retention delete | drops old buckets, rebuilds the one straddling the cutoff |
| `backfillConfirmedStatus` | grace period rewrite, both branches | rebuilds the span, which can cross midnight |

Each rebuild runs in the same transaction as the write, so the two cannot disagree.

Rebuilds always recompute from the raw rows and never apply a delta. The raw table is written with upsert-and-merge, and overlays and the grace period rewrite rows that already exist, so a delta would drift. A recompute is also idempotent, so a retry cannot corrupt a bucket. There is a test that overwrites a row and shows the counts staying right.

## Backfill

The backfill runs after startup, one monitor per transaction, and records progress in site data so a restart continues instead of starting again. It is not in the migration, because migrations run during boot and this walks the whole history. On my data it built 550k buckets from 4.1M rows in about 4.4 seconds, and the rollup came to 23 MB against 577 MB for the raw table.

## Checking it before anything reads it

`verifyBucketsForTag` compares the rollup against the raw rows and reports each field that differs, each bucket that is missing, and each bucket with no raw rows behind it. Since no read path uses the rollup yet, it can be left to run in production for a few days and checked before the next PR switches anything over.

## Tests

22 new tests, covering the timezone property, the latency weighting, idempotency, overwrite, partial and full delete, min and max after the extreme row is removed, monitor isolation, the retention boundary, and the four ways verify can report a difference.

`npm run check` gives 0 errors, `npm run test:server` runs 235 tests and all pass, and the migration and seeds run on a new database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic aggregation of monitoring history into 15-minute summaries, including status counts and latency statistics.
  * Monitoring updates, corrections, deletions, and retention cleanup now keep summaries synchronized.
  * Added startup backfill for existing monitoring history with progress tracking and non-blocking error handling.
  * Added verification support to detect differences between raw monitoring data and summaries.

* **Tests**
  * Added comprehensive coverage for aggregation, rebuilding, retention, deletions, time boundaries, and data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->