### PR TITLE
fix(seed): default Kener.ing monitor hits /healthcheck instead of /

### DIFF
--- a/src/lib/server/db/seedMonitorData.ts
+++ b/src/lib/server/db/seedMonitorData.ts
@@ -1,5 +1,5 @@
 const kenerAPITypeData = {
-  url: "https://kener.ing",
+  url: "https://kener.ing/healthcheck",
   method: "GET",
   headers: [],
   body: "",


### PR DESCRIPTION
Every fresh Kener install seeds a `Kener.ing` monitor that GETs `https://kener.ing` every minute (`seedMonitorData.ts`). That is basically the entire egress bill on the demo.

Railway HTTP logs for the `kener demo` service, 24h to 2026-09-13 06:49 UTC:

- 252,001 requests, 14.34 GB egress
- 99.6% of it is `GET /` from clients with UA `Kener/<version>`
- 170 distinct installs, 154 of them at exactly 1.0 req/min
- 57,878 bytes per request

170 × 1440 × 57.8 KB ≈ 14.1 GB/day, which matches `NETWORK_TX_GB` (~15 GB/day).

`/healthcheck` is 38 bytes (`{"status":"ok","db":true,"redis":true}`), so the same once-a-minute poll costs 1,523x less.

Two things this does not do:

- It only helps new installs. `seeds/monitors.ts` seeds only when the `monitors` table is empty, so the 170 instances already out there keep polling `/` forever, upgrade or not.
- It does not move the current bill. That lever is app-level gzip: the app serves `/` uncompressed at 57,878 bytes and Railway's edge gzips it to 8,694 for the client, but the metered metric counts container-side bytes. Verified by sending a gzip-only request — 8,694 on the wire, 57,878 logged as `txBytes`. Separate PR.

`/healthcheck` returns 200 even when db or redis is down (deliberate, so restarters don't bounce the app), so the tile catches hard outages only. `?strict=1` would make it honest at the cost of showing every blip on other people's status pages — left alone for now.

Server suite not run locally: this worktree has an incomplete `node_modules` (no `.bin/`). No test references the seed URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the seeded Kener API monitor to use the correct health-check endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->